### PR TITLE
feat: add message scheduling SDK (Phase 3.3)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -47,6 +47,9 @@ Actionable work items extracted from the [roadmap](roadmap.md), organized by pri
 |---|---|---|---|
 | [WebApp Enhancements](#webapp-enhancements) | 4 | Mostly Complete | All done except: alerting |
 | [CLI Operational Commands](#cli-operational-commands) | -- | Completed | All endpoint + container commands, colored help, Spectre.Console progress |
+| [SessionKey Attribute](#sessionkey-attribute) | -- | Completed | Declarative `[SessionKey(nameof(Prop))]` replacing `GetSessionId()` overrides |
+| [Identity Extension](#identity-extension) | -- | Completed | `NimBus.Extensions.Identity` for username/password auth with email verification |
+| [Product Website](#product-website) | -- | Completed | GitHub Pages landing site with architecture diagram, code examples, comparison |
 | [Failed Message Hook](#failed-message-hook) | 4 | Not Started | Application-level last-chance handler before dead-lettering |
 | [Source Generators](#source-generators) | 4 | Not Started | Compile-time event type discovery replacing reflection |
 | [Message Versioning](#message-versioning) | 4 | Not Started | Schema evolution with polymorphic dispatch and version attributes |
@@ -408,10 +411,46 @@ Expansion of the `nb` CLI with operational management commands using Spectre.Con
 - Endpoint management: delete sessions, purge subscriptions (with state/date filters), remove deprecated subscriptions/rules, topic/subscription/rule tree visualization
 - Container operations: delete documents, resubmit/skip messages, purge by destination, copy data between Cosmos DB instances
 - Enhanced CLI UX: colored help text generator, progress spinners, global connection string options (`-sbc`, `-dbc`)
+- Function App stop/start during deployment to prevent file lock errors
 
 Code paths:
 - `src/NimBus.CommandLine/Endpoint.cs`
 - `src/NimBus.CommandLine/Container.cs`
 - `src/NimBus.CommandLine/CommandRunner.cs`
+- `src/NimBus.CommandLine/AppDeploymentService.cs`
 - `src/NimBus.CommandLine/ColoredHelpTextGenerator.cs`
 - `src/NimBus.CommandLine/Models/`
+
+### SessionKey Attribute
+
+**Priority:** P3 | **Phase:** -- | **Status:** Completed
+
+Declarative `[SessionKey(nameof(OrderId))]` attribute as an alternative to overriding `GetSessionId()`. Events become clean DTOs without infrastructure method overrides. The base `Event.GetSessionId()` reads the attribute via reflection, falling back to `Guid.NewGuid()`. Existing overrides still take precedence (backward compatible).
+
+Code paths:
+- `src/NimBus.Abstractions/Events/SessionKeyAttribute.cs`
+- `src/NimBus.Abstractions/Events/Event.cs`
+- `src/NimBus.Abstractions/Events/EventType.cs` (SessionKeyProperty metadata)
+
+### Identity Extension
+
+**Priority:** P3 | **Phase:** -- | **Status:** Completed
+
+`NimBus.Extensions.Identity` — opt-in ASP.NET Core Identity extension for username/password authentication with email verification. SQL Server-backed, separate from the core WebApp. Supports three auth modes: Identity-only, Entra ID-only, or dual (both). Claims transformation maps Identity users to existing NimBus authorization model without changing `EndpointAuthorizationService`.
+
+Code paths:
+- `src/NimBus.Extensions.Identity/`
+- `src/NimBus.WebApp/Startup.cs` (Identity detection and auth mode routing)
+
+### Product Website
+
+**Priority:** P3 | **Phase:** -- | **Status:** Completed
+
+Static landing page at `site/index.html` deployed via GitHub Pages. Azure blue color scheme, SVG architecture diagram, code examples, session ordering visualization, competitor comparison table. Auto-deploys via `.github/workflows/pages.yml`.
+
+Live at: https://akakaule.github.io/NimBus/
+
+Code paths:
+- `site/index.html`
+- `site/banner.png`
+- `.github/workflows/pages.yml`

--- a/src/NimBus.Core/Messages/ISender.cs
+++ b/src/NimBus.Core/Messages/ISender.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,5 +9,16 @@ namespace NimBus.Core.Messages
     {
         Task Send(IMessage message, int messageEnqueueDelay = 0, CancellationToken cancellationToken = default);
         Task Send(IEnumerable<IMessage> messages, int messageEnqueueDelay = 0, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Schedules a message for delivery at the specified time.
+        /// Returns a sequence number that can be used to cancel the scheduled message.
+        /// </summary>
+        Task<long> ScheduleMessage(IMessage message, DateTimeOffset scheduledEnqueueTime, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Cancels a previously scheduled message using the sequence number returned by <see cref="ScheduleMessage"/>.
+        /// </summary>
+        Task CancelScheduledMessage(long sequenceNumber, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NimBus.Core/Outbox/OutboxDispatcher.cs
+++ b/src/NimBus.Core/Outbox/OutboxDispatcher.cs
@@ -40,7 +40,14 @@ namespace NimBus.Core.Outbox
                 try
                 {
                     var message = JsonConvert.DeserializeObject<Message>(outboxMessage.Payload);
-                    await _sender.Send(message, outboxMessage.EnqueueDelayMinutes, cancellationToken);
+                    if (outboxMessage.ScheduledEnqueueTimeUtc.HasValue)
+                    {
+                        await _sender.ScheduleMessage(message, new DateTimeOffset(outboxMessage.ScheduledEnqueueTimeUtc.Value, TimeSpan.Zero), cancellationToken);
+                    }
+                    else
+                    {
+                        await _sender.Send(message, outboxMessage.EnqueueDelayMinutes, cancellationToken);
+                    }
                     dispatched.Add(outboxMessage.Id);
                 }
                 catch (Exception)

--- a/src/NimBus.Core/Outbox/OutboxMessage.cs
+++ b/src/NimBus.Core/Outbox/OutboxMessage.cs
@@ -48,6 +48,12 @@ namespace NimBus.Core.Outbox
         public DateTime CreatedAtUtc { get; set; }
 
         /// <summary>
+        /// Absolute scheduled delivery time. Null for immediate delivery.
+        /// Used by <see cref="ISender.ScheduleMessage"/> via the outbox.
+        /// </summary>
+        public DateTime? ScheduledEnqueueTimeUtc { get; set; }
+
+        /// <summary>
         /// When this outbox entry was dispatched to Service Bus. Null if pending.
         /// </summary>
         public DateTime? DispatchedAtUtc { get; set; }

--- a/src/NimBus.Core/Outbox/OutboxSender.cs
+++ b/src/NimBus.Core/Outbox/OutboxSender.cs
@@ -34,6 +34,24 @@ namespace NimBus.Core.Outbox
             await _outbox.StoreBatchAsync(outboxMessages, cancellationToken);
         }
 
+        public async Task<long> ScheduleMessage(IMessage message, DateTimeOffset scheduledEnqueueTime, CancellationToken cancellationToken = default)
+        {
+            var outboxMessage = ToOutboxMessage(message, 0);
+            outboxMessage.ScheduledEnqueueTimeUtc = scheduledEnqueueTime.UtcDateTime;
+            await _outbox.StoreAsync(outboxMessage, cancellationToken);
+            // Outbox returns 0 because the real sequence number is only assigned by
+            // Service Bus when OutboxDispatcher forwards the message. This means
+            // CancelScheduledMessage cannot work in outbox mode.
+            return 0L;
+        }
+
+        public Task CancelScheduledMessage(long sequenceNumber, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException(
+                "Cancelling scheduled messages is not supported when using the transactional outbox. " +
+                "The sequence number is only assigned by Service Bus after the outbox dispatches the message.");
+        }
+
         private static OutboxMessage ToOutboxMessage(IMessage message, int messageEnqueueDelay)
         {
             return new OutboxMessage

--- a/src/NimBus.Outbox.SqlServer/SqlServerOutbox.cs
+++ b/src/NimBus.Outbox.SqlServer/SqlServerOutbox.cs
@@ -37,6 +37,7 @@ namespace NimBus.Outbox.SqlServer
                     [CorrelationId]       NVARCHAR(256) NULL,
                     [Payload]             NVARCHAR(MAX) NOT NULL,
                     [EnqueueDelayMinutes] INT NOT NULL DEFAULT 0,
+                    [ScheduledEnqueueTimeUtc] DATETIME2 NULL,
                     [CreatedAtUtc]        DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
                     [DispatchedAtUtc]     DATETIME2 NULL,
                     INDEX IX_OutboxMessages_Pending NONCLUSTERED ([DispatchedAtUtc], [CreatedAtUtc]) WHERE [DispatchedAtUtc] IS NULL
@@ -54,9 +55,9 @@ namespace NimBus.Outbox.SqlServer
         {
             var sql = $@"
                 INSERT INTO {_options.FullTableName}
-                    ([Id], [MessageId], [EventTypeId], [SessionId], [CorrelationId], [Payload], [EnqueueDelayMinutes], [CreatedAtUtc])
+                    ([Id], [MessageId], [EventTypeId], [SessionId], [CorrelationId], [Payload], [EnqueueDelayMinutes], [ScheduledEnqueueTimeUtc], [CreatedAtUtc])
                 VALUES
-                    (@Id, @MessageId, @EventTypeId, @SessionId, @CorrelationId, @Payload, @EnqueueDelayMinutes, @CreatedAtUtc)";
+                    (@Id, @MessageId, @EventTypeId, @SessionId, @CorrelationId, @Payload, @EnqueueDelayMinutes, @ScheduledEnqueueTimeUtc, @CreatedAtUtc)";
 
             await using var connection = new SqlConnection(_options.ConnectionString);
             await connection.OpenAsync(cancellationToken);
@@ -98,7 +99,7 @@ namespace NimBus.Outbox.SqlServer
         public async Task<IReadOnlyList<OutboxMessage>> GetPendingAsync(int batchSize, CancellationToken cancellationToken = default)
         {
             var sql = $@"
-                SELECT TOP (@BatchSize) [Id], [MessageId], [EventTypeId], [SessionId], [CorrelationId], [Payload], [EnqueueDelayMinutes], [CreatedAtUtc]
+                SELECT TOP (@BatchSize) [Id], [MessageId], [EventTypeId], [SessionId], [CorrelationId], [Payload], [EnqueueDelayMinutes], [CreatedAtUtc], [ScheduledEnqueueTimeUtc]
                 FROM {_options.FullTableName}
                 WHERE [DispatchedAtUtc] IS NULL
                 ORDER BY [CreatedAtUtc] ASC";
@@ -123,6 +124,7 @@ namespace NimBus.Outbox.SqlServer
                     Payload = reader.GetString(5),
                     EnqueueDelayMinutes = reader.GetInt32(6),
                     CreatedAtUtc = reader.GetDateTime(7),
+                    ScheduledEnqueueTimeUtc = reader.IsDBNull(8) ? null : reader.GetDateTime(8),
                     DispatchedAtUtc = null
                 });
             }
@@ -188,6 +190,7 @@ namespace NimBus.Outbox.SqlServer
             command.Parameters.AddWithValue("@CorrelationId", (object)message.CorrelationId ?? DBNull.Value);
             command.Parameters.AddWithValue("@Payload", message.Payload);
             command.Parameters.AddWithValue("@EnqueueDelayMinutes", message.EnqueueDelayMinutes);
+            command.Parameters.AddWithValue("@ScheduledEnqueueTimeUtc", (object?)message.ScheduledEnqueueTimeUtc ?? DBNull.Value);
             command.Parameters.AddWithValue("@CreatedAtUtc", message.CreatedAtUtc);
         }
     }

--- a/src/NimBus.SDK/PublisherClient.cs
+++ b/src/NimBus.SDK/PublisherClient.cs
@@ -129,6 +129,24 @@ public class PublisherClient : IPublisherClient
     }
 
     /// <summary>
+    /// Schedules an event for delivery at the specified time.
+    /// Returns a sequence number that can be used to cancel the scheduled message.
+    /// </summary>
+    public async Task<long> Schedule(IEvent @event, DateTimeOffset scheduledEnqueueTime)
+    {
+        var message = GetMessage(@event);
+        return await _sender.ScheduleMessage(message, scheduledEnqueueTime);
+    }
+
+    /// <summary>
+    /// Cancels a previously scheduled message using the sequence number returned by <see cref="Schedule"/>.
+    /// </summary>
+    public async Task CancelScheduled(long sequenceNumber)
+    {
+        await _sender.CancelScheduledMessage(sequenceNumber);
+    }
+
+    /// <summary>
     /// Use to get batch of maximum possible size supported by Azure Service Bus
     /// </summary>
     /// <param name="events">Events you want to split into multiple batches</param>

--- a/src/NimBus.ServiceBus/Sender.cs
+++ b/src/NimBus.ServiceBus/Sender.cs
@@ -25,6 +25,12 @@ namespace NimBus.ServiceBus
 
         public Task Send(IEnumerable<IMessage> messages, int messageEnqueueDelay = 0, CancellationToken cancellationToken = default) =>
             _serviceBusSender.SendMessagesAsync(messages.Select(message => MessageHelper.ToServiceBusMessage(message, messageEnqueueDelay)).ToList(), cancellationToken);
+
+        public Task<long> ScheduleMessage(IMessage message, DateTimeOffset scheduledEnqueueTime, CancellationToken cancellationToken = default) =>
+            _serviceBusSender.ScheduleMessageAsync(MessageHelper.ToServiceBusMessage(message), scheduledEnqueueTime, cancellationToken);
+
+        public Task CancelScheduledMessage(long sequenceNumber, CancellationToken cancellationToken = default) =>
+            _serviceBusSender.CancelScheduledMessageAsync(sequenceNumber, cancellationToken);
     }
 
     public class Sender : SenderBase

--- a/src/NimBus.Testing/InMemoryMessageBus.cs
+++ b/src/NimBus.Testing/InMemoryMessageBus.cs
@@ -13,6 +13,9 @@ public class InMemoryMessageBus : ISender
     private readonly ConcurrentQueue<IMessage> _pending = new();
     private readonly List<IMessage> _allSent = new();
     private readonly ConcurrentDictionary<string, InMemorySessionState> _sessions = new();
+    private readonly List<(long SequenceNumber, IMessage Message, DateTimeOffset ScheduledTime)> _scheduled = new();
+    private readonly HashSet<long> _cancelledSchedules = new();
+    private long _nextSequenceNumber;
     private readonly object _lock = new();
 
     public IReadOnlyList<IMessage> SentMessages
@@ -77,10 +80,40 @@ public class InMemoryMessageBus : ISender
         return results;
     }
 
+    public Task<long> ScheduleMessage(IMessage message, DateTimeOffset scheduledEnqueueTime, CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            var seq = Interlocked.Increment(ref _nextSequenceNumber);
+            _scheduled.Add((seq, message, scheduledEnqueueTime));
+            _allSent.Add(message);
+            return Task.FromResult(seq);
+        }
+    }
+
+    public Task CancelScheduledMessage(long sequenceNumber, CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            _cancelledSchedules.Add(sequenceNumber);
+        }
+        return Task.CompletedTask;
+    }
+
+    public IReadOnlyList<(long SequenceNumber, IMessage Message, DateTimeOffset ScheduledTime)> ScheduledMessages
+    {
+        get { lock (_lock) { return _scheduled.Where(s => !_cancelledSchedules.Contains(s.SequenceNumber)).ToList(); } }
+    }
+
     public void Clear()
     {
         while (_pending.TryDequeue(out _)) { }
-        lock (_lock) { _allSent.Clear(); }
+        lock (_lock)
+        {
+            _allSent.Clear();
+            _scheduled.Clear();
+            _cancelledSchedules.Clear();
+        }
         _sessions.Clear();
     }
 }

--- a/src/NimBus.WebApp/ClientApp/src/pages/event-details.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/pages/event-details.tsx
@@ -54,8 +54,8 @@ const EventDetails = (props: EventDetailsProps) => {
       )
         client
           .getEventBlockedId(
-            tempCosmosEvent.sessionId!,
             tempCosmosEvent.endpointId!,
+            tempCosmosEvent.sessionId!,
           )
           .then(async (res) => {
             const tempBlockedEvents = [];

--- a/src/NimBus.WebApp/Services/SeedDataService.cs
+++ b/src/NimBus.WebApp/Services/SeedDataService.cs
@@ -177,7 +177,7 @@ public class SeedDataService
 
             var evt = CreateUnresolvedEvent(eventId, sessionId, endpointId,
                 ResolutionStatus.Deferred, eventTypeId, timestamp);
-            evt.Reason = $"Blocked by seed-pending-{endpointId}-0";
+            evt.Reason = $"Blocked by seed-failed-{endpointId}-0";
             evt.MessageContent = content;
             await _cosmosClient.UploadDeferredMessage(eventId, sessionId, endpointId, evt);
 

--- a/src/NimBus.WebApp/Services/SeedDataService.cs
+++ b/src/NimBus.WebApp/Services/SeedDataService.cs
@@ -78,7 +78,7 @@ public class SeedDataService
     {
         var endpointId = endpoint.Id;
         var now = DateTime.UtcNow;
-        var sessionId = $"session-{endpointId}-001";
+        var pendingSessionId = $"session-{endpointId}-pending";
 
         // Pick event types: prefer consumed (subscriber scenarios), fall back to produced
         var eventTypes = endpoint.EventTypesConsumed.Any()
@@ -87,7 +87,7 @@ public class SeedDataService
 
         if (eventTypes.Count == 0) return;
 
-        // Pending events - spread across last 3 days
+        // Pending events - shared session (realistic: messages waiting in queue)
         for (int i = 0; i < PendingCount; i++)
         {
             var eventTypeId = eventTypes[i % eventTypes.Count];
@@ -104,25 +104,26 @@ public class SeedDataService
                 }
             };
 
-            var evt = CreateUnresolvedEvent(eventId, sessionId, endpointId,
+            var evt = CreateUnresolvedEvent(eventId, pendingSessionId, endpointId,
                 ResolutionStatus.Pending, eventTypeId, timestamp);
             evt.MessageContent = content;
-            await _cosmosClient.UploadPendingMessage(eventId, sessionId, endpointId, evt);
+            await _cosmosClient.UploadPendingMessage(eventId, pendingSessionId, endpointId, evt);
 
-            // Store linked message so Messages page can navigate to this event
             await _cosmosClient.StoreMessage(CreateMessageEntity(
                 eventId, messageId, endpointId, EndpointRole.Subscriber,
-                MessageType.EventRequest, eventTypeId, timestamp, sessionId, content));
+                MessageType.EventRequest, eventTypeId, timestamp, pendingSessionId, content));
 
             result.EventsCreated++;
             result.MessagesCreated++;
         }
 
-        // Failed events - spread across last 3 days
+        // Failed events - each gets its own session (realistic: independent order sessions)
+        // The first failed event (i=0) gets deferred events blocked behind it
         for (int i = 0; i < FailedCount; i++)
         {
+            var failedSessionId = $"session-{endpointId}-fail-{i}";
             var eventTypeId = eventTypes[i % eventTypes.Count];
-            var hoursAgo = SeedWindowHours / FailedCount * i + 2; // offset by 2h from pending
+            var hoursAgo = SeedWindowHours / FailedCount * i + 2;
             var timestamp = now.AddHours(-hoursAgo);
             var eventId = $"seed-failed-{endpointId}-{i}";
             var messageId = $"seed-msg-failed-{endpointId}-{i}";
@@ -142,56 +143,58 @@ public class SeedDataService
                 }
             };
 
-            var evt = CreateUnresolvedEvent(eventId, sessionId, endpointId,
+            var evt = CreateUnresolvedEvent(eventId, failedSessionId, endpointId,
                 ResolutionStatus.Failed, eventTypeId, timestamp);
             evt.RetryCount = 3 + i;
             evt.RetryLimit = 5 + i;
             evt.MessageContent = content;
-            await _cosmosClient.UploadFailedMessage(eventId, sessionId, endpointId, evt);
+            await _cosmosClient.UploadFailedMessage(eventId, failedSessionId, endpointId, evt);
 
-            // Store linked ErrorResponse message — feeds Failed Message Insights
             await _cosmosClient.StoreMessage(CreateMessageEntity(
                 eventId, messageId, endpointId, EndpointRole.Subscriber,
-                MessageType.ErrorResponse, eventTypeId, timestamp, sessionId, content));
+                MessageType.ErrorResponse, eventTypeId, timestamp, failedSessionId, content));
 
             result.EventsCreated++;
             result.MessagesCreated++;
-        }
 
