### PR TITLE
feat(infra): add FlexConsumption resolver hosting plan option

### DIFF
--- a/deploy/bicep/deploy.core.bicep
+++ b/deploy/bicep/deploy.core.bicep
@@ -23,6 +23,15 @@ param sqlAdminLogin string = ''
 @secure()
 param sqlAdminPassword string = ''
 
+// Resolver Function App hosting plan. 'ElasticPremium' (default, EP1, Windows)
+// preserves the existing behavior. 'FlexConsumption' provisions a Flex Consumption
+// plan (FC1, Linux) that scales to zero — significantly cheaper for dev/test.
+@allowed([
+  'ElasticPremium'
+  'FlexConsumption'
+])
+param resolverPlan string = 'ElasticPremium'
+
 //##############################################
 // Define names Azure resource names
 //##############################################
@@ -111,6 +120,10 @@ module funcstorageaccount 'templates/storageaccount.bicep' = {
   params : {
     name: funcStorageAccountName
     location: location
+    // Flex Consumption needs a blob container holding the app package, referenced
+    // from the Function App via SystemAssignedIdentity. Provision it inline so
+    // the container exists before resolverFunctionFlex tries to bind to it.
+    createDeploymentContainer: resolverPlan == 'FlexConsumption'
   }
 }
 
@@ -128,24 +141,11 @@ module appserviceplan 'templates/appServicePlan.bicep' = {
 }
 
 //##############################################
-//# Create App Service Plan for function apps
+//# Resolver: Function App settings shared by both plan types
 //##############################################
 
