### PR TITLE
test: add 41 tests covering retry policies, SessionKey, and outbox

### DIFF
--- a/tests/NimBus.Core.Tests/OutboxTests.cs
+++ b/tests/NimBus.Core.Tests/OutboxTests.cs
@@ -1,0 +1,358 @@
+#pragma warning disable CA1707, CA2007
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NimBus.Core.Messages;
+using NimBus.Core.Outbox;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NimBus.Core.Tests;
+
+[TestClass]
+public class OutboxSenderTests
+{
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void Constructor_NullOutbox_Throws()
+    {
+        new OutboxSender(null);
+    }
+
+    [TestMethod]
+    public async Task Send_SingleMessage_StoresInOutbox()
+    {
+        var outbox = new InMemoryOutbox();
+        var sender = new OutboxSender(outbox);
+        var message = CreateMessage("msg-1", "OrderPlaced", "session-1");
+
+        await sender.Send(message);
+
+        Assert.AreEqual(1, outbox.StoredMessages.Count);
+        Assert.AreEqual("msg-1", outbox.StoredMessages[0].MessageId);
+        Assert.AreEqual("session-1", outbox.StoredMessages[0].SessionId);
+    }
+
+    [TestMethod]
+    public async Task Send_WithDelay_SetsEnqueueDelayMinutes()
+    {
+        var outbox = new InMemoryOutbox();
+        var sender = new OutboxSender(outbox);
+        var message = CreateMessage("msg-1", "OrderPlaced", "session-1");
+
+        await sender.Send(message, messageEnqueueDelay: 5);
+
+        Assert.AreEqual(5, outbox.StoredMessages[0].EnqueueDelayMinutes);
+    }
+
+    [TestMethod]
+    public async Task Send_BatchMessages_StoresAllInOutbox()
+    {
+        var outbox = new InMemoryOutbox();
+        var sender = new OutboxSender(outbox);
+        var messages = new[]
+        {
+            CreateMessage("msg-1", "OrderPlaced", "session-1"),
+            CreateMessage("msg-2", "OrderPlaced", "session-1"),
+            CreateMessage("msg-3", "PaymentCaptured", "session-2"),
+        };
+
+        await sender.Send(messages);
+
+        Assert.AreEqual(3, outbox.BatchStoredMessages.Count);
+    }
+
+    [TestMethod]
+    public async Task Send_SerializesPayloadAsJson()
+    {
+        var outbox = new InMemoryOutbox();
+        var sender = new OutboxSender(outbox);
+        var message = CreateMessage("msg-1", "OrderPlaced", "session-1");
+
+        await sender.Send(message);
+
+        var stored = outbox.StoredMessages[0];
+        Assert.IsFalse(string.IsNullOrEmpty(stored.Payload));
+        var deserialized = JsonConvert.DeserializeObject<Message>(stored.Payload);
+        Assert.AreEqual("msg-1", deserialized.MessageId);
+    }
+
+    [TestMethod]
+    public async Task ScheduleMessage_SetsScheduledEnqueueTimeUtc()
+    {
+        var outbox = new InMemoryOutbox();
+        var sender = new OutboxSender(outbox);
+        var message = CreateMessage("msg-1", "OrderPlaced", "session-1");
+        var scheduledTime = DateTimeOffset.UtcNow.AddHours(1);
+
+        var seq = await sender.ScheduleMessage(message, scheduledTime);
+
+        Assert.AreEqual(0L, seq, "Outbox always returns 0 for sequence number");
+        Assert.IsNotNull(outbox.StoredMessages[0].ScheduledEnqueueTimeUtc);
+        var diff = Math.Abs((scheduledTime.UtcDateTime - outbox.StoredMessages[0].ScheduledEnqueueTimeUtc.Value).TotalSeconds);
+        Assert.IsTrue(diff < 1, "ScheduledEnqueueTimeUtc should match within 1 second");
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(NotSupportedException))]
+    public async Task CancelScheduledMessage_ThrowsNotSupported()
+    {
+        var outbox = new InMemoryOutbox();
+        var sender = new OutboxSender(outbox);
+
+        await sender.CancelScheduledMessage(42);
+    }
+
+    [TestMethod]
+    public async Task Send_SetsCreatedAtUtc()
+    {
+        var outbox = new InMemoryOutbox();
+        var sender = new OutboxSender(outbox);
+        var before = DateTime.UtcNow;
+
+        await sender.Send(CreateMessage("msg-1", "OrderPlaced", "s1"));
+
+        var after = DateTime.UtcNow;
+        var created = outbox.StoredMessages[0].CreatedAtUtc;
+        Assert.IsTrue(created >= before && created <= after);
+    }
+
+    [TestMethod]
+    public async Task Send_DispatchedAtUtcIsNull()
+    {
+        var outbox = new InMemoryOutbox();
+        var sender = new OutboxSender(outbox);
+
+        await sender.Send(CreateMessage("msg-1", "OrderPlaced", "s1"));
+
+        Assert.IsNull(outbox.StoredMessages[0].DispatchedAtUtc);
+    }
+
+    private static Message CreateMessage(string messageId, string eventTypeId, string sessionId) => new()
+    {
+        MessageId = messageId,
+        EventTypeId = eventTypeId,
+        SessionId = sessionId,
+        CorrelationId = "corr-1",
+        To = "TestEndpoint",
+        EventId = "evt-1",
+        MessageType = MessageType.EventRequest,
+        OriginatingMessageId = "self",
+        ParentMessageId = "self",
+        From = "publisher",
+        OriginatingFrom = "publisher",
+        OriginalSessionId = sessionId,
+        MessageContent = new MessageContent
+        {
+            EventContent = new EventContent { EventTypeId = eventTypeId, EventJson = "{}" }
+        }
+    };
+}
+
+[TestClass]
+public class OutboxDispatcherTests
+{
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void Constructor_NullOutbox_Throws()
+    {
+        new OutboxDispatcher(null, new RecordingSender());
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void Constructor_NullSender_Throws()
+    {
+        new OutboxDispatcher(new InMemoryOutbox(), null);
+    }
+
+    [TestMethod]
+    public async Task DispatchPending_NoPending_ReturnsZero()
+    {
+        var outbox = new InMemoryOutbox();
+        var sender = new RecordingSender();
+        var dispatcher = new OutboxDispatcher(outbox, sender);
+
+        var count = await dispatcher.DispatchPendingAsync();
+
+        Assert.AreEqual(0, count);
+        Assert.AreEqual(0, sender.SentMessages.Count);
+    }
+
+    [TestMethod]
+    public async Task DispatchPending_SendsMessagesAndMarksDispatched()
+    {
+        var outbox = new InMemoryOutbox();
+        outbox.AddPending(new OutboxMessage
+        {
+            Id = "out-1",
+            MessageId = "msg-1",
+            Payload = JsonConvert.SerializeObject(new Message
+            {
+                MessageId = "msg-1",
+                To = "Test",
+                SessionId = "s1",
+                MessageContent = new MessageContent { EventContent = new EventContent { EventTypeId = "OrderPlaced" } }
+            }),
+            EnqueueDelayMinutes = 0,
+            CreatedAtUtc = DateTime.UtcNow
+        });
+
+        var sender = new RecordingSender();
+        var dispatcher = new OutboxDispatcher(outbox, sender);
+
+        var count = await dispatcher.DispatchPendingAsync();
+
+        Assert.AreEqual(1, count);
+        Assert.AreEqual(1, sender.SentMessages.Count);
+        Assert.IsTrue(outbox.DispatchedIds.Contains("out-1"));
+    }
+
+    [TestMethod]
+    public async Task DispatchPending_ScheduledMessage_UsesScheduleMessage()
+    {
+        var scheduledTime = DateTime.UtcNow.AddHours(1);
+        var outbox = new InMemoryOutbox();
+        outbox.AddPending(new OutboxMessage
+        {
+            Id = "out-1",
+            MessageId = "msg-1",
+            Payload = JsonConvert.SerializeObject(new Message
+            {
+                MessageId = "msg-1",
+                To = "Test",
+                SessionId = "s1",
+                MessageContent = new MessageContent { EventContent = new EventContent { EventTypeId = "OrderPlaced" } }
+            }),
+            ScheduledEnqueueTimeUtc = scheduledTime,
+            EnqueueDelayMinutes = 0,
+            CreatedAtUtc = DateTime.UtcNow
+        });
+
+        var sender = new RecordingSender();
+        var dispatcher = new OutboxDispatcher(outbox, sender);
+
+        var count = await dispatcher.DispatchPendingAsync();
+
+        Assert.AreEqual(1, count);
+        Assert.AreEqual(1, sender.ScheduledMessages.Count, "Should use ScheduleMessage for scheduled outbox entries");
+    }
+
+    [TestMethod]
+    public async Task DispatchPending_FirstFailure_StopsDispatching()
+    {
+        var outbox = new InMemoryOutbox();
+        outbox.AddPending(new OutboxMessage { Id = "out-1", MessageId = "msg-1", Payload = "{invalid json", CreatedAtUtc = DateTime.UtcNow });
+        outbox.AddPending(new OutboxMessage { Id = "out-2", MessageId = "msg-2", Payload = "{invalid json", CreatedAtUtc = DateTime.UtcNow });
+
+        var sender = new RecordingSender();
+        var dispatcher = new OutboxDispatcher(outbox, sender);
+
+        var count = await dispatcher.DispatchPendingAsync();
+
+        Assert.AreEqual(0, count, "Should stop on first failure");
+        Assert.AreEqual(0, outbox.DispatchedIds.Count);
+    }
+
+    [TestMethod]
+    public async Task DispatchPending_RespectsBatchSize()
+    {
+        var outbox = new InMemoryOutbox();
+        for (int i = 0; i < 10; i++)
+        {
+            outbox.AddPending(new OutboxMessage
+            {
+                Id = $"out-{i}",
+                MessageId = $"msg-{i}",
+                Payload = JsonConvert.SerializeObject(new Message
+                {
+                    MessageId = $"msg-{i}",
+                    To = "Test",
+                    SessionId = "s1",
+                    MessageContent = new MessageContent { EventContent = new EventContent { EventTypeId = "OrderPlaced" } }
+                }),
+                CreatedAtUtc = DateTime.UtcNow
+            });
+        }
+
+        var sender = new RecordingSender();
+        var dispatcher = new OutboxDispatcher(outbox, sender);
+
+        var count = await dispatcher.DispatchPendingAsync(batchSize: 3);
+
+        Assert.AreEqual(3, count);
+    }
+}
+
+// ── Test doubles ─────────────────────────────────────────────────────
+
+file sealed class InMemoryOutbox : IOutbox
+{
+    public List<OutboxMessage> StoredMessages { get; } = new();
+    public List<OutboxMessage> BatchStoredMessages { get; } = new();
+    public List<string> DispatchedIds { get; } = new();
+
+    private readonly List<OutboxMessage> _pending = new();
+
+    public void AddPending(OutboxMessage msg) => _pending.Add(msg);
+
+    public Task StoreAsync(OutboxMessage message, CancellationToken ct = default)
+    {
+        StoredMessages.Add(message);
+        return Task.CompletedTask;
+    }
+
+    public Task StoreBatchAsync(IEnumerable<OutboxMessage> messages, CancellationToken ct = default)
+    {
+        BatchStoredMessages.AddRange(messages);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<OutboxMessage>> GetPendingAsync(int batchSize, CancellationToken ct = default)
+    {
+        var result = _pending.Take(batchSize).ToList();
+        return Task.FromResult<IReadOnlyList<OutboxMessage>>(result);
+    }
+
+    public Task MarkAsDispatchedAsync(string id, CancellationToken ct = default)
+    {
+        DispatchedIds.Add(id);
+        return Task.CompletedTask;
+    }
+
+    public Task MarkAsDispatchedAsync(IEnumerable<string> ids, CancellationToken ct = default)
+    {
+        DispatchedIds.AddRange(ids);
+        return Task.CompletedTask;
+    }
+}
+
+file sealed class RecordingSender : ISender
+{
+    public List<IMessage> SentMessages { get; } = new();
+    public List<(IMessage Message, DateTimeOffset ScheduledTime)> ScheduledMessages { get; } = new();
+    public int LastDelay { get; private set; }
+
+    public Task Send(IMessage message, int messageEnqueueDelay = 0, CancellationToken ct = default)
+    {
+        SentMessages.Add(message);
+        LastDelay = messageEnqueueDelay;
+        return Task.CompletedTask;
+    }
+
+    public Task Send(IEnumerable<IMessage> messages, int messageEnqueueDelay = 0, CancellationToken ct = default)
+    {
+        SentMessages.AddRange(messages);
+        return Task.CompletedTask;
+    }
+
+    public Task<long> ScheduleMessage(IMessage message, DateTimeOffset scheduledEnqueueTime, CancellationToken ct = default)
+    {
+        ScheduledMessages.Add((message, scheduledEnqueueTime));
+        return Task.FromResult(42L);
+    }
+
+    public Task CancelScheduledMessage(long sequenceNumber, CancellationToken ct = default) => Task.CompletedTask;
+}

--- a/tests/NimBus.Core.Tests/RetryPolicyProviderTests.cs
+++ b/tests/NimBus.Core.Tests/RetryPolicyProviderTests.cs
@@ -1,0 +1,194 @@
+#pragma warning disable CA1707, CA2007
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NimBus.Core.Messages;
+using System;
+
+namespace NimBus.Core.Tests;
+
+[TestClass]
+public class RetryPolicyProviderTests
+{
+    private static RetryPolicy MakePolicy(int maxRetries = 3) => new()
+    {
+        MaxRetries = maxRetries,
+        Strategy = BackoffStrategy.Fixed,
+        BaseDelay = TimeSpan.FromMinutes(1)
+    };
+
+    // ── Default policy ──────────────────────────────────────────────
+
+    [TestMethod]
+    public void GetRetryPolicy_NoConfig_ReturnsNull()
+    {
+        var provider = new DefaultRetryPolicyProvider();
+        var result = provider.GetRetryPolicy("OrderPlaced", "some error");
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void GetRetryPolicy_DefaultPolicySet_ReturnsFallback()
+    {
+        var policy = MakePolicy(5);
+        var provider = new DefaultRetryPolicyProvider();
+        provider.SetDefaultPolicy(policy);
+
+        var result = provider.GetRetryPolicy("AnyEvent", "any exception");
+        Assert.AreSame(policy, result);
+    }
+
+    // ── Event-type policies ─────────────────────────────────────────
+
+    [TestMethod]
+    public void GetRetryPolicy_EventTypeMatch_ReturnsEventPolicy()
+    {
+        var eventPolicy = MakePolicy(10);
+        var defaultPolicy = MakePolicy(1);
+        var provider = new DefaultRetryPolicyProvider();
+        provider.AddEventTypePolicy("OrderPlaced", eventPolicy);
+        provider.SetDefaultPolicy(defaultPolicy);
+
+        var result = provider.GetRetryPolicy("OrderPlaced", "some error");
+        Assert.AreSame(eventPolicy, result);
+    }
+
+    [TestMethod]
+    public void GetRetryPolicy_EventTypeMismatch_ReturnsDefault()
+    {
+        var eventPolicy = MakePolicy(10);
+        var defaultPolicy = MakePolicy(1);
+        var provider = new DefaultRetryPolicyProvider();
+        provider.AddEventTypePolicy("OrderPlaced", eventPolicy);
+        provider.SetDefaultPolicy(defaultPolicy);
+
+        var result = provider.GetRetryPolicy("PaymentCaptured", "some error");
+        Assert.AreSame(defaultPolicy, result);
+    }
+
+    [TestMethod]
+    public void GetRetryPolicy_EventTypeCaseInsensitive()
+    {
+        var policy = MakePolicy();
+        var provider = new DefaultRetryPolicyProvider();
+        provider.AddEventTypePolicy("OrderPlaced", policy);
+
+        var result = provider.GetRetryPolicy("orderplaced", "error");
+        Assert.AreSame(policy, result);
+    }
+
+    // ── Exception rules ─────────────────────────────────────────────
+
+    [TestMethod]
+    public void GetRetryPolicy_ExceptionRuleMatches_ReturnsRulePolicy()
+    {
+        var timeoutPolicy = MakePolicy(2);
+        var defaultPolicy = MakePolicy(5);
+        var provider = new DefaultRetryPolicyProvider();
+        provider.AddExceptionRule("timeout", timeoutPolicy);
+        provider.SetDefaultPolicy(defaultPolicy);
+
+        var result = provider.GetRetryPolicy("OrderPlaced", "Connection timeout after 30s");
+        Assert.AreSame(timeoutPolicy, result);
+    }
+
+    [TestMethod]
+    public void GetRetryPolicy_ExceptionRuleCaseInsensitive()
+    {
+        var policy = MakePolicy();
+        var provider = new DefaultRetryPolicyProvider();
+        provider.AddExceptionRule("timeout", policy);
+
+        var result = provider.GetRetryPolicy("AnyEvent", "TIMEOUT occurred");
+        Assert.AreSame(policy, result);
+    }
+
+    [TestMethod]
+    public void GetRetryPolicy_ExceptionRuleDoesNotMatch_FallsToEventType()
+    {
+        var exceptionPolicy = MakePolicy(1);
+        var eventPolicy = MakePolicy(5);
+        var provider = new DefaultRetryPolicyProvider();
+        provider.AddExceptionRule("timeout", exceptionPolicy);
+        provider.AddEventTypePolicy("OrderPlaced", eventPolicy);
+
+        var result = provider.GetRetryPolicy("OrderPlaced", "NullReferenceException");
+        Assert.AreSame(eventPolicy, result);
+    }
+
+    [TestMethod]
+    public void GetRetryPolicy_ExceptionRuleTakesPrecedenceOverEventType()
+    {
+        var exceptionPolicy = MakePolicy(1);
+        var eventPolicy = MakePolicy(5);
+        var provider = new DefaultRetryPolicyProvider();
+        provider.AddExceptionRule("timeout", exceptionPolicy);
+        provider.AddEventTypePolicy("OrderPlaced", eventPolicy);
+
+        var result = provider.GetRetryPolicy("OrderPlaced", "Connection timeout");
+        Assert.AreSame(exceptionPolicy, result, "Exception rule should take precedence over event-type policy");
+    }
+
+    [TestMethod]
+    public void GetRetryPolicy_ExceptionRuleScopedToEventType_MatchesOnlyScoped()
+    {
+        var scopedPolicy = MakePolicy(2);
+        var defaultPolicy = MakePolicy(5);
+        var provider = new DefaultRetryPolicyProvider();
+        provider.AddExceptionRule("timeout", scopedPolicy, "OrderPlaced");
+        provider.SetDefaultPolicy(defaultPolicy);
+
+        var matchResult = provider.GetRetryPolicy("OrderPlaced", "timeout error");
+        Assert.AreSame(scopedPolicy, matchResult);
+
+        var noMatchResult = provider.GetRetryPolicy("PaymentCaptured", "timeout error");
+        Assert.AreSame(defaultPolicy, noMatchResult, "Scoped rule should not match other event types");
+    }
+
+    [TestMethod]
+    public void GetRetryPolicy_NullExceptionMessage_SkipsExceptionRules()
+    {
+        var exceptionPolicy = MakePolicy(1);
+        var defaultPolicy = MakePolicy(5);
+        var provider = new DefaultRetryPolicyProvider();
+        provider.AddExceptionRule("timeout", exceptionPolicy);
+        provider.SetDefaultPolicy(defaultPolicy);
+
+        var result = provider.GetRetryPolicy("OrderPlaced", null);
+        Assert.AreSame(defaultPolicy, result);
+    }
+
+    [TestMethod]
+    public void GetRetryPolicy_EmptyExceptionMessage_SkipsExceptionRules()
+    {
+        var exceptionPolicy = MakePolicy(1);
+        var defaultPolicy = MakePolicy(5);
+        var provider = new DefaultRetryPolicyProvider();
+        provider.AddExceptionRule("timeout", exceptionPolicy);
+        provider.SetDefaultPolicy(defaultPolicy);
+
+        var result = provider.GetRetryPolicy("OrderPlaced", "");
+        Assert.AreSame(defaultPolicy, result);
+    }
+
+    // ── Validation ──────────────────────────────────────────────────
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void AddEventTypePolicy_NullPolicy_Throws()
+    {
+        new DefaultRetryPolicyProvider().AddEventTypePolicy("OrderPlaced", null);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void AddExceptionRule_NullContains_Throws()
+    {
+        new DefaultRetryPolicyProvider().AddExceptionRule(null, MakePolicy());
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void AddExceptionRule_NullPolicy_Throws()
+    {
+        new DefaultRetryPolicyProvider().AddExceptionRule("timeout", null);
+    }
+}

--- a/tests/NimBus.Core.Tests/SessionKeyAttributeTests.cs
+++ b/tests/NimBus.Core.Tests/SessionKeyAttributeTests.cs
@@ -1,0 +1,139 @@
+#pragma warning disable CA1707, CA2007
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NimBus.Core.Events;
+using System;
+using System.ComponentModel;
+
+namespace NimBus.Core.Tests;
+
+[TestClass]
+public class SessionKeyAttributeTests
+{
+    // ── Test event classes ──────────────────────────────────────────
+
+    [SessionKey(nameof(OrderId))]
+    private class OrderWithAttribute : Event
+    {
+        public Guid OrderId { get; set; }
+        public string Product { get; set; }
+    }
+
+    private sealed class OrderWithOverride : Event
+    {
+        public Guid OrderId { get; set; }
+        public override string GetSessionId() => $"custom-{OrderId}";
+    }
+
+    private sealed class OrderWithNoSessionKey : Event
+    {
+        public Guid OrderId { get; set; }
+    }
+
+    [SessionKey("NonExistentProperty")]
+    private sealed class OrderWithBadAttribute : Event
+    {
+        public Guid OrderId { get; set; }
+    }
+
+    [SessionKey(nameof(NullableField))]
+    private sealed class OrderWithNullableField : Event
+    {
+        public string NullableField { get; set; }
+    }
+
+    [SessionKey(nameof(CustomerId))]
+    private sealed class DerivedOrder : OrderWithAttribute
+    {
+        public Guid CustomerId { get; set; }
+    }
+
+    // ── Tests ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void GetSessionId_WithAttribute_ReturnsPropertyValue()
+    {
+        var orderId = Guid.NewGuid();
+        var evt = new OrderWithAttribute { OrderId = orderId };
+
+        Assert.AreEqual(orderId.ToString(), evt.GetSessionId());
+    }
+
+    [TestMethod]
+    public void GetSessionId_WithOverride_ReturnsOverrideValue()
+    {
+        var orderId = Guid.NewGuid();
+        var evt = new OrderWithOverride { OrderId = orderId };
+
+        Assert.AreEqual($"custom-{orderId}", evt.GetSessionId());
+    }
+
+    [TestMethod]
+    public void GetSessionId_NoAttributeNoOverride_ReturnsGuid()
+    {
+        var evt = new OrderWithNoSessionKey { OrderId = Guid.NewGuid() };
+        var sessionId = evt.GetSessionId();
+
+        Assert.IsTrue(Guid.TryParse(sessionId, out _), "Should return a valid GUID");
+    }
+
+    [TestMethod]
+    public void GetSessionId_NoAttributeNoOverride_ReturnsDifferentGuidsEachCall()
+    {
+        var evt = new OrderWithNoSessionKey { OrderId = Guid.NewGuid() };
+        var id1 = evt.GetSessionId();
+        var id2 = evt.GetSessionId();
+
+        Assert.AreNotEqual(id1, id2, "Each call should return a unique GUID");
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(InvalidOperationException))]
+    public void GetSessionId_AttributeReferencesNonExistentProperty_Throws()
+    {
+        var evt = new OrderWithBadAttribute { OrderId = Guid.NewGuid() };
+        evt.GetSessionId();
+    }
+
+    [TestMethod]
+    public void GetSessionId_AttributePropertyIsNull_ReturnsGuid()
+    {
+        var evt = new OrderWithNullableField { NullableField = null };
+        var sessionId = evt.GetSessionId();
+
+        Assert.IsTrue(Guid.TryParse(sessionId, out _), "Null property value should fall back to GUID");
+    }
+
+    [TestMethod]
+    public void GetSessionId_AttributePropertyHasValue_ReturnsValue()
+    {
+        var evt = new OrderWithNullableField { NullableField = "my-session" };
+        Assert.AreEqual("my-session", evt.GetSessionId());
+    }
+
+    [TestMethod]
+    public void GetSessionId_DerivedClassOverridesAttribute_UsesDerivedAttribute()
+    {
+        var customerId = Guid.NewGuid();
+        var evt = new DerivedOrder
+        {
+            OrderId = Guid.NewGuid(),
+            CustomerId = customerId
+        };
+
+        Assert.AreEqual(customerId.ToString(), evt.GetSessionId());
+    }
+
+    [TestMethod]
+    public void SessionKeyAttribute_ExposedInEventTypeMetadata()
+    {
+        var eventType = new EventType(typeof(OrderWithAttribute));
+        Assert.AreEqual("OrderId", eventType.SessionKeyProperty);
+    }
+
+    [TestMethod]
+    public void SessionKeyAttribute_NullForEventsWithoutAttribute()
+    {
+        var eventType = new EventType(typeof(OrderWithNoSessionKey));
+        Assert.IsNull(eventType.SessionKeyProperty);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the three highest-priority test coverage gaps identified in the test audit.

### New test files (3 files, 41 tests)

**RetryPolicyProviderTests (13 tests)**
- 3-tier policy resolution: exception rules > event-type policies > default
- Case-insensitive matching for event types and exception text
- Scoped exception rules (per event type)
- Null/empty exception message edge cases
- Argument validation (null policy, null contains)

**SessionKeyAttributeTests (10 tests)**
- `[SessionKey(nameof(Prop))]` reads property value correctly
- `GetSessionId()` override takes precedence over attribute
- No attribute/no override returns random GUID (different each call)
- Bad property name throws `InvalidOperationException`
- Null property value falls back to GUID
- Derived class attribute overrides parent
- `EventType.SessionKeyProperty` metadata exposed correctly

**OutboxSenderTests (9 tests) + OutboxDispatcherTests (6 tests)**
- Single message store, batch store, delay propagation
- JSON serialization of payload
- `ScheduleMessage` sets `ScheduledEnqueueTimeUtc`, returns 0
- `CancelScheduledMessage` throws `NotSupportedException`
- Dispatcher sends and marks dispatched
- Scheduled messages routed via `ScheduleMessage`
- First failure stops batch (ordering preservation)
- Batch size respected

## Test results

- Core tests: 119 passed (was 78, +41 new)
- E2E tests: 51 passed (unchanged)
- ServiceBus tests: 128 passed (unchanged)
- **Total: 298+ tests, 0 failures**

## Test plan

- [x] All 119 Core tests pass
- [x] All 51 E2E tests pass (regression check)
- [x] All 128 ServiceBus tests pass (regression check)