-        // Deferred events - spread across last 3 days
-        for (int i = 0; i < DeferredCount; i++)
-        {
-            var eventTypeId = eventTypes[i % eventTypes.Count];
-            var hoursAgo = SeedWindowHours / DeferredCount * i + 5; // offset by 5h
-            var timestamp = now.AddHours(-hoursAgo);
-            var eventId = $"seed-deferred-{endpointId}-{i}";
-            var messageId = $"seed-msg-deferred-{endpointId}-{i}";
-            var content = new MessageContent
+            // Create deferred events blocked behind the first failed event
+            if (i == 0)
             {
-                EventContent = new EventContent
+                for (int d = 0; d < DeferredCount; d++)
                 {
-                    EventTypeId = eventTypeId,
-                    EventJson = GenerateSamplePayload(eventTypeId, eventId)
+                    var deferredEventTypeId = eventTypes[(d + 1) % eventTypes.Count];
+                    var deferredTimestamp = timestamp.AddMinutes(d + 1);
+                    var deferredEventId = $"seed-deferred-{endpointId}-{d}";
+                    var deferredMessageId = $"seed-msg-deferred-{endpointId}-{d}";
+                    var deferredContent = new MessageContent
+                    {
+                        EventContent = new EventContent
+                        {
+                            EventTypeId = deferredEventTypeId,
+                            EventJson = GenerateSamplePayload(deferredEventTypeId, deferredEventId)
+                        }
+                    };
+
+                    var deferredEvt = CreateUnresolvedEvent(deferredEventId, failedSessionId, endpointId,
+                        ResolutionStatus.Deferred, deferredEventTypeId, deferredTimestamp);
+                    deferredEvt.Reason = $"Blocked by {eventId}";
+                    deferredEvt.MessageContent = deferredContent;
+                    await _cosmosClient.UploadDeferredMessage(deferredEventId, failedSessionId, endpointId, deferredEvt);
+
+                    await _cosmosClient.StoreMessage(CreateMessageEntity(
+                        deferredEventId, deferredMessageId, endpointId, EndpointRole.Subscriber,
+                        MessageType.EventRequest, deferredEventTypeId, deferredTimestamp, failedSessionId, deferredContent));
+
+                    result.EventsCreated++;
+                    result.MessagesCreated++;
                 }
-            };
-
-            var evt = CreateUnresolvedEvent(eventId, sessionId, endpointId,
-                ResolutionStatus.Deferred, eventTypeId, timestamp);
-            evt.Reason = $"Blocked by seed-failed-{endpointId}-0";
-            evt.MessageContent = content;
-            await _cosmosClient.UploadDeferredMessage(eventId, sessionId, endpointId, evt);
-
-            await _cosmosClient.StoreMessage(CreateMessageEntity(
-                eventId, messageId, endpointId, EndpointRole.Subscriber,
-                MessageType.EventRequest, eventTypeId, timestamp, sessionId, content));
-
-            result.EventsCreated++;
-            result.MessagesCreated++;
+            }
         }
 