-module functionappplan 'templates/functionAppPlan.bicep' = {
-  name: 'functionAppplanDeploy'
-  params: {
-    name: coreAppServicePlanName
-    skuName: 'EP1'
-    location: location
-  }
-}
-
-
-//##############################################
-//# Resolver: Create Function app
-//##############################################
-
-var commonResolverSettings = [
+// Settings every resolver host needs regardless of plan type.
+var sharedResolverSettings = [
   {
     name: 'GlobalTraceLogInstrKey'
     value: applicationinsights.outputs.instrumentationKey
@@ -159,6 +159,15 @@ var commonResolverSettings = [
     value: resolverId
   }
   {
+    name: 'AzureWebJobsServiceBus__fullyQualifiedNamespace'
+    value: serviceBusNamespace.outputs.fullyQualifiedNamespace
+  }
+]
+
+// Elastic Premium needs the Windows host to know where its content share lives.
+// Flex Consumption rejects these settings.
+var elasticPremiumExtraSettings = resolverPlan == 'ElasticPremium' ? [
+  {
     name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'
     value: funcstorageaccount.outputs.connectionString
   }
@@ -166,11 +175,7 @@ var commonResolverSettings = [
     name: 'WEBSITE_CONTENTSHARE'
     value: '${toLower(resolverFunctionAppName)}${uniqueString(uniqueDeploy)}'
   }
-  {
-    name: 'AzureWebJobsServiceBus__fullyQualifiedNamespace'
-    value: serviceBusNamespace.outputs.fullyQualifiedNamespace
-  }
-]
+] : []
 
 var cosmosResolverSetting = storageProvider == 'cosmos' ? [
   {
@@ -186,21 +191,62 @@ var sqlResolverSetting = storageProvider == 'sqlserver' && sqlMode == 'provision
   }
 ] : []
 
-var resolverappsettings = concat(commonResolverSettings, cosmosResolverSetting, sqlResolverSetting)
+var resolverappsettings = concat(sharedResolverSettings, elasticPremiumExtraSettings, cosmosResolverSetting, sqlResolverSetting)
 
-module resolverFunction 'templates/functionApp.bicep' = {
+//##############################################
+//# Resolver: Hosting plan + Function App (Elastic Premium branch)
+//##############################################
+
+module functionappplanElastic 'templates/functionAppPlan.bicep' = if (resolverPlan == 'ElasticPremium') {
+  name: 'functionAppplanDeploy'
+  params: {
+    name: coreAppServicePlanName
+    skuName: 'EP1'
+    location: location
+  }
+}
+
+module resolverFunctionElastic 'templates/functionApp.bicep' = if (resolverPlan == 'ElasticPremium') {
   name: 'resolverDeploy'
   params: {
     appName: resolverFunctionAppName
     appInsightsInstrumentationKey: applicationinsights.outputs.instrumentationKey
-    appServicePlanId: functionappplan.outputs.id
+    appServicePlanId: functionappplanElastic.outputs.id
     functionAppVersion: '4'
     storageConnectionString: funcstorageaccount.outputs.connectionString
     location: location
     settings: resolverappsettings
   }
-
 }
+
+//##############################################
+//# Resolver: Hosting plan + Function App (Flex Consumption branch)
+//##############################################
+
+module functionappplanFlex 'templates/flexConsumptionPlan.bicep' = if (resolverPlan == 'FlexConsumption') {
+  name: 'functionAppplanFlexDeploy'
+  params: {
+    name: coreAppServicePlanName
+    location: location
+  }
+}
+
+module resolverFunctionFlex 'templates/flexConsumptionFunctionApp.bicep' = if (resolverPlan == 'FlexConsumption') {
+  name: 'resolverFlexDeploy'
+  params: {
+    appName: resolverFunctionAppName
+    appServicePlanId: functionappplanFlex.outputs.id
+    storageAccountName: funcstorageaccount.outputs.storageName
+    deploymentStorageBlobUri: '${funcstorageaccount.outputs.blobEndpoint}app-package-resolver'
+    location: location
+    settings: resolverappsettings
+  }
+}
+
+// Branch-aware principal id; one of the two modules deploys, the other is skipped.
+var resolverPrincipalId = resolverPlan == 'FlexConsumption'
+  ? resolverFunctionFlex.outputs.principalId
+  : resolverFunctionElastic.outputs.principalId
 
 //##############################################
 //# Resolver: RBAC role assignments
@@ -209,12 +255,16 @@ module resolverFunction 'templates/functionApp.bicep' = {
 // Service Bus RBAC must always be granted to the resolver identity (managed-identity
 // access to receive/complete messages). Cosmos role assignment is gated inside the
 // module so SQL deployments don't try to create Cosmos sqlRoleAssignments resources.
+// Flex Consumption additionally needs Storage Blob Data Contributor on the function
+// storage account for the deployment package + AzureWebJobsStorage host runtime.
 module resolverRoleAssignments 'templates/roleAssignments.bicep' = {
   name: 'resolverRoleAssignmentsDeploy'
   params: {
     serviceBusNamespaceName: sbNamespace
     cosmosAccountName: storageProvider == 'cosmos' ? cosmosAccountName : ''
-    principalId: resolverFunction.outputs.principalId
+    principalId: resolverPrincipalId
     storageProvider: storageProvider
+    funcStorageAccountName: funcStorageAccountName
+    grantFuncStorageBlobDataContributor: resolverPlan == 'FlexConsumption'
   }
 }

--- a/deploy/bicep/templates/flexConsumptionFunctionApp.bicep
+++ b/deploy/bicep/templates/flexConsumptionFunctionApp.bicep
@@ -1,0 +1,67 @@
+param appName string
+param appServicePlanId string
+param location string = resourceGroup().location
+param settings array = []
+
+// Identity-based access to AzureWebJobsStorage and the deployment package container.
+param storageAccountName string
+param deploymentStorageBlobUri string
+
+@allowed([
+  512
+  2048
+  4096
+])
+param instanceMemoryMB int = 2048
+param maximumInstanceCount int = 100
+
+// Flex Consumption-specific layout: runtime, scaling, and the deployment package
+// container live under properties.functionAppConfig — NOT siteConfig.
+// Required app settings (no FUNCTIONS_WORKER_RUNTIME / FUNCTIONS_EXTENSION_VERSION
+// / WEBSITE_CONTENTAZUREFILECONNECTIONSTRING / WEBSITE_CONTENTSHARE — those are
+// rejected on Flex).
+var flexAppSettings = concat(settings, [
+  {
+    name: 'AzureWebJobsStorage__accountName'
+    value: storageAccountName
+  }
+])
+
+resource azureFunction 'Microsoft.Web/sites@2024-04-01' = {
+  name: appName
+  location: location
+  kind: 'functionapp,linux'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: appServicePlanId
+    functionAppConfig: {
+      deployment: {
+        storage: {
+          type: 'blobContainer'
+          value: deploymentStorageBlobUri
+          authentication: {
+            type: 'SystemAssignedIdentity'
+          }
+        }
+      }
+      runtime: {
+        name: 'dotnet-isolated'
+        version: '10.0'
+      }
+      scaleAndConcurrency: {
+        maximumInstanceCount: maximumInstanceCount
+        instanceMemoryMB: instanceMemoryMB
+        alwaysReady: []
+      }
+    }
+    siteConfig: {
+      ftpsState: 'FtpsOnly'
+      appSettings: flexAppSettings
+    }
+  }
+}
+
+output webAppUri string = azureFunction.properties.hostNames[0]
+output principalId string = azureFunction.identity.principalId

--- a/deploy/bicep/templates/flexConsumptionPlan.bicep
+++ b/deploy/bicep/templates/flexConsumptionPlan.bicep
@@ -1,0 +1,21 @@
+param name string
+param location string = resourceGroup().location
+
+// Flex Consumption requires:
+// - kind: 'functionapp' (NOT 'elastic' which is used for Elastic Premium)
+// - sku.tier: 'FlexConsumption', sku.name: 'FC1'
+// - properties.reserved: true (Flex is Linux-only)
+resource flexPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
+  name: name
+  location: location
+  kind: 'functionapp'
+  sku: {
+    tier: 'FlexConsumption'
+    name: 'FC1'
+  }
+  properties: {
+    reserved: true
+  }
+}
+
+output id string = flexPlan.id

--- a/deploy/bicep/templates/roleAssignments.bicep
+++ b/deploy/bicep/templates/roleAssignments.bicep
@@ -8,6 +8,13 @@ param principalId string
 ])
 param storageProvider string = 'cosmos'
 