-        // DeadLettered events - spread across last 3 days
+        // DeadLettered events - each gets its own session
         for (int i = 0; i < DeadLetteredCount; i++)
         {
+            var dlSessionId = $"session-{endpointId}-dl-{i}";
             var eventTypeId = eventTypes[i % eventTypes.Count];
             var hoursAgo = SeedWindowHours / DeadLetteredCount * i + 10; // offset by 10h
             var timestamp = now.AddHours(-hoursAgo);
@@ -213,18 +216,18 @@ public class SeedDataService
                 }
             };
 
-            var evt = CreateUnresolvedEvent(eventId, sessionId, endpointId,
+            var evt = CreateUnresolvedEvent(eventId, dlSessionId, endpointId,
                 ResolutionStatus.DeadLettered, eventTypeId, timestamp);
             evt.RetryCount = 10;
             evt.RetryLimit = 10;
             evt.DeadLetterReason = "MaxDeliveryCountExceeded";
             evt.DeadLetterErrorDescription = "Max delivery count of 10 exceeded";
             evt.MessageContent = content;
-            await _cosmosClient.UploadDeadletteredMessage(eventId, sessionId, endpointId, evt);
+            await _cosmosClient.UploadDeadletteredMessage(eventId, dlSessionId, endpointId, evt);
 
             await _cosmosClient.StoreMessage(CreateMessageEntity(
                 eventId, messageId, endpointId, EndpointRole.Subscriber,
-                MessageType.ErrorResponse, eventTypeId, timestamp, sessionId, content));
+                MessageType.ErrorResponse, eventTypeId, timestamp, dlSessionId, content));
 
             result.EventsCreated++;
             result.MessagesCreated++;
@@ -356,25 +359,63 @@ public class SeedDataService
 
     public async Task ClearSeedDataAsync()
     {
-        // Clean up per-endpoint events + their linked messages
-        var prefixCounts = new (string Prefix, string MsgPrefix, int Count)[]
-        {
-            ("seed-pending-", "seed-msg-pending-", PendingCount),
-            ("seed-failed-", "seed-msg-failed-", FailedCount),
-            ("seed-deferred-", "seed-msg-deferred-", DeferredCount),
-            ("seed-deadletter-", "seed-msg-deadletter-", DeadLetteredCount),
-        };
         foreach (var endpoint in PlatformEndpoints)
         {
             var endpointId = endpoint.Id;
-            var sessionId = $"session-{endpointId}-001";
-            foreach (var (prefix, msgPrefix, count) in prefixCounts)
+
+            // Pending events — shared session
+            var pendingSessionId = $"session-{endpointId}-pending";
+            for (int i = 0; i < PendingCount; i++)
             {
-                for (int i = 0; i < count; i++)
+                var eventId = $"seed-pending-{endpointId}-{i}";
+                var messageId = $"seed-msg-pending-{endpointId}-{i}";
+                try { await _cosmosClient.RemoveMessage(eventId, pendingSessionId, endpointId); } catch { }
+                try { await _cosmosClient.RemoveStoredMessage(eventId, messageId); } catch { }
+            }
+
+            // Failed events — per-failure session; deferred events on first failure's session
+            for (int i = 0; i < FailedCount; i++)
+            {
+                var failedSessionId = $"session-{endpointId}-fail-{i}";
+                var eventId = $"seed-failed-{endpointId}-{i}";
+                var messageId = $"seed-msg-failed-{endpointId}-{i}";
+                try { await _cosmosClient.RemoveMessage(eventId, failedSessionId, endpointId); } catch { }
+                try { await _cosmosClient.RemoveStoredMessage(eventId, messageId); } catch { }
+
+                if (i == 0)
                 {
-                    var eventId = $"{prefix}{endpointId}-{i}";
+                    for (int d = 0; d < DeferredCount; d++)
+                    {
+                        var deferredEventId = $"seed-deferred-{endpointId}-{d}";
+                        var deferredMessageId = $"seed-msg-deferred-{endpointId}-{d}";
+                        try { await _cosmosClient.RemoveMessage(deferredEventId, failedSessionId, endpointId); } catch { }
+                        try { await _cosmosClient.RemoveStoredMessage(deferredEventId, deferredMessageId); } catch { }
+                    }
+                }
+            }
+
+            // Dead-lettered events — per-dl session
+            for (int i = 0; i < DeadLetteredCount; i++)
+            {
+                var dlSessionId = $"session-{endpointId}-dl-{i}";
+                var eventId = $"seed-deadletter-{endpointId}-{i}";
+                var messageId = $"seed-msg-deadletter-{endpointId}-{i}";
+                try { await _cosmosClient.RemoveMessage(eventId, dlSessionId, endpointId); } catch { }
+                try { await _cosmosClient.RemoveStoredMessage(eventId, messageId); } catch { }
+            }
+
+            // Also clean up legacy single-session seed data (from previous seed format)
+            var legacySessionId = $"session-{endpointId}-001";
+            var legacyPrefixes = new[] { "seed-pending-", "seed-failed-", "seed-deferred-", "seed-deadletter-" };
+            var legacyCounts = new[] { PendingCount, FailedCount, DeferredCount, DeadLetteredCount };
+            for (int p = 0; p < legacyPrefixes.Length; p++)
+            {
+                for (int i = 0; i < legacyCounts[p]; i++)
+                {
+                    var eventId = $"{legacyPrefixes[p]}{endpointId}-{i}";
+                    var msgPrefix = legacyPrefixes[p].Replace("seed-", "seed-msg-");
                     var messageId = $"{msgPrefix}{endpointId}-{i}";
-                    try { await _cosmosClient.RemoveMessage(eventId, sessionId, endpointId); } catch { }
+                    try { await _cosmosClient.RemoveMessage(eventId, legacySessionId, endpointId); } catch { }
                     try { await _cosmosClient.RemoveStoredMessage(eventId, messageId); } catch { }
                 }
             }

--- a/tests/NimBus.Core.Tests/ResponseServiceTests.cs
+++ b/tests/NimBus.Core.Tests/ResponseServiceTests.cs
@@ -379,6 +379,15 @@ public class ResponseServiceTests
             LastDelay = messageEnqueueDelay;
             return Task.CompletedTask;
         }
+
+        public Task<long> ScheduleMessage(IMessage message, DateTimeOffset scheduledEnqueueTime, CancellationToken cancellationToken = default)
+        {
+            SentMessages.Add(message);
+            return Task.FromResult(0L);
+        }
+
+        public Task CancelScheduledMessage(long sequenceNumber, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
     }
 
     private sealed class FakeMessageContext : IMessageContext

--- a/tests/NimBus.EndToEnd.Tests/Infrastructure/InMemoryBus.cs
+++ b/tests/NimBus.EndToEnd.Tests/Infrastructure/InMemoryBus.cs
@@ -133,6 +133,20 @@ internal sealed class InMemoryBus : ISender
         return results;
     }
 