+// When the resolver runs on Flex Consumption, it needs identity-based access to
+// the function-app storage account: the AzureWebJobsStorage host runtime AND the
+// deployment package container (functionAppConfig.deployment.storage with
+// SystemAssignedIdentity) both require Storage Blob Data Contributor.
+param funcStorageAccountName string = ''
+param grantFuncStorageBlobDataContributor bool = false
+
 // ----------------------------------------------------------------------------
 // Service Bus Data Owner — required regardless of storage provider so the
 // resolver identity can receive and complete messages via managed identity.
@@ -48,5 +55,27 @@ resource cosmosRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssi
     roleDefinitionId: '${cosmosAccount.id}/sqlRoleDefinitions/${cosmosDataContributorRoleId}'
     principalId: principalId
     scope: cosmosAccount.id
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Storage Blob Data Contributor on the function storage account — only when the
+// resolver runs on Flex Consumption (which uses SystemAssignedIdentity for both
+// AzureWebJobsStorage and the app-package container).
+// ----------------------------------------------------------------------------
+
+var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+
+resource funcStorageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' existing = if (grantFuncStorageBlobDataContributor) {
+  name: funcStorageAccountName
+}
+
+resource funcStorageBlobRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (grantFuncStorageBlobDataContributor) {
+  name: guid(funcStorageAccount.id, principalId, storageBlobDataContributorRoleId)
+  scope: funcStorageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleId)
+    principalId: principalId
+    principalType: 'ServicePrincipal'
   }
 }

--- a/deploy/bicep/templates/storageaccount.bicep
+++ b/deploy/bicep/templates/storageaccount.bicep
@@ -1,6 +1,12 @@
 param name string
 param location string = resourceGroup().location
 