+    public Task<long> ScheduleMessage(IMessage message, DateTimeOffset scheduledEnqueueTime, CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            _allSentMessages.Add(message);
+            _sentMessagesWithDelay.Add((message, 0));
+        }
+        _messages.Enqueue(message);
+        return Task.FromResult(0L);
+    }
+
+    public Task CancelScheduledMessage(long sequenceNumber, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
     private FakeServiceBusSession GetOrCreateSession(string? sessionId)
     {
         var normalizedSessionId = NormalizeSessionId(sessionId);


### PR DESCRIPTION
## Summary

- Add `ScheduleMessage` and `CancelScheduledMessage` to `ISender` interface — first-class message scheduling exposing Azure Service Bus's native `ScheduledEnqueueTimeUtc`
- `PublisherClient` exposes `Schedule()` and `CancelScheduled()` convenience methods
- Outbox integration: `SqlServerOutbox` persists `ScheduledEnqueueTimeUtc` column, `OutboxDispatcher` dispatches via `ScheduleMessage` when set
- `InMemoryMessageBus` tracks scheduled messages for test assertions
- Seed data redesigned: each failed/dead-lettered event gets its own session with deferred events properly blocked behind the first failure

## Usage

```csharp
// Schedule an event for 30 minutes from now
var seq = await publisher.Schedule(orderReminder, DateTimeOffset.UtcNow.AddMinutes(30));

// Cancel if no longer needed
await publisher.CancelScheduled(seq);
```

## Outbox limitations

- `ScheduleMessage` returns `0L` in outbox mode (real sequence number assigned by Service Bus on dispatch)
- `CancelScheduledMessage` throws `NotSupportedException` in outbox mode — cancellation requires the Service Bus sequence number which is only available after dispatch

## Test plan

- [ ] `dotnet build src/NimBus.sln` compiles clean
- [ ] All existing tests pass (288+ tests across 5 projects)
- [ ] Verify seed data: first failed event shows Blocked (2) in Event Details
- [ ] Verify seed data cleanup removes all seeded events including legacy format
- [ ] Verify `Schedule()` on a real Service Bus instance delivers at the scheduled time