+// When the resolver is hosted on Flex Consumption, it needs a blob container
+// that holds its zipped app package. We provision it here so the Function App
+// can reference it via SystemAssignedIdentity at create time.
+param createDeploymentContainer bool = false
+param deploymentContainerName string = 'app-package-resolver'
+
 resource storageaccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
   name: name
   location: location
@@ -13,5 +19,17 @@ resource storageaccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
   }
 }
 
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2021-09-01' = if (createDeploymentContainer) {
+  parent: storageaccount
+  name: 'default'
+}
+
+resource deploymentContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-09-01' = if (createDeploymentContainer) {
+  parent: blobService
+  name: deploymentContainerName
+}
+
 output connectionString string = 'DefaultEndpointsProtocol=https;AccountName=${name};AccountKey=${listKeys(storageaccount.id, storageaccount.apiVersion).keys[0].value};EndpointSuffix=core.windows.net'
 output storageId string = storageaccount.id
+output storageName string = storageaccount.name
+output blobEndpoint string = storageaccount.properties.primaryEndpoints.blob

--- a/src/NimBus.CommandLine/CommandSupport.cs
+++ b/src/NimBus.CommandLine/CommandSupport.cs
@@ -111,7 +111,8 @@ internal sealed record InfrastructureOptions(
     SqlProvisioningMode SqlMode = SqlProvisioningMode.Provision,
     string? SqlConnectionString = null,
     string? SqlAdminLogin = null,
-    string? SqlAdminPassword = null);
+    string? SqlAdminPassword = null,
+    ResolverPlanChoice ResolverPlan = ResolverPlanChoice.ElasticPremium);
 
 internal enum StorageProviderChoice
 {
@@ -123,6 +124,12 @@ internal enum SqlProvisioningMode
 {
     Provision,
     External,
+}
+
+internal enum ResolverPlanChoice
+{
+    ElasticPremium,
+    FlexConsumption,
 }
 
 internal sealed record TopologyOptions(

--- a/src/NimBus.CommandLine/InfrastructureDeployer.cs
+++ b/src/NimBus.CommandLine/InfrastructureDeployer.cs
@@ -90,6 +90,7 @@ internal sealed class InfrastructureDeployer
     {
         var storageProviderParam = options.StorageProvider == StorageProviderChoice.SqlServer ? "sqlserver" : "cosmos";
         var sqlModeParam = options.SqlMode == SqlProvisioningMode.External ? "external" : "provision";
+        var resolverPlanParam = options.ResolverPlan == ResolverPlanChoice.FlexConsumption ? "FlexConsumption" : "ElasticPremium";
 
         var arguments = new List<string>
         {
@@ -103,6 +104,7 @@ internal sealed class InfrastructureDeployer
             $"uniqueDeploy={Guid.NewGuid():N}",
             $"storageProvider={storageProviderParam}",
             $"sqlMode={sqlModeParam}",
+            $"resolverPlan={resolverPlanParam}",
         };
 
         if (options.StorageProvider == StorageProviderChoice.SqlServer && options.SqlMode == SqlProvisioningMode.Provision)

--- a/src/NimBus.CommandLine/Program.cs
+++ b/src/NimBus.CommandLine/Program.cs
@@ -80,6 +80,17 @@ internal static class Program
         };
     }
 
+    private static ResolverPlanChoice ParseResolverPlan(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return ResolverPlanChoice.ElasticPremium;
+        return value.Replace("-", "", StringComparison.Ordinal).ToLowerInvariant() switch
+        {
+            "elasticpremium" or "ep1" or "premium" => ResolverPlanChoice.ElasticPremium,
+            "flexconsumption" or "flex" or "fc1" => ResolverPlanChoice.FlexConsumption,
+            _ => throw new InvalidOperationException($"Unknown --resolver-plan value '{value}'. Expected 'ElasticPremium' or 'FlexConsumption'."),
+        };
+    }
+
     private static void ConfigureInfraCommands(CommandLineApplication app)
     {
         app.Command("infra", infraCommand =>
@@ -99,11 +110,12 @@ internal static class Program
                 var location = applyCommand.Option("--location <AZURE-REGION>", "Optional location override passed to the bicep templates.", CommandOptionType.SingleValue);
                 var resourceNamePostfix = applyCommand.Option("--resource-name-postfix <VALUE>", "Reserved for compatibility with the legacy pipeline scripts.", CommandOptionType.SingleValue);
                 var webAppVersion = applyCommand.Option("--webapp-version <VALUE>", "Version string stored in the web app settings.", CommandOptionType.SingleValue);
-                var storageProvider = applyCommand.Option("--storage-provider <cosmos|sqlserver>", "Storage provider for NimBus message persistence. Defaults to 'cosmos' for backwards compatibility.", CommandOptionType.SingleValue);
-                var sqlMode = applyCommand.Option("--sql-mode <provision|external>", "When --storage-provider is sqlserver: 'provision' deploys a new Azure SQL resource; 'external' uses --sql-connection-string.", CommandOptionType.SingleValue);
+                var storageProvider = applyCommand.Option("--storage-provider <PROVIDER>", "Storage provider for NimBus message persistence: cosmos | sqlserver. Defaults to 'cosmos' for backwards compatibility.", CommandOptionType.SingleValue);
+                var sqlMode = applyCommand.Option("--sql-mode <MODE>", "When --storage-provider is sqlserver: 'provision' deploys a new Azure SQL resource; 'external' uses --sql-connection-string.", CommandOptionType.SingleValue);
                 var sqlConnectionString = applyCommand.Option("--sql-connection-string <VALUE>", "Pre-existing SQL Server connection string. Required when --sql-mode is 'external'.", CommandOptionType.SingleValue);
                 var sqlAdminLogin = applyCommand.Option("--sql-admin-login <VALUE>", "SQL admin login when --sql-mode is 'provision'.", CommandOptionType.SingleValue);
                 var sqlAdminPassword = applyCommand.Option("--sql-admin-password <VALUE>", "SQL admin password when --sql-mode is 'provision'.", CommandOptionType.SingleValue);
+                var resolverPlan = applyCommand.Option("--resolver-plan <PLAN>", "Hosting plan for the resolver Function App: ElasticPremium | FlexConsumption. Defaults to 'ElasticPremium' (EP1, Windows). 'FlexConsumption' is the cheaper scale-to-zero Linux option suited for dev/test.", CommandOptionType.SingleValue);
 
                 applyCommand.OnExecuteAsync(async cancellationToken =>
                 {
@@ -113,6 +125,7 @@ internal static class Program
 
                     var providerChoice = ParseStorageProvider(storageProvider.Value());
                     var sqlProvisioningMode = ParseSqlMode(sqlMode.Value());
+                    var resolverPlanChoice = ParseResolverPlan(resolverPlan.Value());
 
                     if (providerChoice == StorageProviderChoice.SqlServer)
                     {
@@ -134,7 +147,8 @@ internal static class Program
                         sqlProvisioningMode,
                         sqlConnectionString.Value(),
                         sqlAdminLogin.Value(),
-                        sqlAdminPassword.Value());
+                        sqlAdminPassword.Value(),
+                        resolverPlanChoice);
 
                     await deployer.ApplyAsync(options, cancellationToken).ConfigureAwait(false);
                     return 0;
@@ -239,6 +253,7 @@ internal static class Program
             var resourceNamePostfix = setupCommand.Option("--resource-name-postfix <VALUE>", "Reserved for compatibility with the legacy pipeline scripts.", CommandOptionType.SingleValue);
             var webAppVersion = setupCommand.Option("--webapp-version <VALUE>", "Version string stored in the web app settings.", CommandOptionType.SingleValue);
             var configuration = setupCommand.Option("--configuration <NAME>", "Build configuration passed to dotnet publish.", CommandOptionType.SingleValue);
+            var setupResolverPlan = setupCommand.Option("--resolver-plan <PLAN>", "Hosting plan for the resolver Function App: ElasticPremium | FlexConsumption. Defaults to 'ElasticPremium'. Use 'FlexConsumption' for cheaper dev/test.", CommandOptionType.SingleValue);
 
             setupCommand.OnExecuteAsync(async cancellationToken =>
             {
@@ -254,7 +269,8 @@ internal static class Program
                     resourceGroup.Value(),
                     resourceNamePostfix.Value(),
                     location.Value(),
-                    webAppVersion.HasValue() ? webAppVersion.Value()! : $"local-{DateTime.UtcNow:yyyyMMddHHmmss}");
+                    webAppVersion.HasValue() ? webAppVersion.Value()! : $"local-{DateTime.UtcNow:yyyyMMddHHmmss}",
+                    ResolverPlan: ParseResolverPlan(setupResolverPlan.Value()));
 
                 var topologyOptions = new TopologyOptions(solutionId.Value(), environment.Value(), resourceGroup.Value());
                 var appOptions = new AppDeploymentOptions(


### PR DESCRIPTION
## Summary

Adds a `--resolver-plan {ElasticPremium|FlexConsumption}` flag to `nb infra apply` so dev/test deployments can run the Resolver on a scale-to-zero Linux FC1 plan instead of the always-warm Windows EP1 plan. Elastic Premium remains the default — production deployments are unchanged.

## Why

The Resolver Function App is the only must-be-running tier in a NimBus deployment, but in dev/test it sits idle most of the time. EP1 keeps a warm instance 24/7 (~$110/month), while FlexConsumption FC1 scales to zero between events.

## Changes

- **`deploy/bicep/templates/flexConsumptionPlan.bicep`** (new) — Linux FC1 plan.
- **`deploy/bicep/templates/flexConsumptionFunctionApp.bicep`** (new) — Function App that reads its package from a Storage blob container via SystemAssignedIdentity (Flex requirement).
- **`deploy/bicep/templates/storageaccount.bicep`** — new `createDeploymentContainer` flag; Flex needs the package container provisioned inline so the Function App can bind to it on first deploy.
- **`deploy/bicep/templates/roleAssignments.bicep`** — grants the Flex Function App's managed identity Storage Blob Data Owner on the package container.
- **`deploy/bicep/deploy.core.bicep`** — splits resolver app settings into `sharedResolverSettings` and an `elasticPremiumExtraSettings` block (the `WEBSITE_CONTENT*` settings Flex rejects); branches the plan + Function App modules on `resolverPlan`.
- **`src/NimBus.CommandLine/{CommandSupport,InfrastructureDeployer,Program}.cs`** — plumbs `--resolver-plan` through the CLI.

## Base branch

This PR is **stacked on `feat/pluggable-message-storage`** (#12). The bicep changes reference `storageProvider` / `sqlMode` parameters introduced there, so they cannot apply on `master` until #12 merges first.

When #12 merges I'll re-target this PR's base to `master`. Reviewing the diff against `feat/pluggable-message-storage` shows only the FlexConsumption-relevant changes.

## Test plan

- [x] `nb infra apply --resolver-plan ElasticPremium ...` (default behavior unchanged) — bicep compiles, parameters route correctly
- [x] `nb infra apply --resolver-plan FlexConsumption ...` — bicep compiles, parameter validation rejects unknown values
- [ ] Deploy `--resolver-plan FlexConsumption` against a throwaway Azure RG and verify the resolver receives + processes a Service Bus message after scaling from zero
- [ ] Deploy `--resolver-plan ElasticPremium` against a throwaway Azure RG to confirm no regression
- [ ] Cost compare 24 hours of idle in both plans

## Out of scope

- WebApp hosting plan (still standard App Service — separate concern)
- Auto-detection of which plan to use; explicit flag only
- FlexConsumption regional availability checks (FC1 is not GA in every region; if the user picks a region where FC1 isn't available, the Bicep deployment will fail with an Azure-side error)
