### PR TITLE
feat: async message completion via PendingHandoff

### DIFF
--- a/docs/adr/012-pending-handoff.md
+++ b/docs/adr/012-pending-handoff.md
@@ -1,0 +1,97 @@
+# ADR-012: PendingHandoff Outcome for Async Message Completion
+
+## Status
+Accepted (introduced 2026-05; implements [spec 002](../specs/002-async-message-completion/spec.md), issue #15)
+
+## Context
+
+NimBus today resolves a message at the moment the handler returns. That assumption breaks for adapters whose unit of work is an external long-running job — the canonical case is the D365 F&O DMF integration, where the import is asynchronous and the per-entity outcome only arrives later via a status checker.
+
+Three forces collided:
+
+1. **Service Bus peek-locks cannot be held for the duration.** F&O DMF jobs frequently exceed the 5-minute lock cap, so the inbound message has to be settled promptly. We cannot just hold the receiver and wait.
+2. **Sibling messages on the same session must defer until the external work reports back**, otherwise per-session FIFO ordering breaks across the duration of the external job.
+3. **Settling the audit row as Completed lies** (the work has not happened); settling as Failed lies the other way and pollutes dashboards / alerting.
+
+The only existing way to keep a session blocked was to throw an exception from the handler — i.e., abuse the failure path for happy-path control flow. That is the status quo we wanted to leave behind. Pipeline middleware, telemetry filters, lifecycle observers, and ordinary code review all treat exceptions as faults; using them to signal a healthy in-flight handoff is wrong on every axis.
+
+## Decision
+
+Introduce a new handler outcome — **PendingHandoff** — signalled explicitly by a method on the handler context, mapped to the existing `ResolutionStatus.Pending` with a sub-status discriminator:
+
+- `IEventHandlerContext.MarkPendingHandoff(reason, externalJobId, expectedBy)` records the outcome on a back-reference to `IMessageContext`. The handler returns normally afterwards.
+- After the handler returns, `StrictMessageHandler.HandleEventRequest` inspects `messageContext.HandlerOutcome`. If it is `PendingHandoff`, it sends a new `PendingHandoffResponse` to the Resolver, calls `BlockSession`, and completes the inbound. It does NOT send `ResolutionResponse` and does NOT consult retry policy.
+- Two new control messages — `HandoffCompletedRequest` and `HandoffFailedRequest` — drive terminal settlement from the Manager. The subscriber's `HandleHandoffCompletedRequest` / `HandleHandoffFailedRequest` overrides settle the audit row directly and DO NOT re-invoke the user handler.
+- Two new `IManagerClient` methods (`CompleteHandoff`, `FailHandoff`) construct those control messages. They validate `pendingEntry.PendingSubStatus == "Handoff"` upfront before sending, so misuse fails fast with `InvalidOperationException`.
+- `MessageEntity` and `UnresolvedEvent` gain four nullable fields — `PendingSubStatus`, `HandoffReason`, `ExternalJobId`, `ExpectedBy` — persisted by every storage provider satisfying the conformance suite.
+- The WebApp Pending column counts Pending+Handoff entries; a small "Awaiting external" badge and a "Handoff details" section render on the message detail page when `PendingSubStatus = "Handoff"`. Operator Resubmit / Skip remain available unchanged.
+
+`HandlerOutcome` (enum) and `HandoffMetadata` (record) live in `NimBus.Core.Messages`, NOT in `NimBus.SDK.EventHandlers`. This is non-obvious: the SDK references Core (not the other way around), so the back-reference from `EventHandlerContext` to `IMessageContext` requires the type to be defined where Core can see it. Putting it in the SDK would force a circular reference or a duplicated definition.
+
+## Rejected Alternatives
+
+### 1. Throw-based signalling (e.g. a new `PendingHandoffException`)
+
+Modelled on the existing `SessionBlockedException` pattern: the handler throws, the catch branch sends the response and blocks the session.
+
+Rejected because:
+- It is control-flow-by-exception on a healthy code path. Every pipeline middleware, every lifecycle observer, every telemetry filter has to special-case the new exception to avoid mis-classifying it as a fault.
+- It pollutes stack traces and `OnFailed` observer counts even when nothing is wrong.
+- Code review and IDE tooling treat exceptions as exceptional. Adapter authors writing happy-path async code should not be obliged to throw.
+- NFR-002 explicitly forbids adding new exception types for the happy path.
+
+### 2. Repurposing `Resubmit` for the success case
+
+Use the existing `IManagerClient.Resubmit` to drive Pending → Completed: the status checker, on success, would call `Resubmit` with the result payload, the subscriber would re-invoke the handler, the handler would now succeed, and the existing `ResolutionResponse` flow would close the audit.
+
+Rejected because:
+- `Resubmit` re-invokes the user handler. For a settlement that is already known to be successful, the handler runs a second time — wasted work, doubled middleware metrics, and the audit row is misattributed to a "resubmission" rather than a settlement.
+- Telemetry conflates two semantically different events: "operator hit Resubmit" and "external system reported success".
+- The handler would have to be written to detect the resubmit-after-handoff case to avoid double-effecting downstream side effects. That is exactly the kind of logic NimBus should absorb, not push to adapter authors.
+- `IManagerClient.Skip` has the same shape problem on the failure side: skipping ≠ "external system reported failure".
+
+The clean separation of concerns is: `Resubmit` / `Skip` are operator-initiated recovery primitives; `CompleteHandoff` / `FailHandoff` are status-checker-initiated settlement primitives. They map to different audit-row semantics and should not share code paths.
+
+### 3. Adding a new `ResolutionStatus` value (e.g. `PendingHandoff`)
+
+Treat the new state as a first-class status value alongside `Pending`, `Completed`, `Failed`, `Skipped`, `DeadLettered`, `Unsupported`.
+
+Rejected because:
+- Every dashboard tile, every aggregation query, every `Mapper.cs` count would need to be updated to know about the new status. The "Pending count" goal is "show in-flight work" — Pending+Handoff IS in-flight work. There is no operator-facing reason to split them at the column level.
+- Storage migration impact across providers: every provider has to evolve its enum / status column.
+- Forwarding subscriptions and Resolver classification logic would need a new branch.
+- The sub-status discriminator approach (`PendingSubStatus = "Handoff"`) keeps the existing status machine intact and additive: legacy rows have `PendingSubStatus = null` and render exactly as before. New rows render with the badge.
+
+The chosen design — `Pending` + a nullable sub-status — keeps the dashboard contract stable, the migration path empty (new columns are nullable), and the WebApp logic local to one badge component.
+
+## Consequences
+
+### Positive
+
+- Handler code stays linear and reads as a happy path. No exception abuse.
+- Settlement happens with a single control message; no extra round-trip through `ResubmissionRequest` to obtain a `ResolutionResponse` (NFR-003).
+- The user handler is never re-invoked on settlement (SC-003); middleware metrics and audit attribution stay honest.
+- Existing dashboards work unchanged. Pending+Handoff counts under Pending; the badge tells operators what's in flight.
+- Pure additive change. Existing handlers, audit rows, transports, and operator Resubmit / Skip flows all keep working — adapters that don't call `MarkPendingHandoff` see zero behaviour change (FR-060, FR-063).
+- Subscribers stay pure Service Bus consumers (NFR-005, ADR-002 respected). Adapter-owned correlation stores live in the adapter, not in NimBus.
+
+### Negative
+
+- One additional code path through `StrictMessageHandler.HandleEventRequest`. The post-handler `if (HandlerOutcome == PendingHandoff)` branch is a new joint that future maintainers need to reason about — particularly that the failure-path catch branches still take precedence (FR-012, edge case "calls MarkPendingHandoff and then throws").
+- `HandoffFailedRequest`'s `errorText` is preserved verbatim, but `errorType` is wrapped in a synthetic `HandoffFailedException` so the existing `SendErrorResponse` path can fire. The audit row's `ErrorType` therefore reflects the wrapper, not the operator-supplied `errorType`. This is an explicit v1 trade-off — `errorText` is the field operators read; the `ErrorType` shape carries the round-trip wrapper. Not a bug, not worth fixing without scope discussion.
+- The new fields are nullable on every storage provider. Every conformance test had to grow a round-trip case. This is a one-time cost; future provider implementations get the test for free.
+- `NimBus.Core.Messages` now owns a type — `HandoffMetadata` — that conceptually originates from the SDK handler API. The dependency direction (Core ← SDK) makes this the only sensible home, but the layering is non-obvious and worth a one-line comment in code reviews.
+
+### Operational
+
+- The WebApp surfaces `HandoffReason`, `ExternalJobId`, and `ExpectedBy` on the message detail page. Operators can resubmit / skip Pending+Handoff entries with the same buttons as today (FR-042, SC-006).
+- An optional Resolver-side timeout sweeper (FR-050) is in scope but not built in v1. Adapters with bounded reasonable wait times can opt in later via `ExpectedBy`. The default is "no sweeper running" — adapters with unbounded reasonable wait times stay unaffected.
+
+## See Also
+
+- Spec: [`docs/specs/002-async-message-completion/spec.md`](../specs/002-async-message-completion/spec.md)
+- ADR-002: Centralized Resolver — establishes the audit-trail contract that PendingHandoff plugs into.
+- ADR-001: Session-based ordering — establishes the FIFO contract that sibling-deferral preserves.
+- `docs/error-handling.md` — exception-classification reference; PendingHandoff is explicitly NOT an exception path.
+- `docs/message-flows.md` — flow diagrams; the PendingHandoff settlement flow is added there.
+- `docs/sdk-api-reference.md` — `IEventHandlerContext.MarkPendingHandoff` API documentation with worked example.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,3 +17,4 @@ This directory contains Architecture Decision Records (ADRs) for the NimBus plat
 | [009](009-orchestration-via-application-services.md) | Orchestration via application services, not a saga framework | Accepted | 2026-04 |
 | [010](010-pluggable-message-storage.md) | Pluggable message storage providers (SQL Server + Cosmos DB) | Accepted | 2026-05 |
 | [011](011-rabbitmq-as-second-transport.md) | RabbitMQ as a second, production-grade transport | Accepted | 2026-05 |
+| [012](012-pending-handoff.md) | PendingHandoff outcome for async message completion | Accepted | 2026-05 |

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -62,6 +62,19 @@ flowchart TD
 endpoint dashboard (`Mapper.cs` aggregates `state.FailedCount + state.DeadletterCount`).
 `Pending` and `Unsupported` both fall under **Pending** in the same view.
 
+> **Note on PendingHandoff.** `IEventHandlerContext.MarkPendingHandoff(...)` is
+> **not** an exception path. The handler returns normally and
+> `StrictMessageHandler` reads `messageContext.HandlerOutcome` after the
+> handler returns to decide whether to send a `PendingHandoffResponse` and
+> block the session. The outcome maps to `ResolutionStatus = Pending` with
+> `PendingSubStatus = "Handoff"` — it shows up in the Pending column, not
+> Failed. Settlement is driven by two new control messages
+> (`HandoffCompletedRequest` / `HandoffFailedRequest`) issued by
+> `IManagerClient.CompleteHandoff` / `FailHandoff`, which DO NOT re-invoke
+> the user handler. See [ADR-012](adr/012-pending-handoff.md) and the
+> [PendingHandoff flow](message-flows.md#13-pendinghandoff-async-completion)
+> in the message-flows reference.
+
 ## Flows
 
 ### Transient failure (abandon + redeliver)

--- a/docs/message-flows.md
+++ b/docs/message-flows.md
@@ -317,6 +317,58 @@ sequenceDiagram
 
 If the notification send fails, the dead-letter still happens — the DLQ remains the source of truth and operators can recover via the Manager.
 
+### 13. PendingHandoff (Async Completion)
+
+The handler hands work off to a long-running external system (e.g. D365 F&O DMF) and signals it via `ctx.MarkPendingHandoff(reason, externalJobId, expectedBy)`. The subscriber sends a `PendingHandoffResponse` to the Resolver, blocks the session so siblings defer in FIFO order, and completes the inbound. Settlement happens later via a `HandoffCompletedRequest` (success) or `HandoffFailedRequest` (failure) issued by the Manager — neither re-invokes the user handler. See [ADR-012](adr/012-pending-handoff.md).
+
+```mermaid
+sequenceDiagram
+    participant Pub as Publisher
+    participant Ep as Endpoint Topic
+    participant Sub as SubscriberClient
+    participant Ext as External System
+    participant Mgr as ManagerClient
+    participant Res as Resolver Topic
+    participant Svc as ResolverService
+    participant DefProc as DeferredProcessor
+
+    Note over Pub,Svc: 1 — handler hands off
+    Pub->>Ep: EventRequest (event-1, session-X)
+    Ep->>Sub: main sub
+    Sub->>Sub: handler.Handle calls ctx.MarkPendingHandoff
+    Sub->>Ext: trigger external job (out of band)
+    Sub->>Ep: PendingHandoffResponse (To=Resolver, HandoffReason, ExternalJobId, ExpectedBy)
+    Sub->>Sub: BlockSession by event-1
+    Sub->>Ep: Complete inbound
+    Ep->>Res: forwarded
+    Res->>Svc: status = Pending, PendingSubStatus = "Handoff"
+
+    Note over Pub,DefProc: 2 — siblings on the same session defer (FIFO)
+    Pub->>Ep: EventRequest (event-2, session-X)
+    Ep->>Sub: main sub
+    Sub->>Sub: VerifySessionIsNotBlocked throws SessionBlockedException
+    Sub->>Ep: DeferralResponse + park on Deferred subscription
+    Ep->>Res: forwarded — status = Deferred
+
+    Note over Pub,DefProc: 3 — external system reports back, Manager settles
+    Ext-->>Mgr: status checker observes success
+    Mgr->>Ep: HandoffCompletedRequest (From=Manager, EventId=event-1)
+    Ep->>Sub: main sub (no user handler invocation)
+    Sub->>Sub: AuthorizeManagerRequest, VerifySessionIsBlockedByThis
+    Sub->>Sub: UnblockSession, ContinueWithAnyDeferredMessages
+    Sub->>Ep: ResolutionResponse (To=Resolver, EventId=event-1)
+    Sub->>Ep: ProcessDeferredRequest (To=DeferredProcessor)
+    Sub->>Ep: Complete HandoffCompletedRequest
+    Ep->>Res: forwarded — status flips Pending to Completed
+    Ep->>DefProc: DeferredProcessor sub picks up ProcessDeferredRequest
+    DefProc->>Ep: republish parked siblings as fresh EventRequests
+    Ep->>Sub: main sub — siblings handled in FIFO
+```
+
+The failure path is symmetrical: `ManagerClient.FailHandoff(entity, endpoint, errorText, errorType)` issues a `HandoffFailedRequest`, the subscriber's `HandleHandoffFailedRequest` synthesises an `EventContextHandlerException` that wraps a `HandoffFailedException(errorText, errorType)`, sends an `ErrorResponse` to the Resolver (status flips Pending to Failed with `errorText` preserved verbatim), and leaves the session blocked. The operator chooses Resubmit or Skip from the WebApp — both follow today's existing flows.
+
+`MarkPendingHandoff` is idempotent — calling it twice from the same handler invocation overwrites the metadata (last call wins). If the handler calls it AND then throws, the failure path takes precedence: an `ErrorResponse` is sent and the PendingHandoff metadata is discarded.
+
 ---
 
 ## Retry Policies

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -246,6 +246,10 @@ Application-level last-chance handler before dead-lettering. After retries are e
 
 Reference: Rebus `IFailed<T>`, MassTransit `Fault<T>`.
 
+**4.4a Async Message Completion via PendingHandoff** -- Implemented (issue #15, [ADR-012](adr/012-pending-handoff.md))
+
+Handlers that hand work off to a long-running external system (e.g. D365 F&O DMF) signal it via `IEventHandlerContext.MarkPendingHandoff(reason, externalJobId, expectedBy)` and return normally. The audit row records `ResolutionStatus = Pending` with `PendingSubStatus = "Handoff"`; siblings on the same session defer in FIFO order. Settlement is driven by two new `IManagerClient` methods (`CompleteHandoff` / `FailHandoff`) without re-invoking the user handler. WebApp surfaces an "Awaiting external" badge and handoff-detail fields on Pending+Handoff entries.
+
 **4.5 SDK Developer Experience**
 
 - Source generators: replace reflection-based event type discovery with compile-time source generators

--- a/docs/sdk-api-reference.md
+++ b/docs/sdk-api-reference.md
@@ -180,6 +180,9 @@ it AND then throws, the failure path takes precedence — an `ErrorResponse`
 is sent and the PendingHandoff metadata is discarded. PendingHandoff is NOT
 an exception path; see [`error-handling.md`](error-handling.md).
 
+**See also**: a runnable end-to-end showcase wiring this onto the ERP adapter
+in the CRM/ERP demo — [`samples/CrmErpDemo/README.md#showcase-pendinghandoff-async-erp-imports`](../samples/CrmErpDemo/README.md#showcase-pendinghandoff-async-erp-imports).
+
 ### ISubscriberClient
 
 ```csharp

--- a/docs/sdk-api-reference.md
+++ b/docs/sdk-api-reference.md
@@ -115,8 +115,70 @@ public interface IEventHandlerContext
     string CorrelationId { get; }
     string EventType { get; }
     string MessageId { get; }
+
+    // Read-only state set by MarkPendingHandoff (default: HandlerOutcome.Default).
+    HandlerOutcome Outcome { get; }
+    HandoffMetadata HandoffMetadata { get; }
+
+    // Signal that the handler has handed work off to a long-running external system.
+    // Idempotent — last call wins. See "Async completion via PendingHandoff" below.
+    void MarkPendingHandoff(string reason, string externalJobId = null, TimeSpan? expectedBy = null);
 }
 ```
+
+#### Async completion via PendingHandoff
+
+When a handler triggers an external long-running job (e.g. a D365 F&O DMF
+import) and the per-entity outcome only arrives later, calling
+`ctx.MarkPendingHandoff(...)` and returning normally tells NimBus to:
+
+1. Send a `PendingHandoffResponse` to the Resolver — the audit row is
+   recorded as `ResolutionStatus = Pending` with `PendingSubStatus = "Handoff"`.
+2. Block the session so sibling messages on the same session defer (FIFO)
+   until the external job settles.
+3. Complete the inbound Service Bus message — no peek-lock held for the
+   duration of the external work.
+
+The user handler is **not** re-invoked when the external system reports
+back. Settlement is driven by `IManagerClient.CompleteHandoff` (success) or
+`IManagerClient.FailHandoff` (failure). See [ADR-012](adr/012-pending-handoff.md)
+and the [PendingHandoff message flow](message-flows.md#13-pendinghandoff-async-completion).
+
+```csharp
+public class CreateOrderHandler : IEventHandler<OrderPlaced>
+{
+    private readonly IDmfClient _dmf;
+    private readonly ICorrelationStore _correlations;
+
+    public CreateOrderHandler(IDmfClient dmf, ICorrelationStore correlations)
+    {
+        _dmf = dmf;
+        _correlations = correlations;
+    }
+
+    public async Task Handle(OrderPlaced order, IEventHandlerContext ctx, CancellationToken ct)
+    {
+        // Trigger the long-running external import.
+        var jobId = await _dmf.QueueImportAsync(order, ct);
+
+        // Record (eventId, jobId) so the adapter's status checker can
+        // call ManagerClient.CompleteHandoff / FailHandoff later.
+        await _correlations.SaveAsync(ctx.EventId, jobId, ct);
+
+        // Tell NimBus this is a healthy in-flight handoff. The handler
+        // returns normally — no exception, no failure-path side effects.
+        ctx.MarkPendingHandoff(
+            reason: "DMF import in flight",
+            externalJobId: jobId,
+            expectedBy: TimeSpan.FromMinutes(15));
+    }
+}
+```
+
+`MarkPendingHandoff` is idempotent (last call wins). If the handler calls
+it AND then throws, the failure path takes precedence — an `ErrorResponse`
+is sent and the PendingHandoff metadata is discarded. PendingHandoff is NOT
+an exception path; see [`error-handling.md`](error-handling.md).
 
 ### ISubscriberClient
 

--- a/docs/specs/002-async-message-completion/github-issue.md
+++ b/docs/specs/002-async-message-completion/github-issue.md
@@ -1,0 +1,219 @@
+# Async message completion via PendingHandoff (reuse session blocking, audit as Pending, no exceptions for control flow)
+
+> Spec: [`docs/specs/002-async-message-completion/spec.md`](../docs/specs/002-async-message-completion/spec.md)
+> Companion one-pager (PDF + diagram): [`docs/specs/async-message-completion-onepager.pdf`](../async-message-completion-onepager.pdf)
+
+## Summary
+
+A NimBus subscriber adapter integrated with Microsoft Dynamics 365 F&O via the DMF API cannot complete its work synchronously: it triggers an async import job and the per-entity outcome arrives later. We need to settle the Service Bus lock immediately, keep the session blocked so siblings on that session don't overtake the in-flight import, and have the audit trail report **Pending** — not Failed — until the external work reports back.
+
+This issue tracks the work to:
+
+1. Add a new handler outcome **PendingHandoff**, signalled by an **explicit method** on `IEventHandlerContext` (not by throwing).
+2. Map the audit row to the existing `ResolutionStatus.Pending` with a sub-status discriminator.
+3. Reuse the existing session-blocking + Deferred-subscription machinery (no changes to the FIFO replay path).
+4. Add two **terminal Manager commands** — `CompleteHandoff` / `FailHandoff` — that drive Pending → Completed / Failed **without re-invoking the user handler**. (Avoids the misuse pattern of repurposing `Resubmit` for the success case, which doubles middleware metrics, mislabels audit attribution, and forces every adapter to write defensive idempotency checks.)
+5. Optional Resolver-side timeout sweeper for `ExpectedBy` deadlines.
+
+The feature is purely additive. Adapters that don't call `MarkPendingHandoff` see zero behaviour change.
+
+## Handler API (FR-001..FR-005)
+
+```csharp
+// IEventHandlerContext (NimBus.SDK.EventHandlers) — new method
+void MarkPendingHandoff(
+    string reason,
+    string externalJobId = null,
+    TimeSpan? expectedBy = null);
+
+// Reading the outcome state from middleware after the handler returns
+HandlerOutcome   Outcome           { get; }
+HandoffMetadata? HandoffMetadata   { get; }
+```
+
+A handler reads:
+
+```csharp
+public async Task Handle(ProjectCreated evt, IEventHandlerContext ctx, CancellationToken ct)
+{
+    var jobId = await EnqueueForImport(evt, ct);
+    ctx.MarkPendingHandoff(
+        reason: "Awaiting DMF import job",
+        externalJobId: jobId,
+        expectedBy: TimeSpan.FromHours(2));
+    // Handler returns normally — no throw.
+}
+```
+
+Why a method, not an exception:
+
+- **No control-flow-by-exception** for a happy-path outcome.
+- **Composes with pipeline middleware** — middleware sees a clean return; doesn't have to special-case "is this exception type a fault or a signal?"
+- **Idempotent and inspectable** — `ctx.Outcome` is queryable from middleware; second call wins.
+
+## Message types (FR-010)
+
+Three values added to `MessageType`:
+
+| Type | Direction | Purpose |
+|---|---|---|
+| `PendingHandoffResponse` | subscriber → Resolver | Audit row recorded as Pending with sub-status Handoff. |
+| `HandoffCompletedRequest` | Manager → subscriber | Settle a PendingHandoff message as Completed without invoking the user handler. |
+| `HandoffFailedRequest` | Manager → subscriber | Settle as Failed with verbatim error text from the external system. |
+
+The forwarding subscription that already routes responses to the Resolver picks up `PendingHandoffResponse` with no topology change.
+
+## Core flow (FR-011..FR-015)
+
+`StrictMessageHandler.HandleEventRequest`, after `HandleEventContent` returns successfully, gets a single new branch:
+
+```csharp
+if (ctx.Outcome == HandlerOutcome.PendingHandoff)
+{
+    await SendPendingHandoffResponse(messageContext, ctx, cancellationToken);
+    await BlockSession(messageContext, cancellationToken);
+    await CompleteMessage(messageContext, cancellationToken);
+    return;   // do NOT send ResolutionResponse; do NOT invoke retry policy
+}
+await SendResolutionResponse(messageContext, cancellationToken);
+await CompleteMessage(messageContext, cancellationToken);
+```
+
+Two new control-message handlers, symmetric with `HandleSkipRequest` (neither invokes the user handler):
+
+```csharp
+public override async Task HandleHandoffCompletedRequest(IMessageContext ctx, CancellationToken ct = default)
+{
+    AuthorizeManagerRequest(ctx);
+    await VerifySessionIsBlockedByThis(ctx, ct);
+    await UnblockSession(ctx, ct);
+    await ContinueWithAnyDeferredMessages(ctx, ct);
+    await SendResolutionResponse(ctx, ct);
+    await CompleteMessage(ctx, ct);
+}
+
+public override async Task HandleHandoffFailedRequest(IMessageContext ctx, CancellationToken ct = default)
+{
+    AuthorizeManagerRequest(ctx);
+    await VerifySessionIsBlockedByThis(ctx, ct);
+    await SendErrorResponseFromContext(ctx, ct);   // carries errorText/errorType
+    await CompleteMessage(ctx, ct);   // session stays blocked; operator decides Resubmit/Skip
+}
+```
+
+Existing catch branches (`SessionBlockedException`, `EventContextHandlerException`) are unchanged. Existing retry policy is unchanged. If the handler both calls `MarkPendingHandoff` and throws, the failure path wins.
+
+## Manager API (FR-020..FR-023)
+
+```csharp
+public interface IManagerClient
+{
+    // Existing — unchanged. Operator-initiated re-execution of the handler.
+    Task Resubmit(MessageEntity errorResponse, string endpoint, string eventTypeId, string eventJson);
+    Task Skip(MessageEntity errorResponse, string endpoint, string eventTypeId);
+
+    // New — terminal settlement of a PendingHandoff message based on external outcome.
+    Task CompleteHandoff(MessageEntity pendingEntry, string endpoint, string detailsJson = null);
+    Task FailHandoff(MessageEntity pendingEntry, string endpoint, string errorText, string errorType = null);
+}
+```
+
+`Resubmit` and `Skip` keep their meaning. The new commands are dedicated to automated settlement by an external status checker; they are not the operator path.
+
+## Resolver & MessageStore (FR-030..FR-034)
+
+- `MessageTypeToStatusMap[PendingHandoffResponse] = ResolutionStatus.Pending`. Audit projection via the existing `UploadPendingMessage`.
+- `MessageEntity` and `UnresolvedEvent` gain four nullable fields:
+  - `string PendingSubStatus` — `null` for ordinary Pending; `"Handoff"` for the new outcome.
+  - `string HandoffReason` — free-text reason supplied by the handler.
+  - `string ExternalJobId` — optional external system identifier.
+  - `DateTime? ExpectedBy` — optional deadline used by the optional sweeper.
+- Persisted by every storage provider (Cosmos DB, SQL Server, in-memory) per the conformance suite. Existing rows project these as `null`.
+- `HandoffCompletedRequest` → resulting `ResolutionResponse` flips Pending → Completed.
+- `HandoffFailedRequest` → resulting `ErrorResponse` flips Pending → Failed with `errorText`/`errorType`.
+
+## WebApp (FR-040..FR-043)
+
+- Pending+Handoff entries count under the existing **Pending** column; Failed count is unaffected.
+- Message row shows a small "Awaiting external" badge when `PendingSubStatus = "Handoff"`.
+- Message detail page renders `HandoffReason`, `ExternalJobId`, `ExpectedBy` when present.
+- Existing **Resubmit / Skip** buttons remain available on Pending+Handoff entries.
+- No API contract change required (new fields are optional additions to existing response shapes).
+
+## Optional timeout sweeper (FR-050..FR-053)
+
+- Opt-in. Default off.
+- Resolver-side background pass scans Pending+Handoff entries with `ExpectedBy` in the past, emits a synthetic `HandoffFailedRequest` with `errorType = "TimeoutExpired"`.
+- Resulting Failed entry follows the standard operator Resubmit / Skip flow.
+- Pending entries with `PendingSubStatus = null` or `ExpectedBy = null` are never touched.
+
+## Backwards compatibility (FR-060..FR-063)
+
+- Pure additions: 3 new MessageType values, 1 new method on `IEventHandlerContext`, 2 new methods on `IManagerClient`, 4 new nullable fields on `MessageEntity`/`UnresolvedEvent`.
+- No transport-topology change, no schema migration for existing rows, no breaking changes to public publishing/subscribing APIs.
+- Adapters that don't call `MarkPendingHandoff` see zero behaviour change.
+
+## Acceptance criteria
+
+- [ ] **SC-001** — Handler that calls `ctx.MarkPendingHandoff(...)` and returns produces an audit row with `ResolutionStatus = Pending`, `PendingSubStatus = "Handoff"`, and the supplied metadata, without throwing any exception.
+- [ ] **SC-002** — While a session is in PendingHandoff state, subsequent messages on the same session are parked on the Deferred subscription in FIFO order.
+- [ ] **SC-003** — `ManagerClient.CompleteHandoff(...)` settles the message as Completed and unblocks the session **without invoking the user handler** (verified by asserting `IEventHandler<TEvent>.Handle` is not called during settlement).
+- [ ] **SC-004** — `ManagerClient.FailHandoff(...)` settles as Failed with `errorText` preserved verbatim on the audit row; session remains blocked.
+- [ ] **SC-005** — WebApp Pending count includes Pending+Handoff entries; Failed count does not. Message detail renders the new fields when present and is unchanged on legacy rows.
+- [ ] **SC-006** — Existing operator Resubmit / Skip flows work unchanged on Pending+Handoff entries.
+- [ ] **SC-007** — Shared provider conformance suite passes with the four new fields round-tripping across Cosmos DB, SQL Server, and in-memory providers.
+- [ ] **SC-008** — E2E test "PendingHandoff → siblings defer → CompleteHandoff → siblings replay in FIFO" passes.
+- [ ] **SC-009** — E2E test "PendingHandoff → FailHandoff → audit row carries error text → operator Skip" passes.
+- [ ] **SC-010** — No existing test starts failing as a result of the changes.
+
+## Files touched (high level)
+
+| Where | Change |
+|---|---|
+| `NimBus.SDK.EventHandlers.IEventHandlerContext` | Add `MarkPendingHandoff(reason, externalJobId?, expectedBy?)` + `Outcome` / `HandoffMetadata` accessors. `EventHandlerContext` implements them. |
+| `NimBus.SDK.EventHandlers.EventJsonHandler` | Construct `EventHandlerContext` so `StrictMessageHandler` can read post-handler outcome. |
+| `NimBus.Core.Messages.MessageType` | +3 enum values: `PendingHandoffResponse`, `HandoffCompletedRequest`, `HandoffFailedRequest`. |
+| `NimBus.Core.Messages.IResponseService` + `ResponseService` | Add `SendPendingHandoffResponse` (mirrors `SendDeferralResponse`). |
+| `NimBus.Core.Messages.StrictMessageHandler` | One outcome branch in `HandleEventRequest` post-handler success path; two new control-message handlers (`HandleHandoffCompletedRequest`, `HandleHandoffFailedRequest`). Existing catch branches unchanged. |
+| `NimBus.Manager.IManagerClient` + `ManagerClient` | Add `CompleteHandoff(entity, endpoint, detailsJson?)` and `FailHandoff(entity, endpoint, errorText, errorType?)`. |
+| `NimBus.MessageStore.Abstractions` (or `NimBus.Abstractions`, per #001) | `MessageEntity` / `UnresolvedEvent`: +4 nullable fields (`PendingSubStatus`, `HandoffReason`, `ExternalJobId`, `ExpectedBy`). |
+| `NimBus.MessageStore.CosmosDb`, `NimBus.MessageStore.SqlServer`, in-memory | Persist + project the new fields. Conformance suite gains round-trip tests. |
+| `NimBus.Resolver.Services.ResolverService` | Map `PendingHandoffResponse` → `ResolutionStatus.Pending`. Copy new fields onto the entity. |
+| `NimBus.WebApp` | Render Pending+Handoff badge and the new fields on the message detail page. No API contract change. |
+| `NimBus.Resolver` (sweeper, opt-in) | Background pass that flips Pending+Handoff past `ExpectedBy` to Failed via `HandoffFailedRequest`. |
+| `tests/NimBus.Core.Tests` | Handler-success path with `MarkPendingHandoff`; failure-wins-over-handoff path; middleware observing `ctx.Outcome`; the two new `Handle*Request` methods. |
+| `tests/NimBus.EndToEnd.Tests` | E2E happy path; E2E failure path; FIFO replay verification. |
+| `docs/adr/012-pending-handoff.md` | New ADR — rationale, rejected alternatives. |
+| `docs/error-handling.md`, `docs/message-flows.md`, `docs/sdk-api-reference.md` | Documentation updates. |
+
+## Edge cases
+
+- Handler calls `MarkPendingHandoff` and then throws — exception path wins.
+- Handler calls `MarkPendingHandoff` twice — last call wins, idempotent.
+- `CompleteHandoff` / `FailHandoff` against a non-PendingHandoff state — clear error or no-op (decided in design); state machine MUST NOT be corrupted.
+- `CompleteHandoff` / `FailHandoff` against an event that did not block this session — must reject (analogous to today's `VerifySessionIsBlockedByThis`).
+- Two messages on the same session both want PendingHandoff — second one's session-blocked check fires first, parks on Deferred (existing flow).
+- Resolver receives `PendingHandoffResponse` for an unseen event id — must record Pending with the new fields populated.
+- WebApp message detail on a legacy Pending entry (no sub-status) — renders unchanged.
+
+## Out of scope
+
+- Adapter-side correlation store, status checker, or DMF-specific code (lives in the adapter, per ADR-002).
+- Operator-initiated `CompleteHandoff` / `FailHandoff` buttons in the WebApp (Resubmit / Skip remain the operator-facing primitives in v1).
+- A general external-completion API that bypasses the Manager.
+- Cross-session ordering. Sessions remain independent.
+- Persistence-format migrations for existing rows.
+- Renaming or restructuring `IEventHandler` / `IEventHandlerContext`.
+
+## Open questions
+
+- **Naming.** `MarkPendingHandoff` vs `SignalPendingHandoff` vs `DeferToExternal`.
+- **Outcome state shape on the context.** Single `HandlerOutcome` enum + optional `HandoffMetadata`, or a more general `HandlerResult` discriminated union.
+- **Behaviour when `CompleteHandoff` / `FailHandoff` is called against a non-PendingHandoff state.** Hard error vs no-op vs idempotent.
+- **Sweeper hosting.** Resolver-side background pass vs separate worker vs adapter-side. Recommendation: Resolver-side, opt-in via configuration.
+- **WebApp UX.** Whether to add a dedicated "Awaiting external" filter on the endpoint dashboard, beyond the per-row badge.
+- **Authorization for the new control messages.** Reuse `AuthorizeManagerRequest` (recommended) vs add a dedicated capability for the status checker.
+
+## Suggested labels
+
+`enhancement` · `core` · `sdk` · `manager` · `resolver` · `webapp` · `storage` · `non-breaking`

--- a/docs/specs/002-async-message-completion/spec.md
+++ b/docs/specs/002-async-message-completion/spec.md
@@ -1,0 +1,302 @@
+# Feature Specification: Async Message Completion via PendingHandoff
+
+Feature Branch: `002-async-message-completion`
+Created: 2026-05-04
+Updated: 2026-05-04
+Status: Draft for review
+Input: User description: "A NimBus subscriber adapter integrates with Microsoft Dynamics 365 F&O via the DMF API. Inserts are asynchronous: the adapter triggers an import job, and the per-entity outcome only arrives later when the status checker polls DMF. We need to settle the Service Bus message immediately, keep the session blocked so siblings on that session don't overtake the in-flight import, and have the audit trail report Pending — not Failed — until the external work reports back."
+
+## Problem (resolved)
+
+NimBus today resolves a message at the moment the handler returns. That works when the handler is the unit of work. It does not work when the unit of work is an external long-running job, because:
+
+1. The Service Bus peek-lock cannot be held for the duration (max ~5 min; F&O DMF jobs frequently exceed this), so the inbound message must be settled promptly.
+2. Sibling messages on the same session must defer until the external work reports back, otherwise per-session ordering breaks.
+3. Settling as Completed lies about the state (work has not happened yet); settling as Failed lies the other way and pollutes dashboards.
+4. The only existing way to keep a session blocked is to throw an exception from the handler — using exceptions for happy-path control flow is an anti-pattern that breaks middleware, telemetry filters, and reasonable code review.
+
+This feature introduces a new outcome — **PendingHandoff** — that maps to the existing `ResolutionStatus.Pending` (with a sub-status), reuses the existing session-blocking machinery, and is signalled by an explicit method on the handler context rather than an exception.
+
+## Scope (resolved)
+
+In scope:
+- A new handler outcome `PendingHandoff` signalled by a method on `IEventHandlerContext`.
+- Three new `MessageType` values (`PendingHandoffResponse`, `HandoffCompletedRequest`, `HandoffFailedRequest`).
+- Two new `IManagerClient` methods (`CompleteHandoff`, `FailHandoff`) that drive settlement without re-invoking the user handler.
+- Sub-status fields on `MessageEntity` / `UnresolvedEvent` so the WebApp can distinguish "Pending — Handoff" from ordinary Pending.
+- Optional Resolver-side timeout sweeper.
+- Documentation, conformance tests, WebApp badge, ADR.
+
+Out of scope:
+- Adapter-side concerns (correlation store, status checker, DMF integration). These are described as the motivating use case but are not part of the framework feature.
+- A general-purpose external-completion API beyond `CompleteHandoff` / `FailHandoff`.
+- Cross-session ordering. Sessions remain independent by design.
+- Cosmos / SQL data migration. New fields are nullable; existing rows are unaffected.
+- WebApp information-architecture changes beyond rendering the new sub-status.
+
+## User Scenarios & Testing
+
+### User Story 1 - Handler signals async handoff via the context (Priority: P1)
+
+As an adapter author, I want my event handler to signal "this work is in flight on an external system" by calling a method on the handler context — not by throwing an exception — so that my code reads as a normal happy path and middleware does not mistake it for a fault.
+
+Why this priority: Core developer-experience value. Without it, adapter authors fall back to abusing the failure path, which is the status quo we are trying to leave behind.
+
+Independent Test: Write an event handler that calls `ctx.MarkPendingHandoff(reason, externalJobId, expectedBy)` and returns. Assert that no exception is thrown, that `StrictMessageHandler` settles the inbound Service Bus message, that the Resolver records `ResolutionStatus.Pending` with `PendingSubStatus="Handoff"`, and that the session is blocked.
+
+Acceptance Scenarios:
+
+1. Given a handler that calls `ctx.MarkPendingHandoff(...)` and returns, When the message is processed, Then the framework sends `PendingHandoffResponse` to the Resolver, calls `BlockSession`, completes the inbound, and does not send `ResolutionResponse`.
+2. Given a handler that returns without calling `ctx.MarkPendingHandoff`, When the message is processed, Then existing behaviour is unchanged (`ResolutionResponse` is sent and the message is recorded as Completed).
+3. Given a handler that calls `ctx.MarkPendingHandoff(...)` and then throws an unrelated exception, When the message is processed, Then the existing failure path takes precedence (`ErrorResponse`, `BlockSession`, retry policy if applicable). PendingHandoff metadata is not emitted.
+4. Given a handler that calls `ctx.MarkPendingHandoff(...)` twice, When the message is processed, Then the second call wins (idempotent overwrite). No exception is thrown.
+
+---
+
+### User Story 2 - Sibling messages defer while a handoff is in flight (Priority: P1)
+
+As a NimBus operator, I want messages on the same Service Bus session as an in-flight handoff to be parked on the Deferred subscription in FIFO order, so that ordering is preserved across the duration of the external job.
+
+Why this priority: Without it, the feature does not solve the original problem.
+
+Independent Test: Send three messages with the same `SessionId`. The first triggers a `PendingHandoff`. Verify the second and third are received but parked on the Deferred subscription, that the Resolver records them as `Deferred`, and that they are not delivered to the user handler until the session unblocks.
+
+Acceptance Scenarios:
+
+1. Given a session blocked by PendingHandoff, When subsequent messages on the same session arrive, Then they throw `SessionBlockedException` internally and are routed to the Deferred subscription with the existing `DeferralSequence` ordering.
+2. Given the session is later settled via `CompleteHandoff`, When `ContinueWithAnyDeferredMessages` runs, Then the deferred siblings are replayed to the main topic in FIFO order, exactly as today's resubmit/skip flow.
+3. Given the session is settled via `FailHandoff`, When the operator skips the failed event, Then the existing skip → unblock → replay flow works without modification.
+
+---
+
+### User Story 3 - Audit row reports Pending (not Failed) (Priority: P1)
+
+As an operator, I want a message awaiting an external system to appear under "Pending" in the WebApp, with a sub-status making it clear that it is waiting on an external job, so that dashboard counts and alerting are not polluted by healthy in-flight workloads.
+
+Why this priority: Sets the audit-trail contract that the rest of the design hinges on.
+
+Independent Test: Trigger a PendingHandoff and inspect the resulting `MessageEntity` and `UnresolvedEvent`. Verify `ResolutionStatus = Pending`, `PendingSubStatus = "Handoff"`, `HandoffReason` matches the reason argument, `ExternalJobId` matches if supplied, and `ExpectedBy` matches if supplied.
+
+Acceptance Scenarios:
+
+1. Given a `PendingHandoffResponse` arrives at the Resolver, When the projection is written, Then `ResolutionStatus` is `Pending` and `PendingSubStatus` is `"Handoff"`.
+2. Given a Pending+Handoff entry exists, When the WebApp dashboard renders endpoint counts, Then the entry contributes to the Pending count, not the Failed count.
+3. Given the WebApp message detail page is opened on a Pending+Handoff entry, When the page renders, Then `HandoffReason`, `ExternalJobId`, and `ExpectedBy` are visible to the operator.
+4. Given existing audit rows from before this feature, When the WebApp renders them, Then they continue to render unchanged (the new fields are nullable; legacy `Pending` rows have `PendingSubStatus = null`).
+
+---
+
+### User Story 4 - Settle a handoff terminally without re-invoking the handler (Priority: P1)
+
+As an integration author, I want to settle a PendingHandoff message as Completed or Failed directly — without paying for an extra Service Bus delivery and an extra handler invocation just to obtain a `ResolutionResponse` — so that the cost per settled event is minimal and the audit trail is honest.
+
+Why this priority: Without dedicated terminal commands, callers misuse `ManagerClient.Resubmit` (semantic mismatch + wasted handler runs + double-counted middleware metrics + mislabelled audit rows). This is the central design choice of the feature.
+
+Independent Test: From a status-checker stand-in, call `ManagerClient.CompleteHandoff(pendingEntry, endpoint)`. Assert that the user's `IEventHandler<TEvent>.Handle` is **not invoked**, that the Resolver flips Pending → Completed, that the session unblocks, and that any deferred siblings replay.
+
+Acceptance Scenarios:
+
+1. Given a Pending+Handoff message and a registered handler, When `ManagerClient.CompleteHandoff(...)` is called, Then the handler's `Handle` method is not called. The Resolver records Completed; the session unblocks; deferred siblings replay in FIFO order.
+2. Given a Pending+Handoff message, When `ManagerClient.FailHandoff(entity, endpoint, errorText, errorType)` is called, Then the Resolver records Failed with `errorText` preserved verbatim on the audit row, and the session stays blocked.
+3. Given a Pending+Handoff message and the operator instead clicks Resubmit in the WebApp, When `ManagerClient.Resubmit` is called, Then the existing flow runs: handler is invoked again, ResolutionResponse fires on success. (Operator-initiated resubmit must remain available as an explicit override.)
+4. Given any other state (Completed, Failed, Skipped, DeadLettered), When `CompleteHandoff` or `FailHandoff` is called, Then the framework returns a clear error or no-op (decided in design phase). The state machine MUST NOT be corrupted.
+
+---
+
+### User Story 5 - Operator override unchanged (Priority: P2)
+
+As an operator, I want existing Resubmit and Skip buttons in the WebApp to keep working on Pending+Handoff entries, so that I can intervene manually when the status checker is stuck or wrong.
+
+Why this priority: Trust in the platform requires that operators retain manual control.
+
+Independent Test: From the WebApp, click Resubmit and Skip on a Pending+Handoff entry; verify they take the same code path as today (`HandleResubmissionRequest` / `HandleSkipRequest`).
+
+Acceptance Scenarios:
+
+1. Given a Pending+Handoff entry, When an operator clicks Resubmit, Then `ManagerClient.Resubmit` runs unchanged, the handler is invoked, and the message resolves through the existing flow.
+2. Given a Pending+Handoff entry, When an operator clicks Skip, Then `ManagerClient.Skip` runs unchanged, the message moves to Skipped, and deferred siblings replay.
+
+---
+
+### User Story 6 - Optional timeout sweeper (Priority: P2)
+
+As an operator, I want PendingHandoff entries that exceed their `ExpectedBy` deadline to be flipped to Failed automatically with a synthetic timeout error, so that silent backlogs do not accumulate.
+
+Why this priority: Important for production hygiene, but adapter authors must opt in — different integrations have very different reasonable wait times.
+
+Independent Test: Set `ExpectedBy` to a short deadline; trigger a PendingHandoff and let it expire without settlement; verify the Resolver-side sweeper flips it to Failed with `ErrorType = "TimeoutExpired"`. Verify that operators can Resubmit / Skip the resulting Failed entry as usual.
+
+Acceptance Scenarios:
+
+1. Given a Pending+Handoff entry whose `ExpectedBy` has passed, When the sweeper runs, Then the entry is flipped to Failed with a synthetic `TimeoutExpiredError`. Session unblocks via the standard skip/resubmit path.
+2. Given a Pending+Handoff entry with no `ExpectedBy`, When the sweeper runs, Then the entry is left untouched.
+3. Given the sweeper is disabled in configuration, When PendingHandoff entries age beyond `ExpectedBy`, Then nothing happens (opt-in behaviour).
+
+---
+
+## Edge Cases
+
+- A handler that calls `ctx.MarkPendingHandoff(...)` and then throws — exception path wins; PendingHandoff metadata is discarded.
+- A handler that calls `ctx.MarkPendingHandoff(...)` from inside a pipeline middleware — supported. Middleware that observes `ctx.Outcome == PendingHandoff` after the handler returns can branch on it (e.g., metrics).
+- `CompleteHandoff` / `FailHandoff` called for an event that is not in PendingHandoff state — must not corrupt state. Either no-op or explicit error (decided in design).
+- `CompleteHandoff` / `FailHandoff` called for an event the caller did not block (different `BlockedByEventId`) — analogous to today's `VerifySessionIsBlockedByThis` check. Must reject.
+- A session is blocked by a real handler failure (not PendingHandoff). `CompleteHandoff` MUST NOT settle it, since the original failure was not external.
+- `MarkPendingHandoff` is called with `expectedBy = null` — sweeper does not apply; entry can stay Pending+Handoff indefinitely (operator manages).
+- Two messages on the same session both want PendingHandoff. Only the first one's call to `MarkPendingHandoff` blocks the session; the second one's session-blocked check fires before the user handler is invoked, so it parks on Deferred (existing flow).
+- The Resolver receives `PendingHandoffResponse` for an event id it has never seen. Must record the projection with status Pending — same as receiving an `EventRequest` first, but with the sub-status fields populated.
+- A `HandoffCompletedRequest` arrives at a subscriber that does not have the corresponding event in flight (e.g., after a redeploy that lost session state). Must be authorized via `AuthorizeManagerRequest`, must verify session blocked-by-this; if mismatched, behaves like a stale Skip.
+- The WebApp message detail page on a legacy Pending entry (no sub-status) — must continue to render as before, with the new fields hidden.
+
+## Requirements
+
+### Functional Requirements
+
+#### Handler API & SDK
+
+- FR-001: `IEventHandlerContext` (in `NimBus.SDK.EventHandlers`) MUST expose a new method:
+  - `void MarkPendingHandoff(string reason, string externalJobId = null, TimeSpan? expectedBy = null)`
+- FR-002: `IEventHandlerContext` MUST expose readable state for the recorded outcome (e.g., `HandlerOutcome Outcome` and a `HandoffMetadata` accessor returning `reason`, `externalJobId`, `expectedBy`). State MUST be inspectable from pipeline middleware after the handler returns.
+- FR-003: `MarkPendingHandoff` MUST be idempotent. The last call wins. No exception is thrown on repeated calls.
+- FR-004: `EventHandlerContext` (the concrete implementation) MUST be constructed by `EventJsonHandler` such that `StrictMessageHandler` can read the outcome state after the user handler returns. Implementation choice (back-reference to `IMessageContext` vs. shared mutable state container) is decided in design.
+- FR-005: The handler MUST NOT be required to throw to signal PendingHandoff. The existing `SessionBlockedException` / `EventContextHandlerException` paths remain reserved for actual session-blocking and actual faults.
+
+#### Message types & Core flow
+
+- FR-010: `MessageType` MUST gain three values:
+  - `PendingHandoffResponse` — subscriber → Resolver (response)
+  - `HandoffCompletedRequest` — Manager → subscriber (control message)
+  - `HandoffFailedRequest` — Manager → subscriber (control message)
+- FR-011: `IResponseService` / `ResponseService` MUST gain a `SendPendingHandoffResponse` method modelled on `SendDeferralResponse`. Output message MUST carry `HandoffReason`, `ExternalJobId`, `ExpectedBy`.
+- FR-012: `StrictMessageHandler.HandleEventRequest` MUST inspect `ctx.Outcome` after `HandleEventContent` returns successfully. If the outcome is `PendingHandoff`, it MUST:
+  1. Send `PendingHandoffResponse` to the Resolver.
+  2. Call `messageContext.BlockSession` (same call path as the failure flow).
+  3. Call `messageContext.Complete`.
+  4. NOT send `ResolutionResponse`.
+  5. NOT invoke retry policy.
+- FR-013: `StrictMessageHandler` MUST gain a `HandleHandoffCompletedRequest` method analogous to `HandleSkipRequest`. It MUST authorize the Manager origin, verify the session is blocked by this event id, unblock the session, replay deferred messages, send `ResolutionResponse`, and complete the inbound. It MUST NOT invoke the user handler.
+- FR-014: `StrictMessageHandler` MUST gain a `HandleHandoffFailedRequest` method. It MUST authorize the Manager origin, verify the session is blocked by this event id, send `ErrorResponse` carrying the supplied `errorText` / `errorType`, leave the session blocked, and complete the inbound. It MUST NOT invoke the user handler.
+- FR-015: Existing `SessionBlockedException` and `EventContextHandlerException` catch branches in `StrictMessageHandler` MUST remain unchanged.
+
+#### Manager API
+
+- FR-020: `IManagerClient` MUST gain two methods:
+  - `Task CompleteHandoff(MessageEntity pendingEntry, string endpoint, string detailsJson = null)`
+  - `Task FailHandoff(MessageEntity pendingEntry, string endpoint, string errorText, string errorType = null)`
+- FR-021: Each new method MUST construct a NimBus `Message` of the corresponding new type, populate `From = Constants.ManagerId`, address it to the originating endpoint topic, and send it via the existing `ServiceBusClient`. Same shape as today's `Resubmit` / `Skip`.
+- FR-022: `IManagerClient.Resubmit` and `IManagerClient.Skip` MUST remain unchanged in signature and behaviour. They continue to be the operator-initiated recovery primitives.
+- FR-023: The Manager MUST validate that `pendingEntry.ResolutionStatus == Pending` (and `PendingSubStatus == "Handoff"`) before issuing `CompleteHandoff` / `FailHandoff`. Calls against any other state return a clear error and emit no message.
+
+#### Resolver & MessageStore
+
+- FR-030: The Resolver `MessageTypeToStatusMap` MUST map `PendingHandoffResponse` → `ResolutionStatus.Pending`. The audit projection MUST be written via the existing `UploadPendingMessage` path — no new container, no new query path.
+- FR-031: `MessageEntity` and `UnresolvedEvent` MUST gain four nullable fields:
+  - `string PendingSubStatus` — `null` for ordinary Pending; `"Handoff"` for PendingHandoff.
+  - `string HandoffReason` — free-text reason supplied by the handler.
+  - `string ExternalJobId` — optional external system identifier.
+  - `DateTime? ExpectedBy` — optional deadline used by the timeout sweeper.
+- FR-032: All four new fields MUST be persisted by every storage provider satisfying the conformance suite (Cosmos DB, SQL Server, in-memory). Existing rows MUST continue to project with these fields as `null`.
+- FR-033: `HandoffCompletedRequest` MUST cause the Resolver (via the resulting `ResolutionResponse`) to flip the projection from Pending → Completed. The sub-status MAY be cleared on the projection.
+- FR-034: `HandoffFailedRequest` MUST cause the Resolver (via the resulting `ErrorResponse`) to flip the projection from Pending → Failed, with the supplied `errorText` / `errorType` populated on the audit row.
+
+#### WebApp
+
+- FR-040: WebApp endpoint dashboards MUST count Pending+Handoff entries in the existing Pending column (no new column required). A small visual badge ("Awaiting external") SHOULD render on the message row when `PendingSubStatus = "Handoff"`.
+- FR-041: WebApp message detail page MUST render the new sub-status fields (`PendingSubStatus`, `HandoffReason`, `ExternalJobId`, `ExpectedBy`) when present. When absent, the page renders unchanged.
+- FR-042: WebApp Resubmit / Skip buttons MUST be available on Pending+Handoff entries, taking the existing `ManagerClient.Resubmit` / `Skip` paths. Operator-initiated `CompleteHandoff` / `FailHandoff` buttons are out of scope for v1.
+- FR-043: No WebApp API contract change is required. The new fields are optional additions to existing response shapes.
+
+#### Timeout sweeper (opt-in)
+
+- FR-050: NimBus MAY implement a Resolver-side background pass that scans Pending+Handoff entries with non-null `ExpectedBy` in the past, and emits a synthetic `HandoffFailedRequest` with `errorType = "TimeoutExpired"` and a configurable `errorText`.
+- FR-051: The sweeper MUST be opt-in. The default state is "no sweeper running". Adapters that want timeout enforcement enable it via configuration.
+- FR-052: The sweeper MUST NOT touch Pending entries with `PendingSubStatus = null` (legacy Pending) or with `ExpectedBy = null`.
+- FR-053: After a sweep, the resulting Failed entry MUST be reachable through the existing operator Resubmit / Skip flow.
+
+#### Backwards compatibility
+
+- FR-060: Existing handlers, audit rows, transports, and WebApp views MUST keep working unchanged. Adapters that do not call `MarkPendingHandoff` see zero behaviour change.
+- FR-061: The new `MessageType` values MUST be additive. Existing forwarding subscriptions that route response messages to the Resolver pick them up with no topology change.
+- FR-062: The four new `MessageEntity` fields MUST be nullable in every storage provider. No data migration is required for existing rows.
+- FR-063: `IEventHandler<TEvent>.Handle`, `IMessageContext`, `ISender`, and the `AddNimBus*` registration APIs MUST NOT change.
+
+#### Documentation, tests, and ADR
+
+- FR-070: A new ADR MUST be added (suggested: `docs/adr/012-pending-handoff.md`) capturing the rationale and the rejected alternatives (throw-based signalling, repurposing `Resubmit` for the success case).
+- FR-071: The shared provider conformance suite (`NimBus.MessageStore.*Tests`) MUST gain test cases verifying that the four new fields round-trip correctly and that the Resolver projection flips Pending → Completed under `HandoffCompletedRequest`.
+- FR-072: `tests/NimBus.Core.Tests` MUST cover: handler success path with `MarkPendingHandoff`, handler failure path with `MarkPendingHandoff` (failure wins), middleware observing `ctx.Outcome`, and the two new `Handle*Request` methods (authorize, verify, settle, no handler invocation).
+- FR-073: `tests/NimBus.EndToEnd.Tests` MUST gain a scenario covering: handler signals PendingHandoff → siblings defer → external `CompleteHandoff` → Pending → Completed → siblings replay in FIFO order. A second scenario covers `FailHandoff` → Pending → Failed with the error text preserved.
+- FR-074: `docs/error-handling.md` and `docs/message-flows.md` MUST be updated to document the new outcome and the two new control messages.
+- FR-075: SDK API reference (`docs/sdk-api-reference.md`) MUST document `IEventHandlerContext.MarkPendingHandoff` with a worked example.
+
+### Non-Functional Requirements
+
+- NFR-001: The new `MarkPendingHandoff` method MUST be safe to call from any pipeline phase — handler body, middleware before-await, middleware after-await — without changing observable behaviour beyond the documented one.
+- NFR-002: Adding the feature MUST NOT introduce control-flow-by-exception in NimBus's own code paths. The implementation reads `ctx.Outcome` synchronously after the handler returns; no new exception types are added for the happy path.
+- NFR-003: Settling a PendingHandoff message MUST NOT require an extra Service Bus delivery beyond the single `HandoffCompletedRequest` / `HandoffFailedRequest`. (No round-trip through `ResubmissionRequest` to obtain a `ResolutionResponse`.)
+- NFR-004: The DMF error text passed to `FailHandoff` MUST be preserved verbatim on the resulting audit row, subject to existing column-length limits documented per provider.
+- NFR-005: Subscriber processes MUST continue to depend only on Service Bus session state (ADR-002 respected). The feature MUST NOT introduce a database dependency on the subscriber side. Adapter-owned correlation stores live in the adapter, not in NimBus.
+- NFR-006: All new public API surface MUST carry XML doc comments. Breaking changes are not introduced; the feature is purely additive.
+- NFR-007: The feature MUST be compatible with the repository's `net10.0` target and existing analyzer / packaging conventions.
+- NFR-008: WebApp UI changes MUST degrade gracefully on legacy data (rows with `PendingSubStatus = null` render as before).
+
+## Key Entities
+
+- **HandlerOutcome** — enum capturing what the handler signalled (e.g., `Default` = ordinary success, `PendingHandoff`). Internal to `NimBus.SDK.EventHandlers` and `NimBus.Core`.
+- **HandoffMetadata** — value object carried on `IEventHandlerContext` after `MarkPendingHandoff`: `reason`, `externalJobId`, `expectedBy`. Surfaced on response messages and on the resulting `MessageEntity`.
+- **PendingHandoffResponse** — subscriber-emitted response message. Carries `HandoffMetadata`. Mapped to `ResolutionStatus.Pending`.
+- **HandoffCompletedRequest** — Manager-issued control message. Drives Pending → Completed without re-invoking the handler.
+- **HandoffFailedRequest** — Manager-issued control message. Drives Pending → Failed and carries `errorText` / `errorType`.
+- **PendingSubStatus** — string discriminator on `MessageEntity` / `UnresolvedEvent`. `null` for ordinary Pending, `"Handoff"` for the new outcome.
+- **TimeoutExpiredError** — synthetic error type emitted by the optional Resolver sweeper when `ExpectedBy` is exceeded.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- SC-001: An adapter handler that calls `ctx.MarkPendingHandoff(reason, externalJobId, expectedBy)` and returns produces an audit row with `ResolutionStatus = Pending`, `PendingSubStatus = "Handoff"`, and the supplied metadata, without throwing any exception.
+- SC-002: While a session is in PendingHandoff state, subsequent messages on the same session are parked on the Deferred subscription in FIFO order, identical to today's failure-blocked session behaviour.
+- SC-003: `ManagerClient.CompleteHandoff(pendingEntry, endpoint)` settles the message as Completed and unblocks the session **without invoking the user handler**. Verified by asserting `IEventHandler<TEvent>.Handle` is not called during the settlement.
+- SC-004: `ManagerClient.FailHandoff(pendingEntry, endpoint, errorText, errorType)` settles the message as Failed with `errorText` preserved verbatim on the audit row, and the session remains blocked.
+- SC-005: WebApp Pending count includes Pending+Handoff entries; Failed count does not. The message detail page renders `HandoffReason`, `ExternalJobId`, `ExpectedBy` when present and is unchanged on legacy rows.
+- SC-006: Existing operator Resubmit / Skip flows work unchanged on Pending+Handoff entries.
+- SC-007: The shared provider conformance suite passes with the four new nullable fields round-tripping correctly across Cosmos DB, SQL Server, and in-memory providers.
+- SC-008: End-to-end test "PendingHandoff → siblings defer → CompleteHandoff → siblings replay in FIFO" passes against the EndToEnd test harness.
+- SC-009: End-to-end test "PendingHandoff → FailHandoff → audit row carries DMF-style error text → operator Skip" passes against the EndToEnd test harness.
+- SC-010: No existing test in the repository starts failing as a result of the changes (additive feature).
+
+## Assumptions
+
+- The motivating use case (D365 F&O DMF) is representative — the feature is designed for any external long-running settlement pattern, not just F&O.
+- Adapter-side concerns (correlation store, status checker, polling cadence) are owned by the adapter, not NimBus. Subscribers retain their pure Service Bus dependency footprint.
+- The shape of `IEventHandler<TEvent>.Handle(TEvent, IEventHandlerContext, CancellationToken)` is stable; we extend `IEventHandlerContext`, not the handler signature.
+- The Manager continues to be the authoritative source of control messages; `From = Constants.ManagerId` remains the authorization marker.
+- The optional sweeper is genuinely optional. Some integrations have unbounded reasonable wait times; forcing a global timeout would be wrong.
+
+## Out of Scope
+
+- Adapter-side correlation store, status checker, or DMF-specific code.
+- Operator-initiated `CompleteHandoff` / `FailHandoff` buttons in the WebApp (Resubmit / Skip remain the operator-facing primitives in v1).
+- A general external-completion API that bypasses the Manager (e.g., a direct Resolver write). All settlement flows through Service Bus messages.
+- Cross-session ordering. Sessions remain independent.
+- Persistence-format migrations. New fields are nullable; existing rows are unaffected.
+- Renaming or restructuring `IEventHandler` / `IEventHandlerContext`.
+- Telemetry / OpenTelemetry attribute additions beyond what falls out naturally from the new `MessageType` values.
+
+## Open Questions
+
+- **Naming.** `MarkPendingHandoff` vs `SignalPendingHandoff` vs `DeferToExternal`. Decided in design phase.
+- **Outcome state shape on the context.** A single `HandlerOutcome` enum + optional `HandoffMetadata` value object, or a more general `HandlerResult` discriminated union. Decided in design phase.
+- **Concrete authorization for `HandoffCompletedRequest` / `HandoffFailedRequest`.** Reuse `AuthorizeManagerRequest` (require `From = ManagerId`) — safest default — or add a dedicated capability for the status checker. Recommendation: reuse existing.
+- **Behaviour when `CompleteHandoff` / `FailHandoff` is called against a non-PendingHandoff state.** Hard error vs no-op vs idempotent (already-completed → success). Decided in design phase.
+- **Sweeper hosting.** Resolver-side background pass vs separate worker vs adapter-side. Recommendation: Resolver-side, opt-in via configuration.
+- **WebApp UX.** Whether to add a dedicated "Awaiting external" filter / chip on the endpoint dashboard, beyond the per-row badge. Decided during WebApp work.
+- **Message detail page surfacing of `HandoffReason`/`ExternalJobId`.** Inline panel vs collapsible "Handoff details" section. Decided during WebApp work.
+
+## Resolved Questions
+
+- The new outcome MUST be signalled by an explicit method on `IEventHandlerContext`, not by throwing. (Resolved during review — control flow by exception is rejected.)
+- The audit row MUST be `Pending` (not `Failed`). (Resolved — failure semantics are wrong for healthy in-flight workloads.)
+- Settlement MUST use dedicated terminal commands (`CompleteHandoff` / `FailHandoff`), not `Resubmit` / `Skip`. (Resolved — `Resubmit` re-runs the handler, doubles middleware metrics, and mislabels audit attribution.)
+- Settlement MUST NOT re-invoke the user handler. (Resolved — `Handle*Request` methods drive the state machine directly, like today's `HandleSkipRequest`.)
+- Adapter-side concerns (correlation store, status checker) are out of scope for the framework feature. (Resolved — ADR-002 keeps subscribers pure Service Bus consumers; the adapter owns its own state.)
+- The feature is additive only. No breaking changes to existing handlers, transports, audit rows, or APIs. (Resolved.)

--- a/samples/CrmErpDemo/CrmErpDemo.AppHost/Program.cs
+++ b/samples/CrmErpDemo/CrmErpDemo.AppHost/Program.cs
@@ -66,6 +66,12 @@ var nimbusOps = builder.AddProject<Projects.NimBus_WebApp>("nimbus-ops")
     .WithReference(servicebus)
     .WithEnvironment("NimBus__PlatformType", typeof(CrmErpDemo.Contracts.CrmErpPlatformConfiguration).FullName!)
     .WithEnvironment("NimBus__PlatformAssembly", crmErpContractsPath)
+    // Local-dev auth bypass — required so the e2e Playwright suite (and a
+    // human operator browsing the dashboard) can hit the API without an
+    // Azure AD ClientId. Aspire defaults ASPNETCORE_ENVIRONMENT to Development
+    // for child projects, which is the gate Startup.cs checks before honoring
+    // this flag.
+    .WithEnvironment("EnableLocalDevAuthentication", "true")
     .WithEndpoint("http", e => e.Port = 28376)
     .WithEndpoint("https", e => e.Port = 28375)
     .WithExternalHttpEndpoints()

--- a/samples/CrmErpDemo/Erp.Adapter.Functions/Handlers/CrmAccountCreatedHandler.cs
+++ b/samples/CrmErpDemo/Erp.Adapter.Functions/Handlers/CrmAccountCreatedHandler.cs
@@ -1,6 +1,8 @@
 using CrmErpDemo.Contracts.Events;
 using Erp.Adapter.Functions.Clients;
+using Erp.Adapter.Functions.HandoffMode;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using NimBus.SDK.EventHandlers;
 
 namespace Erp.Adapter.Functions.Handlers;
@@ -8,11 +10,43 @@ namespace Erp.Adapter.Functions.Handlers;
 public sealed class CrmAccountCreatedHandler(
     IErpApiClient erp,
     IServiceModeClient modeClient,
+    IHandoffModeClient handoffMode,
+    IHandoffJobRegistration jobRegistration,
     ILogger<CrmAccountCreatedHandler> logger)
     : IEventHandler<CrmAccountCreated>
 {
     public async Task Handle(CrmAccountCreated message, IEventHandlerContext context, CancellationToken cancellationToken = default)
     {
+        var mode = await handoffMode.GetAsync(cancellationToken);
+        if (mode.Enabled)
+        {
+            var jobId = $"DMF-{Guid.NewGuid():N}".Substring(0, 16);
+            await jobRegistration.RegisterAsync(new HandoffJob
+            {
+                EventId = context.EventId,
+                SessionId = message.AccountId.ToString(),
+                MessageId = context.MessageId,
+                OriginatingMessageId = context.MessageId,
+                EventTypeId = context.EventType,
+                CorrelationId = context.CorrelationId,
+                ExternalJobId = jobId,
+                DueAt = DateTime.UtcNow.AddSeconds(mode.DurationSeconds),
+                PayloadJson = JsonConvert.SerializeObject(message),
+            }, cancellationToken);
+
+            logger.LogInformation(
+                "Handing off CRM account {AccountId} to ERP DMF job {JobId} (due in {Seconds}s).",
+                message.AccountId,
+                jobId,
+                mode.DurationSeconds);
+
+            context.MarkPendingHandoff(
+                reason: "Awaiting ERP DMF import job (demo)",
+                externalJobId: jobId,
+                expectedBy: TimeSpan.FromSeconds(mode.DurationSeconds));
+            return;
+        }
+
         await ErrorModeGuard.ThrowIfEnabledAsync(modeClient, context, logger, cancellationToken);
         logger.LogInformation("Creating ERP customer from CRM account {AccountId} ({LegalName})", message.AccountId, message.LegalName);
 

--- a/samples/CrmErpDemo/Erp.Adapter.Functions/HandoffMode/HandoffJobRegistration.cs
+++ b/samples/CrmErpDemo/Erp.Adapter.Functions/HandoffMode/HandoffJobRegistration.cs
@@ -1,0 +1,12 @@
+using System.Net.Http.Json;
+
+namespace Erp.Adapter.Functions.HandoffMode;
+
+public sealed class HandoffJobRegistration(HttpClient http) : IHandoffJobRegistration
+{
+    public async Task RegisterAsync(HandoffJob job, CancellationToken cancellationToken)
+    {
+        var response = await http.PostAsJsonAsync("/api/internal/handoff-jobs", job, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/samples/CrmErpDemo/Erp.Adapter.Functions/HandoffMode/HandoffModeClient.cs
+++ b/samples/CrmErpDemo/Erp.Adapter.Functions/HandoffMode/HandoffModeClient.cs
@@ -1,0 +1,29 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Erp.Adapter.Functions.HandoffMode;
+
+public sealed class HandoffModeClient(HttpClient http, ILogger<HandoffModeClient> logger) : IHandoffModeClient
+{
+    private static readonly HandoffModeSnapshot Disabled = new(false, 0, 0.0);
+
+    public async Task<HandoffModeSnapshot> GetAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await http.GetFromJsonAsync<ModeResponse>("/api/admin/handoff-mode", cancellationToken);
+            if (response is null)
+                return Disabled;
+            return new HandoffModeSnapshot(response.Enabled, response.DurationSeconds, response.FailureRate);
+        }
+        catch (Exception ex)
+        {
+            // If the flag can't be read (e.g. erp-api unreachable), default to off — the
+            // synchronous upsert path will run instead and surface any real error.
+            logger.LogDebug(ex, "Could not read handoff mode flag — assuming disabled.");
+            return Disabled;
+        }
+    }
+
+    private sealed record ModeResponse(bool Enabled, int DurationSeconds, double FailureRate, DateTimeOffset ChangedAt);
+}

--- a/samples/CrmErpDemo/Erp.Adapter.Functions/HandoffMode/IHandoffJobRegistration.cs
+++ b/samples/CrmErpDemo/Erp.Adapter.Functions/HandoffMode/IHandoffJobRegistration.cs
@@ -1,0 +1,22 @@
+namespace Erp.Adapter.Functions.HandoffMode;
+
+public interface IHandoffJobRegistration
+{
+    Task RegisterAsync(HandoffJob job, CancellationToken cancellationToken);
+}
+
+// Mirrors Erp.Api.HandoffMode.HandoffJob (the receiving DTO). The first six fields
+// match the MessageEntity shape that ManagerClient.CompleteHandoff / FailHandoff read,
+// so Erp.Api can settle the message without dragging in the message store.
+public sealed record HandoffJob
+{
+    public required string EventId { get; init; }
+    public required string SessionId { get; init; }
+    public required string MessageId { get; init; }
+    public string? OriginatingMessageId { get; init; }
+    public required string EventTypeId { get; init; }
+    public string? CorrelationId { get; init; }
+    public required string ExternalJobId { get; init; }
+    public required DateTime DueAt { get; init; }
+    public required string PayloadJson { get; init; }
+}

--- a/samples/CrmErpDemo/Erp.Adapter.Functions/HandoffMode/IHandoffModeClient.cs
+++ b/samples/CrmErpDemo/Erp.Adapter.Functions/HandoffMode/IHandoffModeClient.cs
@@ -1,0 +1,8 @@
+namespace Erp.Adapter.Functions.HandoffMode;
+
+public interface IHandoffModeClient
+{
+    Task<HandoffModeSnapshot> GetAsync(CancellationToken cancellationToken);
+}
+
+public sealed record HandoffModeSnapshot(bool Enabled, int DurationSeconds, double FailureRate);

--- a/samples/CrmErpDemo/Erp.Adapter.Functions/Program.cs
+++ b/samples/CrmErpDemo/Erp.Adapter.Functions/Program.cs
@@ -1,6 +1,7 @@
 using Azure.Messaging.ServiceBus;
 using CrmErpDemo.Contracts.Events;
 using Erp.Adapter.Functions.Clients;
+using Erp.Adapter.Functions.HandoffMode;
 using Erp.Adapter.Functions.Handlers;
 using Erp.Adapter.Functions.Pipeline;
 using Microsoft.Azure.Functions.Worker.Builder;
@@ -46,6 +47,15 @@ builder.Services.AddHttpClient<IServiceModeClient, ServiceModeClient>(c =>
     c.BaseAddress = new Uri(ResolveErpApiBaseUrl(builder.Configuration));
     c.Timeout = TimeSpan.FromSeconds(2);
 });
+
+builder.Services.AddHttpClient<IHandoffModeClient, HandoffModeClient>(c =>
+{
+    c.BaseAddress = new Uri(ResolveErpApiBaseUrl(builder.Configuration));
+    c.Timeout = TimeSpan.FromSeconds(2);
+});
+
+builder.Services.AddHttpClient<IHandoffJobRegistration, HandoffJobRegistration>(c =>
+    c.BaseAddress = new Uri(ResolveErpApiBaseUrl(builder.Configuration)));
 
 builder.Services.AddNimBus(n =>
 {

--- a/samples/CrmErpDemo/Erp.Api/Erp.Api.csproj
+++ b/samples/CrmErpDemo/Erp.Api/Erp.Api.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\..\src\NimBus.SDK\NimBus.SDK.csproj" />
     <ProjectReference Include="..\..\..\src\NimBus.Outbox.SqlServer\NimBus.Outbox.SqlServer.csproj" />
     <ProjectReference Include="..\..\..\src\NimBus.ServiceDefaults\NimBus.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\..\src\NimBus.Manager\NimBus.Manager.csproj" />
     <ProjectReference Include="..\CrmErpDemo.Contracts\CrmErpDemo.Contracts.csproj" />
   </ItemGroup>
 

--- a/samples/CrmErpDemo/Erp.Api/HandoffMode/HandoffEndpoints.cs
+++ b/samples/CrmErpDemo/Erp.Api/HandoffMode/HandoffEndpoints.cs
@@ -1,0 +1,40 @@
+namespace Erp.Api.HandoffMode;
+
+public static class HandoffEndpoints
+{
+    public static void MapHandoffEndpoints(this IEndpointRouteBuilder app)
+    {
+        var admin = app.MapGroup("/api/admin");
+
+        admin.MapGet("/handoff-mode", (HandoffModeState state) =>
+        {
+            var (enabled, durationSeconds, failureRate, changedAt) = state.Snapshot();
+            return Results.Ok(new HandoffModeResponse(enabled, durationSeconds, failureRate, changedAt));
+        });
+
+        admin.MapPut("/handoff-mode", (HandoffModeRequest request, HandoffModeState state) =>
+        {
+            if (request.DurationSeconds < 1 || request.DurationSeconds > 600)
+                return Results.BadRequest(new { error = "durationSeconds must be in [1, 600]." });
+            if (request.FailureRate < 0.0 || request.FailureRate > 1.0)
+                return Results.BadRequest(new { error = "failureRate must be in [0.0, 1.0]." });
+
+            var (enabled, durationSeconds, failureRate, changedAt) = state.Set(
+                request.Enabled, request.DurationSeconds, request.FailureRate);
+            return Results.Ok(new HandoffModeResponse(enabled, durationSeconds, failureRate, changedAt));
+        });
+
+        var jobs = app.MapGroup("/api/internal/handoff-jobs");
+
+        jobs.MapPost("/", (HandoffJob job, HandoffJobTracker tracker) =>
+        {
+            tracker.Register(job);
+            return Results.Created($"/api/internal/handoff-jobs/{Uri.EscapeDataString(job.EventId)}", job);
+        });
+
+        jobs.MapGet("/", (HandoffJobTracker tracker) => Results.Ok(tracker.GetAll()));
+    }
+}
+
+public record HandoffModeRequest(bool Enabled, int DurationSeconds, double FailureRate);
+public record HandoffModeResponse(bool Enabled, int DurationSeconds, double FailureRate, DateTimeOffset ChangedAt);

--- a/samples/CrmErpDemo/Erp.Api/HandoffMode/HandoffJob.cs
+++ b/samples/CrmErpDemo/Erp.Api/HandoffMode/HandoffJob.cs
@@ -1,0 +1,27 @@
+namespace Erp.Api.HandoffMode;
+
+// In-flight handoff job tracked by Erp.Api on behalf of the ERP adapter. The
+// adapter POSTs one of these when its CrmAccountCreated handler signals
+// PendingHandoff. The BackgroundService picks it up after DueAt and drives
+// settlement via IManagerClient.CompleteHandoff / FailHandoff.
+//
+// The first six fields are exactly what ManagerClient.CompleteHandoff /
+// FailHandoff read off MessageEntity, so we can construct a minimal stub
+// without dragging the message store into Erp.Api.
+//
+// PayloadJson carries the original event so the BackgroundService can apply
+// the ERP-side write before signalling Completed (the user handler is NOT
+// re-invoked on settlement, per the PendingHandoff spec).
+public sealed record HandoffJob
+{
+    public required string EventId { get; init; }
+    public required string SessionId { get; init; }
+    public required string MessageId { get; init; }
+    public string? OriginatingMessageId { get; init; }
+    public required string EventTypeId { get; init; }
+    public string? CorrelationId { get; init; }
+    public required string ExternalJobId { get; init; }
+    public required DateTime DueAt { get; init; }
+    public required string PayloadJson { get; init; }
+    public DateTimeOffset RegisteredAt { get; init; } = DateTimeOffset.UtcNow;
+}

--- a/samples/CrmErpDemo/Erp.Api/HandoffMode/HandoffJobBackgroundService.cs
+++ b/samples/CrmErpDemo/Erp.Api/HandoffMode/HandoffJobBackgroundService.cs
@@ -1,0 +1,179 @@
+using CrmErpDemo.Contracts.Events;
+using Erp.Api.Entities;
+using Erp.Api.Mapping;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using NimBus.Manager;
+using NimBus.MessageStore;
+using NimBus.SDK;
+
+namespace Erp.Api.HandoffMode;
+
+// Drains expired handoff jobs once per second and drives PendingHandoff →
+// Completed (or Failed) on the NimBus side via the manager client.
+//
+// On success: applies the ERP upsert that the user handler skipped (the spec
+// guarantees the user handler is NOT re-invoked on settlement, so the ERP
+// write has to happen here for the demo to remain end-to-end coherent), then
+// publishes ErpCustomerCreated through the same outbox the live handler uses,
+// and signals CompleteHandoff.
+//
+// On failure: skips the upsert and signals FailHandoff with a canned DMF-style
+// error string. The Resolver flips the audit row to Failed; the session stays
+// blocked until the operator clicks Resubmit / Skip in NimBus.WebApp.
+internal sealed class HandoffJobBackgroundService(
+    HandoffJobTracker tracker,
+    HandoffModeState modeState,
+    IServiceProvider services,
+    ILogger<HandoffJobBackgroundService> logger)
+    : BackgroundService
+{
+    private static readonly string[] CannedDmfErrors =
+    [
+        "DMF rejected: invalid postal code",
+        "DMF rejected: duplicate customer number",
+        "DMF rejected: tax ID validation failed",
+        "DMF rejected: missing mandatory address line",
+        "DMF rejected: country code not configured in legal entity",
+    ];
+
+    private const string Endpoint = "ErpEndpoint";
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var expired = tracker.DrainExpired(DateTime.UtcNow);
+                if (expired.Count > 0)
+                {
+                    logger.LogInformation("Draining {Count} expired handoff job(s).", expired.Count);
+                    foreach (var job in expired)
+                    {
+                        await SettleAsync(job, stoppingToken);
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Handoff drain tick failed; will retry.");
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task SettleAsync(HandoffJob job, CancellationToken cancellationToken)
+    {
+        var (_, _, failureRate, _) = modeState.Snapshot();
+        var roll = Random.Shared.NextDouble();
+        var shouldFail = roll < failureRate;
+
+        // ManagerClient.CompleteHandoff / FailHandoff only inspect these six fields
+        // plus PendingSubStatus on the entity — anything else is accepted as null.
+        var entity = new MessageEntity
+        {
+            EventId = job.EventId,
+            SessionId = job.SessionId,
+            MessageId = job.MessageId,
+            OriginatingMessageId = job.OriginatingMessageId,
+            EventTypeId = job.EventTypeId,
+            CorrelationId = job.CorrelationId,
+            PendingSubStatus = "Handoff",
+        };
+
+        await using var scope = services.CreateAsyncScope();
+        var manager = scope.ServiceProvider.GetRequiredService<IManagerClient>();
+
+        if (shouldFail)
+        {
+            var errorText = CannedDmfErrors[Random.Shared.Next(CannedDmfErrors.Length)];
+            logger.LogWarning(
+                "Handoff job {ExternalJobId} for event {EventId} failing (roll={Roll:F2} < failureRate={FailureRate:F2}): {ErrorText}",
+                job.ExternalJobId, job.EventId, roll, failureRate, errorText);
+            await manager.FailHandoff(entity, Endpoint, errorText, errorType: "DmfValidationError");
+            return;
+        }
+
+        try
+        {
+            await ApplyUpsertAsync(scope.ServiceProvider, job, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // If the demo upsert itself blows up, treat it as a DMF failure rather
+            // than leaking the exception out of the background tick.
+            logger.LogError(ex, "Handoff job {ExternalJobId} upsert failed; settling as failed.", job.ExternalJobId);
+            await manager.FailHandoff(entity, Endpoint, $"Erp upsert failed: {ex.Message}", errorType: "DmfValidationError");
+            return;
+        }
+
+        var detailsJson = JsonConvert.SerializeObject(new { importedRecordId = job.ExternalJobId });
+        logger.LogInformation(
+            "Handoff job {ExternalJobId} for event {EventId} completed.",
+            job.ExternalJobId, job.EventId);
+        await manager.CompleteHandoff(entity, Endpoint, detailsJson);
+    }
+
+    private static async Task ApplyUpsertAsync(IServiceProvider scopedServices, HandoffJob job, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(job.EventTypeId, nameof(CrmAccountCreated), StringComparison.Ordinal))
+        {
+            // The demo only wires PendingHandoff onto CrmAccountCreated. If we ever
+            // start tracking other event types here, this is the line to revisit.
+            return;
+        }
+
+        var payload = JsonConvert.DeserializeObject<CrmAccountCreated>(job.PayloadJson)
+            ?? throw new InvalidOperationException($"Handoff payload was empty for event {job.EventId}.");
+
+        var db = scopedServices.GetRequiredService<ErpDbContext>();
+        var publisher = scopedServices.GetRequiredService<IPublisherClient>();
+
+        var existing = await db.Customers.FirstOrDefaultAsync(c => c.CrmAccountId == payload.AccountId, cancellationToken);
+        var isNew = existing is null;
+
+        await OutboxScope.RunAsync(db, async () =>
+        {
+            Customer entity;
+            if (isNew)
+            {
+                entity = new Customer
+                {
+                    Id = Guid.NewGuid(),
+                    CrmAccountId = payload.AccountId,
+                    CustomerNumber = $"C-{DateTime.UtcNow:yyMMdd}-{Random.Shared.Next(10000, 99999)}",
+                    LegalName = payload.LegalName,
+                    TaxId = payload.TaxId,
+                    CountryCode = payload.CountryCode,
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    Origin = "Crm",
+                };
+                db.Customers.Add(entity);
+            }
+            else
+            {
+                entity = existing!;
+                entity.LegalName = payload.LegalName;
+                entity.TaxId = payload.TaxId;
+                entity.CountryCode = payload.CountryCode;
+                entity.UpdatedAt = DateTimeOffset.UtcNow;
+            }
+            await db.SaveChangesAsync(cancellationToken);
+            if (isNew)
+                await publisher.Publish(CustomerMapper.ToCreatedEvent(entity));
+        }, cancellationToken);
+    }
+}

--- a/samples/CrmErpDemo/Erp.Api/HandoffMode/HandoffJobTracker.cs
+++ b/samples/CrmErpDemo/Erp.Api/HandoffMode/HandoffJobTracker.cs
@@ -1,0 +1,37 @@
+using System.Collections.Concurrent;
+
+namespace Erp.Api.HandoffMode;
+
+// In-process registry of handoff jobs keyed by EventId. Singleton.
+// Concurrency: ConcurrentDictionary handles the registry; DrainExpired
+// snapshots and removes expired entries atomically per key so the background
+// service tick and a late /api/internal/handoff-jobs POST can't double-process.
+public sealed class HandoffJobTracker
+{
+    private readonly ConcurrentDictionary<string, HandoffJob> _jobs = new(StringComparer.Ordinal);
+
+    public void Register(HandoffJob job)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        _jobs[job.EventId] = job;
+    }
+
+    public bool TryRemove(string eventId, out HandoffJob? job)
+        => _jobs.TryRemove(eventId, out job);
+
+    public IReadOnlyList<HandoffJob> DrainExpired(DateTime utcNow)
+    {
+        var drained = new List<HandoffJob>();
+        foreach (var kvp in _jobs)
+        {
+            if (kvp.Value.DueAt <= utcNow && _jobs.TryRemove(kvp.Key, out var job))
+            {
+                drained.Add(job);
+            }
+        }
+        return drained;
+    }
+
+    public IReadOnlyList<HandoffJob> GetAll()
+        => _jobs.Values.ToList();
+}

--- a/samples/CrmErpDemo/Erp.Api/HandoffMode/HandoffModeState.cs
+++ b/samples/CrmErpDemo/Erp.Api/HandoffMode/HandoffModeState.cs
@@ -1,0 +1,43 @@
+namespace Erp.Api.HandoffMode;
+
+// Toggle + parameters for the demo PendingHandoff showcase. The ERP adapter's
+// CrmAccountCreated handler polls this via /api/admin/handoff-mode and, when
+// Enabled, signals MarkPendingHandoff(...) instead of running the synchronous
+// upsert. Mirrors ServiceModeState / ErrorModeState — singleton, lock-guarded.
+public sealed class HandoffModeState
+{
+    private readonly object _gate = new();
+    private bool _enabled;
+    private int _durationSeconds = 5;
+    private double _failureRate;
+    private DateTimeOffset _changedAt = DateTimeOffset.UtcNow;
+
+    public (bool Enabled, int DurationSeconds, double FailureRate, DateTimeOffset ChangedAt) Snapshot()
+    {
+        lock (_gate)
+        {
+            return (_enabled, _durationSeconds, _failureRate, _changedAt);
+        }
+    }
+
+    public (bool Enabled, int DurationSeconds, double FailureRate, DateTimeOffset ChangedAt) Set(
+        bool enabled,
+        int durationSeconds,
+        double failureRate)
+    {
+        lock (_gate)
+        {
+            var changed = _enabled != enabled
+                || _durationSeconds != durationSeconds
+                || Math.Abs(_failureRate - failureRate) > double.Epsilon;
+            if (changed)
+            {
+                _enabled = enabled;
+                _durationSeconds = durationSeconds;
+                _failureRate = failureRate;
+                _changedAt = DateTimeOffset.UtcNow;
+            }
+            return (_enabled, _durationSeconds, _failureRate, _changedAt);
+        }
+    }
+}

--- a/samples/CrmErpDemo/Erp.Api/Program.cs
+++ b/samples/CrmErpDemo/Erp.Api/Program.cs
@@ -1,9 +1,11 @@
 using Azure.Messaging.ServiceBus;
 using Erp.Api;
 using Erp.Api.Endpoints;
+using Erp.Api.HandoffMode;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
+using NimBus.Manager;
 using NimBus.Outbox.SqlServer;
 using NimBus.SDK.Extensions;
 using NimBus.SDK.Hosting;
@@ -28,6 +30,8 @@ builder.Services.AddDbContext<ErpDbContext>(opt => opt.UseSqlServer(erpConnectio
 
 builder.Services.AddSingleton<ServiceModeState>();
 builder.Services.AddSingleton<ErrorModeState>();
+builder.Services.AddSingleton<HandoffModeState>();
+builder.Services.AddSingleton<HandoffJobTracker>();
 
 // ERP hosts the outbox dispatcher (the Functions adapter doesn't host long-running polling).
 builder.Services.AddNimBusSqlServerOutbox(erpConnectionString);
@@ -40,6 +44,13 @@ if (hasServiceBus)
         return new OutboxDispatcherSender(client.CreateSender("ErpEndpoint"));
     });
     builder.Services.AddNimBusOutboxDispatcher(TimeSpan.FromSeconds(1));
+
+    // ManagerClient drives Pending → Completed/Failed transitions for handoff
+    // jobs once the ERP "DMF import" completes. Only registered when Service Bus
+    // is wired — without it the handoff demo can't issue control messages.
+    builder.Services.AddSingleton<IManagerClient>(sp =>
+        new ManagerClient(sp.GetRequiredService<ServiceBusClient>()));
+    builder.Services.AddHostedService<HandoffJobBackgroundService>();
 }
 else
 {
@@ -108,5 +119,6 @@ if (!initSucceeded)
 app.MapCustomerEndpoints();
 app.MapErpContactEndpoints();
 app.MapAdminEndpoints();
+app.MapHandoffEndpoints();
 
 app.Run();

--- a/samples/CrmErpDemo/Erp.Web/src/App.tsx
+++ b/samples/CrmErpDemo/Erp.Web/src/App.tsx
@@ -4,6 +4,7 @@ import CustomersList from './pages/CustomersList';
 import CustomerForm from './pages/CustomerForm';
 import ContactsList from './pages/ContactsList';
 import ContactForm from './pages/ContactForm';
+import HandoffModePanel from './components/admin/handoff-mode-panel';
 import { api } from './api';
 
 const tabClass = ({ isActive }: { isActive: boolean }) =>
@@ -30,7 +31,8 @@ export default function App() {
       </header>
       <ServiceModeBanner />
       <ErrorModeBanner />
-      <main className="max-w-5xl mx-auto px-6 py-8">
+      <main className="max-w-5xl mx-auto px-6 py-8 space-y-6">
+        <HandoffModePanel />
         <Routes>
           <Route path="/" element={<CustomersList />} />
           <Route path="/customers" element={<CustomersList />} />

--- a/samples/CrmErpDemo/Erp.Web/src/api.ts
+++ b/samples/CrmErpDemo/Erp.Web/src/api.ts
@@ -29,6 +29,26 @@ export interface ModeState {
   changedAt: string;
 }
 
+export interface HandoffMode {
+  enabled: boolean;
+  durationSeconds: number;
+  failureRate: number;
+  changedAt: string;
+}
+
+export interface HandoffJob {
+  eventId: string;
+  sessionId: string;
+  messageId: string;
+  originatingMessageId?: string | null;
+  eventTypeId: string;
+  correlationId?: string | null;
+  externalJobId: string;
+  dueAt: string;
+  payloadJson: string;
+  registeredAt: string;
+}
+
 async function json<T>(res: Response): Promise<T> {
   if (!res.ok) {
     const body = await res.text().catch(() => '');
@@ -70,6 +90,16 @@ export const api = {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ enabled }),
     }).then(json<ModeState>),
+
+  getHandoffMode: () => fetch('/api/admin/handoff-mode').then(json<HandoffMode>),
+  setHandoffMode: (m: { enabled: boolean; durationSeconds: number; failureRate: number }) =>
+    fetch('/api/admin/handoff-mode', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(m),
+    }).then(json<HandoffMode>),
+
+  getHandoffJobs: () => fetch('/api/internal/handoff-jobs').then(json<HandoffJob[]>),
 
   listContacts: () => fetch('/api/contacts').then(json<Contact[]>),
   getContact: (id: string) => fetch(`/api/contacts/${id}`).then(json<Contact>),

--- a/samples/CrmErpDemo/Erp.Web/src/components/admin/handoff-mode-panel.tsx
+++ b/samples/CrmErpDemo/Erp.Web/src/components/admin/handoff-mode-panel.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useRef, useState } from 'react';
+import { api, HandoffJob } from '../../api';
+
+// Pending-handoff demo controls. The ERP adapter's CrmAccountCreated handler
+// polls /api/admin/handoff-mode and, when Enabled, signals MarkPendingHandoff
+// instead of writing the customer synchronously. Erp.Api then re-applies the
+// write after `durationSeconds` and (probabilistically, per `failureRate`)
+// either completes or fails the message.
+
+const DEBOUNCE_MS = 300;
+
+export default function HandoffModePanel() {
+  const [enabled, setEnabled] = useState<boolean>(false);
+  const [durationSeconds, setDurationSeconds] = useState<number>(10);
+  // failureRate is shown as 0..100 in the UI and divided by 100 on send.
+  const [failurePercent, setFailurePercent] = useState<number>(0);
+  const [loaded, setLoaded] = useState<boolean>(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const skipNextSendRef = useRef<boolean>(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const m = await api.getHandoffMode();
+        if (cancelled) return;
+        setEnabled(m.enabled);
+        setDurationSeconds(Math.max(1, Math.min(60, Math.round(m.durationSeconds))));
+        setFailurePercent(Math.max(0, Math.min(100, Math.round(m.failureRate * 100))));
+        setLoaded(true);
+      } catch {
+        setLoaded(true);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (!loaded) return;
+    // First render after the GET seeds initial values; don't echo it back.
+    if (skipNextSendRef.current) {
+      skipNextSendRef.current = false;
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      api.setHandoffMode({
+        enabled,
+        durationSeconds,
+        failureRate: failurePercent / 100,
+      }).catch(() => { /* ignore — UI will reflect next refresh */ });
+    }, DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [enabled, durationSeconds, failurePercent, loaded]);
+
+  return (
+    <section className="bg-white border border-slate-200 rounded-md p-4 space-y-4">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-slate-700">Pending-handoff mode</h2>
+          <p className="text-xs text-slate-500">
+            When enabled, CrmAccountCreated returns <code>PendingHandoff</code> instead of writing immediately.
+            Erp.Api settles the message after the configured delay.
+          </p>
+        </div>
+        <label className="inline-flex items-center gap-2 cursor-pointer">
+          <span className="text-xs text-slate-600">{enabled ? 'ON' : 'OFF'}</span>
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            disabled={!loaded}
+            className="h-4 w-4 accent-indigo-600"
+          />
+        </label>
+      </header>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <div className="flex items-center justify-between text-xs text-slate-600">
+            <label htmlFor="handoff-duration">Duration</label>
+            <span className="font-mono">{durationSeconds}s</span>
+          </div>
+          <input
+            id="handoff-duration"
+            type="range"
+            min={1}
+            max={60}
+            step={1}
+            value={durationSeconds}
+            onChange={(e) => setDurationSeconds(Number(e.target.value))}
+            disabled={!loaded}
+            className="w-full accent-indigo-600"
+          />
+        </div>
+        <div>
+          <div className="flex items-center justify-between text-xs text-slate-600">
+            <label htmlFor="handoff-failure">Failure rate</label>
+            <span className="font-mono">{failurePercent}% chance of failure</span>
+          </div>
+          <input
+            id="handoff-failure"
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={failurePercent}
+            onChange={(e) => setFailurePercent(Number(e.target.value))}
+            disabled={!loaded}
+            className="w-full accent-rose-600"
+          />
+        </div>
+      </div>
+
+      <InFlightJobsPanel />
+    </section>
+  );
+}
+
+function InFlightJobsPanel() {
+  const [jobs, setJobs] = useState<HandoffJob[]>([]);
+  const [now, setNow] = useState<number>(Date.now());
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const list = await api.getHandoffJobs();
+        if (!cancelled) setJobs(list);
+      } catch { /* ignore */ }
+    };
+    tick();
+    const poll = setInterval(tick, 1000);
+    const clock = setInterval(() => setNow(Date.now()), 250);
+    return () => { cancelled = true; clearInterval(poll); clearInterval(clock); };
+  }, []);
+
+  return (
+    <div className="border-t border-slate-200 pt-3">
+      <h3 className="text-xs font-semibold text-slate-600 mb-2">In-flight handoff jobs</h3>
+      {jobs.length === 0 ? (
+        <p className="text-xs text-slate-400">No active handoff jobs</p>
+      ) : (
+        <ul className="space-y-1 text-xs font-mono">
+          {jobs.map((j) => {
+            const remainingMs = new Date(j.dueAt).getTime() - now;
+            const remaining = Math.max(0, Math.ceil(remainingMs / 1000));
+            return (
+              <li key={j.eventId} className="flex items-center gap-3 text-slate-700">
+                <span className="px-1.5 py-0.5 bg-slate-100 rounded">{j.externalJobId}</span>
+                <span className="text-slate-500">{j.eventId.slice(0, 8)}</span>
+                <span className={remaining === 0 ? 'text-rose-600' : 'text-indigo-600'}>
+                  {remaining === 0 ? 'settling…' : `${remaining}s remaining`}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/samples/CrmErpDemo/README.md
+++ b/samples/CrmErpDemo/README.md
@@ -387,6 +387,30 @@ In Cosmos mode Aspire skips provisioning the `nimbus` SQL database; the Resolver
 
 For the full classification of error types in an adapter (transient redelivery, retry, immediate dead-letter, validation rejection) and how each path is recorded by the Resolver, see [`docs/error-handling.md`](../../docs/error-handling.md).
 
+## Showcase: PendingHandoff (async ERP imports)
+
+NimBus's [PendingHandoff feature](../../docs/specs/002-async-message-completion/spec.md) ([ADR-012](../../docs/adr/012-pending-handoff.md)) lets a subscriber handler signal "work is in flight on an external system" via `ctx.MarkPendingHandoff(reason, externalJobId, expectedBy)` and return normally — the inbound message is settled, the session blocks for siblings, the audit row reads `Pending` + `PendingSubStatus = "Handoff"`, and settlement happens later via `ManagerClient.CompleteHandoff` / `FailHandoff` without re-invoking the user handler. This demo wires the feature onto the ERP adapter's `CrmAccountCreated` handler so the lifecycle (Pending badge, deferred siblings, completion replay, failure + operator Skip) is visible end-to-end in the AppHost.
+
+The control surface is in **erp-web → Admin**: a toggle plus duration and failure-rate sliders. `Erp.Api/HandoffMode/HandoffJobBackgroundService` simulates the external import, draining expired jobs once a second and rolling against the configured failure rate; on success it applies the upsert and calls `CompleteHandoff`, on failure it calls `FailHandoff` with one of a small set of canned `DMF rejected: ...` errors.
+
+### Manual smoke flow
+
+1. AppHost up → open **erp-web** → Admin → flip handoff mode ON, set ~30 s, 0% failure.
+2. Open **crm-web** → create account "Acme".
+3. Open **nimbus-ops** (the operator UI) → navigate to `ErpEndpoint` → see the `CrmAccountCreated` row marked **Pending** with the **Awaiting external** badge. Click it → the detail page shows `HandoffReason`, `ExternalJobId`, `ExpectedBy`.
+4. Back in **crm-web** → update "Acme" twice in quick succession.
+5. **nimbus-ops** → both updates show **Deferred** (queued behind the in-flight create on the same session).
+6. Wait. After ~30 s the create row flips to **Completed**, the deferred updates replay in FIFO order (also Completed), and the ERP customer in **erp-web** reflects the latest update.
+7. Re-flip Erp.Web admin: failure rate = 100%. Create another account.
+8. **nimbus-ops** → after ~30 s the row is **Failed** with `ErrorContent.ErrorText` matching one of the canned `DMF rejected: ...` strings verbatim. Click **Skip** → audit row flips to **Skipped**, session unblocks.
+
+### Automated coverage
+
+The lifecycle is exercised end-to-end by the Playwright suite in [`e2e/`](e2e/):
+
+- [`e2e/tests/04-pending-handoff-success.spec.ts`](e2e/tests/04-pending-handoff-success.spec.ts) — create handoff + 2 sibling updates → create reaches `Pending+Handoff`, updates Defer, all complete on settlement.
+- [`e2e/tests/05-pending-handoff-failure.spec.ts`](e2e/tests/05-pending-handoff-failure.spec.ts) — handoff fails with a `DMF rejected:` error → operator Skip flips the row to `Skipped`.
+
 ## Out of scope (v1)
 
 No authn/authz, no multi-tenant, no production deployment scripts, no non-Azure transports, no realistic tax/currency/shipping math, no automated browser tests, no UI i18n, no Sales Orders/Products/Inventory.

--- a/samples/CrmErpDemo/e2e/helpers/erp-api-client.ts
+++ b/samples/CrmErpDemo/e2e/helpers/erp-api-client.ts
@@ -27,6 +27,32 @@ export interface ServiceModeState {
   changedAt: string;
 }
 
+export interface HandoffModeRequest {
+  enabled: boolean;
+  durationSeconds: number;
+  failureRate: number;
+}
+
+export interface HandoffModeState {
+  enabled: boolean;
+  durationSeconds: number;
+  failureRate: number;
+  changedAt: string;
+}
+
+export interface HandoffJob {
+  eventId: string;
+  sessionId: string;
+  messageId: string;
+  originatingMessageId?: string | null;
+  eventTypeId: string;
+  correlationId?: string | null;
+  externalJobId: string;
+  dueAt: string;
+  payloadJson: string;
+  registeredAt: string;
+}
+
 export class ErpApiClient {
   private constructor(private readonly api: APIRequestContext) {}
 
@@ -104,5 +130,30 @@ export class ErpApiClient {
   async resetFailureModes(): Promise<void> {
     await this.setErrorMode(false);
     await this.setServiceMode(false);
+  }
+
+  // ─── Handoff mode (PendingHandoff showcase) ───────────────────
+
+  async getHandoffMode(): Promise<HandoffModeState> {
+    const res = await this.api.get("/api/admin/handoff-mode");
+    if (!res.ok()) throw new Error(`ERP GET handoff-mode → ${res.status()}`);
+    return (await res.json()) as HandoffModeState;
+  }
+
+  async setHandoffMode(req: HandoffModeRequest): Promise<HandoffModeState> {
+    const res = await this.api.put("/api/admin/handoff-mode", { data: req });
+    if (!res.ok()) throw new Error(`ERP PUT handoff-mode → ${res.status()} ${await res.text()}`);
+    return (await res.json()) as HandoffModeState;
+  }
+
+  /** Disable handoff mode with sensible defaults; safe to call from afterEach hooks. */
+  async resetHandoffMode(): Promise<void> {
+    await this.setHandoffMode({ enabled: false, durationSeconds: 10, failureRate: 0 });
+  }
+
+  async getHandoffJobs(): Promise<HandoffJob[]> {
+    const res = await this.api.get("/api/internal/handoff-jobs");
+    if (!res.ok()) throw new Error(`ERP GET handoff-jobs → ${res.status()}`);
+    return (await res.json()) as HandoffJob[];
   }
 }

--- a/samples/CrmErpDemo/e2e/helpers/nimbus-api-client.ts
+++ b/samples/CrmErpDemo/e2e/helpers/nimbus-api-client.ts
@@ -13,6 +13,17 @@ export interface EndpointStatusCount {
   deadletterCount: number;
 }
 
+export interface MessageErrorContent {
+  errorText?: string | null;
+  errorType?: string | null;
+  [key: string]: unknown;
+}
+
+export interface MessageContent {
+  errorContent?: MessageErrorContent | null;
+  [key: string]: unknown;
+}
+
 export interface NimBusEvent {
   eventId: string;
   sessionId: string;
@@ -20,6 +31,12 @@ export interface NimBusEvent {
   eventTypeId: string;
   resolutionStatus: string;
   lastMessageId: string;
+  pendingSubStatus?: string | null;
+  handoffReason?: string | null;
+  externalJobId?: string | null;
+  expectedBy?: string | null;
+  /** Search results nest the error under messageContent.errorContent. */
+  messageContent?: MessageContent | null;
   // ... many more fields, but tests only need the above
   [key: string]: unknown;
 }
@@ -94,6 +111,12 @@ export class NimBusApiClient {
   async resubmit(eventId: string, messageId: string): Promise<void> {
     const res = await this.api.post(`/api/event/resubmit/${eventId}/${messageId}`);
     if (!res.ok()) throw new Error(`NimBus resubmit → ${res.status()} ${await res.text()}`);
+  }
+
+  /** Skip a single event (terminal — flips Failed → Skipped, unblocks the session). */
+  async skipMessage(eventId: string, messageId: string): Promise<void> {
+    const res = await this.api.post(`/api/event/skip/${eventId}/${messageId}`);
+    if (!res.ok()) throw new Error(`NimBus skip → ${res.status()} ${await res.text()}`);
   }
 
   /** Trigger reprocessing of all Deferred messages on a (endpoint, session). */

--- a/samples/CrmErpDemo/e2e/tests/04-pending-handoff-success.spec.ts
+++ b/samples/CrmErpDemo/e2e/tests/04-pending-handoff-success.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect } from "@playwright/test";
+import { CrmApiClient } from "../helpers/crm-api-client.js";
+import { ErpApiClient } from "../helpers/erp-api-client.js";
+import { NimBusApiClient, type NimBusEvent } from "../helpers/nimbus-api-client.js";
+import { Timeouts } from "../helpers/service-urls.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+/**
+ * PendingHandoff happy path.
+ *
+ * With handoff mode enabled, the ERP adapter's CrmAccountCreated handler
+ * signals MarkPendingHandoff(...) and returns. NimBus records the audit row
+ * as Pending+Handoff and blocks the session, so sibling messages on the same
+ * session (further updates to the same account) defer FIFO behind it.
+ *
+ * After the configured deadline elapses, Erp.Api's HandoffJobBackgroundService
+ * applies the ERP-side upsert and signals CompleteHandoff. The Resolver flips
+ * the Pending row to Completed; the deferred siblings replay in order.
+ *
+ * Verification: all three audit rows end Completed, ERP customer reflects the
+ * latest update, and the original handoff metadata fields were populated.
+ */
+test.describe("PendingHandoff success: create handed off, sibling updates defer, all complete", () => {
+  let crm: CrmApiClient;
+  let erp: ErpApiClient;
+  let nimbus: NimBusApiClient;
+
+  test.beforeAll(async () => {
+    crm = await CrmApiClient.create();
+    erp = await ErpApiClient.create();
+    nimbus = await NimBusApiClient.create();
+    await erp.resetFailureModes();
+    await erp.resetHandoffMode();
+  });
+
+  test.afterEach(async () => {
+    // Reset handoff mode so other specs see a clean state. Other failure modes
+    // are owned by their own specs' afterEach; we only own handoff here.
+    await erp.resetHandoffMode();
+  });
+
+  test.afterAll(async () => {
+    await erp.resetFailureModes();
+    await erp.resetHandoffMode();
+    await crm.dispose();
+    await erp.dispose();
+    await nimbus.dispose();
+  });
+
+  test("create + 2 in-flight updates → create reaches Pending+Handoff, updates defer, all complete", async () => {
+    // ── 1. Enable handoff mode with a short deadline so the test wraps up
+    //       quickly. failureRate=0 means CompleteHandoff always wins.
+    await erp.setHandoffMode({ enabled: true, durationSeconds: 3, failureRate: 0 });
+
+    // ── 2. Create one CRM account. The ERP adapter's CrmAccountCreated handler
+    //       reads handoff mode, registers a job in Erp.Api, and signals
+    //       MarkPendingHandoff — so the audit row should land as Pending+Handoff.
+    const baseName = `Handoff-Success-${Date.now()}`;
+    const account = await crm.createAccount({ legalName: baseName, countryCode: "US" });
+
+    // ── 3. Wait for the CrmAccountCreated audit row on ErpEndpoint to surface
+    //       in Pending+Handoff with the handoff metadata fields populated.
+    const pendingCreate: NimBusEvent = await waitFor(
+      async () => {
+        const events = await nimbus.searchEvents("ErpEndpoint", {
+          sessionId: account.id,
+          eventTypeId: ["CrmAccountCreated"],
+          resolutionStatus: ["Pending"],
+        });
+        return events.find((e) => e.pendingSubStatus === "Handoff") ?? null;
+      },
+      { timeoutMs: Timeouts.propagationMs, description: `Pending+Handoff CrmAccountCreated for session ${account.id}` },
+    );
+    expect(pendingCreate.handoffReason, "handoffReason").toBeTruthy();
+    expect(pendingCreate.externalJobId, "externalJobId").toBeTruthy();
+    expect(pendingCreate.expectedBy, "expectedBy").toBeTruthy();
+
+    // Sanity: the corresponding ERP customer should NOT exist yet — the upsert
+    // is deferred to the BackgroundService settlement tick.
+    expect(await erp.findCustomerByCrmAccountId(account.id)).toBeNull();
+
+    // ── 4. Within the 3s window, fire two updates back-to-back. They share
+    //       SessionKey=AccountId with the in-flight create, so they should
+    //       defer behind it instead of running.
+    const updates = [
+      { revision: 1, legalName: `${baseName}-rev1` },
+      { revision: 2, legalName: `${baseName}-rev2` },
+    ];
+    for (const u of updates) {
+      await crm.updateAccount(account.id, { legalName: u.legalName, countryCode: "US" });
+    }
+
+    // ── 5. Both update audit rows on ErpEndpoint should reach Deferred. We
+    //       poll because the outbox dispatcher + ServiceBus have ~1s latency
+    //       before the messages even hit the subscription.
+    await waitFor(
+      async () => {
+        const events = await nimbus.searchEvents("ErpEndpoint", {
+          sessionId: account.id,
+          eventTypeId: ["CrmAccountUpdated"],
+          resolutionStatus: ["Deferred"],
+        });
+        return events.length >= 2 ? events : null;
+      },
+      { timeoutMs: Timeouts.propagationMs, description: `Both CrmAccountUpdated rows reach Deferred for session ${account.id}` },
+    );
+
+    // ── 6. Wait past the 3s deadline + one BackgroundService tick (~1s) plus
+    //       slack for the deferred replay to drain. The polling helper covers
+    //       the slack — we don't need a fixed sleep.
+    //
+    // ── 7. All three audit rows for our session on ErpEndpoint should be
+    //       Completed (the create after CompleteHandoff fires; the two updates
+    //       after the deferred replay drains the session).
+    const lastRevName = updates[updates.length - 1].legalName;
+    await waitFor(
+      async () => {
+        const events = await nimbus.searchEvents("ErpEndpoint", {
+          sessionId: account.id,
+          resolutionStatus: ["Completed"],
+        });
+        const create = events.find((e) => e.eventTypeId === "CrmAccountCreated");
+        const updateCount = events.filter((e) => e.eventTypeId === "CrmAccountUpdated").length;
+        return create && updateCount >= 2 ? events : null;
+      },
+      {
+        timeoutMs: Timeouts.failedMessageMs,
+        description: `Create + 2 updates all Completed for session ${account.id}`,
+      },
+    );
+
+    // ── 8. Verify the ERP customer materialised and reflects the LATEST update.
+    //       (BackgroundService applied the create-time payload on settlement,
+    //       then the deferred update handlers ran the synchronous upsert path.)
+    const finalCustomer = await waitFor(
+      async () => {
+        const c = await erp.findCustomerByCrmAccountId(account.id);
+        return c && c.legalName === lastRevName ? c : null;
+      },
+      {
+        timeoutMs: Timeouts.propagationMs,
+        description: `ERP customer reflects final update ${lastRevName} for session ${account.id}`,
+      },
+    );
+    expect(finalCustomer.legalName).toBe(lastRevName);
+
+    // No Failed/DeadLettered/Pending/Deferred should linger on this session.
+    const stuck = (await nimbus.searchEvents("ErpEndpoint", {
+      sessionId: account.id,
+      resolutionStatus: ["Failed", "Deferred", "DeadLettered", "Pending"],
+    })).filter((e) => e.sessionId === account.id);
+    expect.soft(stuck.length, "no lingering non-terminal audit rows").toBe(0);
+  });
+});

--- a/samples/CrmErpDemo/e2e/tests/05-pending-handoff-failure.spec.ts
+++ b/samples/CrmErpDemo/e2e/tests/05-pending-handoff-failure.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from "@playwright/test";
+import { CrmApiClient } from "../helpers/crm-api-client.js";
+import { ErpApiClient } from "../helpers/erp-api-client.js";
+import { NimBusApiClient, type NimBusEvent } from "../helpers/nimbus-api-client.js";
+import { Timeouts } from "../helpers/service-urls.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+/**
+ * PendingHandoff failure path.
+ *
+ * With handoff mode enabled at failureRate=1.0, every settlement tick
+ * picks a canned DMF-style error and calls IManagerClient.FailHandoff(...).
+ * The Resolver flips Pending → Failed; the session stays blocked until an
+ * operator clicks Skip (or Resubmit) in NimBus.WebApp.
+ *
+ * Verification:
+ *  1. Audit row reaches resolutionStatus=Failed with errorContent.errorText
+ *     starting with "DMF rejected:" (one of the canned strings produced by
+ *     HandoffJobBackgroundService).
+ *  2. Skip via NimBus REST flips the row to Skipped.
+ */
+test.describe("PendingHandoff failure: handoff fails → operator Skip → row reaches Skipped", () => {
+  let crm: CrmApiClient;
+  let erp: ErpApiClient;
+  let nimbus: NimBusApiClient;
+
+  test.beforeAll(async () => {
+    crm = await CrmApiClient.create();
+    erp = await ErpApiClient.create();
+    nimbus = await NimBusApiClient.create();
+    await erp.resetFailureModes();
+    await erp.resetHandoffMode();
+  });
+
+  test.afterEach(async () => {
+    await erp.resetHandoffMode();
+  });
+
+  test.afterAll(async () => {
+    await erp.resetFailureModes();
+    await erp.resetHandoffMode();
+    await crm.dispose();
+    await erp.dispose();
+    await nimbus.dispose();
+  });
+
+  test("create + handoff fails → audit Failed with DMF errorText → operator Skip → Skipped", async () => {
+    // ── 1. Force every handoff settlement to fail.
+    await erp.setHandoffMode({ enabled: true, durationSeconds: 3, failureRate: 1.0 });
+
+    // ── 2. Create one CRM account. Single-message scenario: no siblings.
+    const account = await crm.createAccount({
+      legalName: `Handoff-Fail-${Date.now()}`,
+      countryCode: "GB",
+    });
+
+    // ── 3. Wait for the audit row to reach Failed with the DMF errorText.
+    //       The window is ~3s (deadline) + 1s (BackgroundService tick) + slack
+    //       for the resolver write to land — covered by the polling timeout.
+    const failedEvent: NimBusEvent = await waitFor(
+      async () => {
+        const events = await nimbus.searchEvents("ErpEndpoint", {
+          sessionId: account.id,
+          eventTypeId: ["CrmAccountCreated"],
+          resolutionStatus: ["Failed"],
+        });
+        return events[0] ?? null;
+      },
+      {
+        timeoutMs: Timeouts.failedMessageMs,
+        description: `Failed CrmAccountCreated audit row for session ${account.id}`,
+      },
+    );
+    expect(failedEvent.eventId, "eventId").toBeTruthy();
+    expect(failedEvent.lastMessageId, "lastMessageId").toBeTruthy();
+    const errorText = failedEvent.messageContent?.errorContent?.errorText ?? "";
+    expect(errorText, "messageContent.errorContent.errorText").toMatch(/^DMF rejected:/);
+
+    // Sanity: ERP customer was NOT created (FailHandoff path skips the upsert).
+    expect(await erp.findCustomerByCrmAccountId(account.id)).toBeNull();
+
+    // ── 4. Operator triggers Skip via the NimBus REST API. The eventTypeId is
+    //       inferred server-side from the message; we just need eventId +
+    //       lastMessageId.
+    await nimbus.skipMessage(failedEvent.eventId, failedEvent.lastMessageId);
+
+    // ── 5. The audit row should flip to Skipped. The session unblocks; if any
+    //       sibling messages had been queued they would now drain — but we
+    //       intentionally created no siblings, so this just verifies the
+    //       Skipped terminal state.
+    await waitFor(
+      async () => {
+        const events = await nimbus.searchEvents("ErpEndpoint", {
+          sessionId: account.id,
+          eventTypeId: ["CrmAccountCreated"],
+          resolutionStatus: ["Skipped"],
+        });
+        return events.find((e) => e.eventId === failedEvent.eventId) ?? null;
+      },
+      {
+        timeoutMs: Timeouts.failedMessageMs,
+        description: `Audit row ${failedEvent.eventId} flips to Skipped after operator skip`,
+      },
+    );
+
+    // The Failed bucket for this event should be cleared.
+    const stillFailed = (await nimbus.searchEvents("ErpEndpoint", {
+      sessionId: account.id,
+      resolutionStatus: ["Failed"],
+    })).find((e) => e.eventId === failedEvent.eventId);
+    expect.soft(stillFailed, "event no longer in Failed bucket").toBeFalsy();
+  });
+});

--- a/src/NimBus.Core/Messages/Exceptions/HandoffFailedException.cs
+++ b/src/NimBus.Core/Messages/Exceptions/HandoffFailedException.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace NimBus.Core.Messages.Exceptions
+{
+    /// <summary>
+    /// Synthesised on the subscriber side when a HandoffFailedRequest is
+    /// received from the Manager. Carries the operator-supplied error text
+    /// (and optional error-type tag) so the existing error-response path can
+    /// flip the audit row Pending → Failed with the failure text preserved
+    /// verbatim. Never thrown by user code.
+    /// </summary>
+    public class HandoffFailedException : Exception
+    {
+        public HandoffFailedException(string message, string originalErrorType = null) : base(message)
+        {
+            OriginalErrorType = originalErrorType;
+        }
+
+        /// <summary>
+        /// Optional error-type tag supplied by the Manager via
+        /// <c>ErrorContent.ErrorType</c>. Preserved on the exception for
+        /// observability; not currently round-tripped to the response.
+        /// </summary>
+        public string OriginalErrorType { get; }
+    }
+}

--- a/src/NimBus.Core/Messages/HandlerOutcome.cs
+++ b/src/NimBus.Core/Messages/HandlerOutcome.cs
@@ -1,0 +1,17 @@
+namespace NimBus.Core.Messages
+{
+    /// <summary>
+    /// Outcome signalled by an event handler. <see cref="Default"/> means the
+    /// handler completed normally and the subscriber will send a
+    /// ResolutionResponse. <see cref="PendingHandoff"/> is signalled via
+    /// <c>IEventHandlerContext.MarkPendingHandoff</c> when work has been
+    /// handed off to a long-running external system; the subscriber sends a
+    /// PendingHandoffResponse and blocks the session until the Manager
+    /// settles it via CompleteHandoff or FailHandoff.
+    /// </summary>
+    public enum HandlerOutcome
+    {
+        Default = 0,
+        PendingHandoff = 1
+    }
+}

--- a/src/NimBus.Core/Messages/HandoffMetadata.cs
+++ b/src/NimBus.Core/Messages/HandoffMetadata.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace NimBus.Core.Messages
+{
+    /// <summary>
+    /// Metadata supplied by the handler when signalling
+    /// <see cref="HandlerOutcome.PendingHandoff"/>. <paramref name="ExpectedBy"/>
+    /// is a duration; the subscriber converts it to an absolute UTC deadline
+    /// when constructing the outgoing PendingHandoffResponse.
+    /// </summary>
+    public sealed record HandoffMetadata(string Reason, string ExternalJobId, TimeSpan? ExpectedBy);
+}

--- a/src/NimBus.Core/Messages/IMessageContext.cs
+++ b/src/NimBus.Core/Messages/IMessageContext.cs
@@ -13,6 +13,9 @@ namespace NimBus.Core.Messages
         new string EventTypeId { get; }
         new string DeadLetterReason { get; }
         new string DeadLetterErrorDescription { get; }
+        new string HandoffReason { get; }
+        new string ExternalJobId { get; }
+        new DateTime? ExpectedBy { get; }
     }
 
     public interface IMessageContext : IReceivedMessage

--- a/src/NimBus.Core/Messages/IMessageContext.cs
+++ b/src/NimBus.Core/Messages/IMessageContext.cs
@@ -112,5 +112,23 @@ namespace NimBus.Core.Messages
         /// <see cref="ProcessingTimeMs"/>.
         /// </summary>
         DateTime? HandlerStartedAtUtc { get; set; }
+
+        /// <summary>
+        /// Outcome signalled by the handler via
+        /// <c>IEventHandlerContext.MarkPendingHandoff</c>. Defaults to
+        /// <see cref="HandlerOutcome.Default"/>; flips to
+        /// <see cref="HandlerOutcome.PendingHandoff"/> when the handler hands
+        /// work off to a long-running external system. Read by
+        /// <c>StrictMessageHandler</c> after the handler returns to decide
+        /// whether to send a PendingHandoffResponse and block the session.
+        /// </summary>
+        HandlerOutcome HandlerOutcome { get; set; }
+
+        /// <summary>
+        /// Metadata supplied by the handler alongside
+        /// <see cref="HandlerOutcome.PendingHandoff"/>. Null when
+        /// <see cref="HandlerOutcome"/> is <see cref="HandlerOutcome.Default"/>.
+        /// </summary>
+        HandoffMetadata HandoffMetadata { get; set; }
     }
 }

--- a/src/NimBus.Core/Messages/IResponseService.cs
+++ b/src/NimBus.Core/Messages/IResponseService.cs
@@ -32,5 +32,14 @@ namespace NimBus.Core.Messages
         /// Called when a session is unblocked and there are deferred messages to process.
         /// </summary>
         Task SendProcessDeferredRequest(IMessageContext messageContext, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Notifies the Resolver that the handler signalled
+        /// <c>HandlerOutcome.PendingHandoff</c>. Carries the supplied
+        /// <see cref="HandoffMetadata"/> on the response message; the
+        /// <c>ExpectedBy</c> duration is converted to an absolute UTC
+        /// deadline at send time.
+        /// </summary>
+        Task SendPendingHandoffResponse(IMessageContext messageContext, HandoffMetadata handoff, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NimBus.Core/Messages/MessageHandler.cs
+++ b/src/NimBus.Core/Messages/MessageHandler.cs
@@ -189,6 +189,12 @@ namespace NimBus.Core.Messages
                 case MessageType.ResubmissionRequest:
                     return HandleResubmissionRequest(messageContext, cancellationToken);
 
+                case MessageType.HandoffCompletedRequest:
+                    return HandleHandoffCompletedRequest(messageContext, cancellationToken);
+
+                case MessageType.HandoffFailedRequest:
+                    return HandleHandoffFailedRequest(messageContext, cancellationToken);
+
                 case MessageType.RetryRequest:
                     return HandleRetryRequest(messageContext, cancellationToken);
 
@@ -237,6 +243,12 @@ namespace NimBus.Core.Messages
             HandleDefault(messageContext, cancellationToken);
 
         public virtual Task HandleProcessDeferredRequest(IMessageContext messageContext, CancellationToken cancellationToken = default) =>
+            HandleDefault(messageContext, cancellationToken);
+
+        public virtual Task HandleHandoffCompletedRequest(IMessageContext messageContext, CancellationToken cancellationToken = default) =>
+            HandleDefault(messageContext, cancellationToken);
+
+        public virtual Task HandleHandoffFailedRequest(IMessageContext messageContext, CancellationToken cancellationToken = default) =>
             HandleDefault(messageContext, cancellationToken);
     }
 }

--- a/src/NimBus.Core/Messages/Models/Message.cs
+++ b/src/NimBus.Core/Messages/Models/Message.cs
@@ -1,4 +1,6 @@
-﻿namespace NimBus.Core.Messages
+﻿using System;
+
+namespace NimBus.Core.Messages
 {
     public interface IMessage
     {
@@ -87,6 +89,28 @@
         /// the audit record as DeadLettered.
         /// </summary>
         string DeadLetterErrorDescription => null;
+
+        /// <summary>
+        /// Free-text reason supplied by an event handler when it signals
+        /// PendingHandoff via <c>IEventHandlerContext.MarkPendingHandoff</c>.
+        /// Carried on <see cref="MessageType.PendingHandoffResponse"/> to the
+        /// Resolver for audit-row enrichment.
+        /// </summary>
+        string HandoffReason => null;
+
+        /// <summary>
+        /// Optional external-system identifier (e.g. a D365 F&O DMF job id)
+        /// for messages awaiting completion of long-running external work.
+        /// Carried alongside <see cref="HandoffReason"/>.
+        /// </summary>
+        string ExternalJobId => null;
+
+        /// <summary>
+        /// Optional UTC deadline by which the external work is expected to
+        /// settle. Used by the optional Resolver-side timeout sweeper. Null
+        /// means no deadline (operator manages indefinitely).
+        /// </summary>
+        DateTime? ExpectedBy => null;
     }
 
     public class Message : IMessage
@@ -121,5 +145,8 @@
         public long? ProcessingTimeMs { get; set; }
         public string DeadLetterReason { get; set; }
         public string DeadLetterErrorDescription { get; set; }
+        public string HandoffReason { get; set; }
+        public string ExternalJobId { get; set; }
+        public DateTime? ExpectedBy { get; set; }
     }
 }

--- a/src/NimBus.Core/Messages/Models/MessageType.cs
+++ b/src/NimBus.Core/Messages/Models/MessageType.cs
@@ -20,6 +20,16 @@
 
         HeartbeatResponse,
 
-        ProcessDeferredRequest
+        ProcessDeferredRequest,
+
+        // Async-completion / PendingHandoff control flow.
+        // PendingHandoffResponse: subscriber → Resolver, signals the message is
+        // settled but the work is in flight on an external system.
+        // HandoffCompletedRequest / HandoffFailedRequest: Manager → subscriber,
+        // drive the Pending → Completed / Failed transition without re-invoking
+        // the user handler.
+        PendingHandoffResponse,
+        HandoffCompletedRequest,
+        HandoffFailedRequest
     }
 }

--- a/src/NimBus.Core/Messages/ResponseService.cs
+++ b/src/NimBus.Core/Messages/ResponseService.cs
@@ -55,6 +55,17 @@ namespace NimBus.Core.Messages
             await _sender.Send(response, cancellationToken: cancellationToken);
         }
 
+        public async Task SendPendingHandoffResponse(IMessageContext messageContext, HandoffMetadata handoff, CancellationToken cancellationToken = default)
+        {
+            var response = (Message)CreateResponse(messageContext, MessageType.PendingHandoffResponse, messageContext.MessageContent);
+            response.HandoffReason = handoff?.Reason;
+            response.ExternalJobId = handoff?.ExternalJobId;
+            response.ExpectedBy = handoff?.ExpectedBy.HasValue == true
+                ? DateTime.UtcNow.Add(handoff.ExpectedBy.Value)
+                : (DateTime?)null;
+            await _sender.Send(response, cancellationToken: cancellationToken);
+        }
+
         public async Task SendRetryResponse(IMessageContext messageContext, int messageDelayMinutes, CancellationToken cancellationToken = default)
         {
             IMessage response = CreateRetryResponse(messageContext, MessageType.RetryRequest, responseContent: messageContext.MessageContent);

--- a/src/NimBus.Core/Messages/StrictMessageHandler.cs
+++ b/src/NimBus.Core/Messages/StrictMessageHandler.cs
@@ -66,6 +66,21 @@ namespace NimBus.Core.Messages
                 {
                     await VerifySessionIsNotBlocked(messageContext, cancellationToken);
                     await HandleEventContent(messageContext, cancellationToken);
+
+                    // PendingHandoff branch — handler handed off to an external system.
+                    // Send PendingHandoffResponse, block the session so siblings defer
+                    // until the Manager settles via CompleteHandoff / FailHandoff, and
+                    // skip the usual ResolutionResponse. If HandleEventContent threw,
+                    // execution never reaches here — the catch branches below own it.
+                    if (messageContext.HandlerOutcome == HandlerOutcome.PendingHandoff)
+                    {
+                        await _responseService.SendPendingHandoffResponse(messageContext, messageContext.HandoffMetadata, cancellationToken);
+                        await BlockSession(messageContext, cancellationToken);
+                        await CompleteMessage(messageContext, cancellationToken);
+                        LogInfo(messageContext, "Successfully processed (PendingHandoff)");
+                        return;
+                    }
+
                     await SendResolutionResponse(messageContext, cancellationToken);
                 }
                 await CompleteMessage(messageContext, cancellationToken);
@@ -170,6 +185,35 @@ namespace NimBus.Core.Messages
             }
 
             LogInfo(messageContext, "Successfully processed (Skip)");
+        }
+
+        public override async Task HandleHandoffCompletedRequest(IMessageContext messageContext, CancellationToken cancellationToken = default)
+        {
+            LogInfo(messageContext, "Handle (HandoffCompleted)");
+            AuthorizeManagerRequest(messageContext);
+            await VerifySessionIsBlockedByThis(messageContext, cancellationToken);
+            await UnblockSession(messageContext, cancellationToken);
+            await ContinueWithAnyDeferredMessages(messageContext, cancellationToken);
+            // Existing ResolutionResponse path flips Pending → Completed on the
+            // original audit row. The user handler is intentionally NOT invoked.
+            await SendResolutionResponse(messageContext, cancellationToken);
+            await CompleteMessage(messageContext, cancellationToken);
+            LogInfo(messageContext, "Successfully processed (HandoffCompleted)");
+        }
+
+        public override async Task HandleHandoffFailedRequest(IMessageContext messageContext, CancellationToken cancellationToken = default)
+        {
+            LogInfo(messageContext, "Handle (HandoffFailed)");
+            AuthorizeManagerRequest(messageContext);
+            await VerifySessionIsBlockedByThis(messageContext, cancellationToken);
+            // Synthesise an exception from the inbound ErrorContent so the existing
+            // SendErrorResponse path flips the audit row Pending → Failed with the
+            // operator-supplied error text preserved verbatim. Session stays
+            // blocked — the operator decides Resubmit / Skip from the WebApp.
+            var handoffError = BuildHandoffError(messageContext);
+            await SendErrorResponse(messageContext, handoffError, cancellationToken);
+            await CompleteMessage(messageContext, cancellationToken);
+            LogInfo(messageContext, "Successfully processed (HandoffFailed)");
         }
 
         public override async Task HandleContinuationRequest(IMessageContext messageContext, CancellationToken cancellationToken = default)
@@ -354,6 +398,21 @@ namespace NimBus.Core.Messages
                 await SendRetryResponse(messageContext, retryDefinition.RetryDelay, cancellationToken);
             }
 #pragma warning restore CS0618
+        }
+
+        // HandoffFailedRequest carries errorText/errorType in
+        // MessageContent.ErrorContent. Wrap them in a synthetic
+        // EventContextHandlerException so the existing SendErrorResponse path
+        // produces a response whose ErrorText preserves the operator-supplied
+        // text verbatim. ErrorType is not round-tripped through this exception
+        // shape — the response's ErrorType reflects the synthetic wrapper, not
+        // the operator-supplied errorType.
+        private static EventContextHandlerException BuildHandoffError(IMessageContext messageContext)
+        {
+            var errorContent = messageContext?.MessageContent?.ErrorContent;
+            var errorText = errorContent?.ErrorText ?? "Handoff failed.";
+            var inner = new HandoffFailedException(errorText, errorContent?.ErrorType);
+            return new EventContextHandlerException(inner);
         }
 
         private void LogInfo(IMessageContext messageContext, string prefixMessage)

--- a/src/NimBus.Core/Messages/UserPropertyName.cs
+++ b/src/NimBus.Core/Messages/UserPropertyName.cs
@@ -18,5 +18,8 @@
         DeferralSequence,
         QueueTimeMs,
         ProcessingTimeMs,
+        HandoffReason,
+        ExternalJobId,
+        ExpectedBy,
     }
 }

--- a/src/NimBus.Manager/ManagerClient.cs
+++ b/src/NimBus.Manager/ManagerClient.cs
@@ -25,6 +25,29 @@ public interface IManagerClient
     /// </summary>
     /// <param name="errorResponse">ErrorResponse received from endpoint, representing the error that needs to be resolved.</param>
     Task Skip(MessageEntity errorResponse, string endpoint, string eventTypeId);
+
+    /// <summary>
+    /// Drive a Pending → Completed transition for a message currently parked in the
+    /// PendingHandoff state. The subscriber acknowledges the request without re-invoking
+    /// the user handler.
+    /// </summary>
+    /// <param name="pendingEntry">The pending audit entry that was projected from a PendingHandoffResponse.</param>
+    /// <param name="endpoint">The subscriber endpoint that owns the pending message.</param>
+    /// <param name="detailsJson">Optional JSON payload describing the completion result; carried in MessageContent.EventContent.EventJson.</param>
+    /// <exception cref="InvalidOperationException">Thrown when <paramref name="pendingEntry"/> is not in the PendingHandoff sub-status.</exception>
+    Task CompleteHandoff(MessageEntity pendingEntry, string endpoint, string detailsJson = null);
+
+    /// <summary>
+    /// Drive a Pending → Failed transition for a message currently parked in the
+    /// PendingHandoff state. The supplied error text is surfaced to the subscriber's
+    /// HandleHandoffFailedRequest via MessageContent.ErrorContent.
+    /// </summary>
+    /// <param name="pendingEntry">The pending audit entry that was projected from a PendingHandoffResponse.</param>
+    /// <param name="endpoint">The subscriber endpoint that owns the pending message.</param>
+    /// <param name="errorText">Human-readable error text describing the failure.</param>
+    /// <param name="errorType">Optional logical error type / classifier.</param>
+    /// <exception cref="InvalidOperationException">Thrown when <paramref name="pendingEntry"/> is not in the PendingHandoff sub-status.</exception>
+    Task FailHandoff(MessageEntity pendingEntry, string endpoint, string errorText, string errorType = null);
 }
 
 public class ManagerClient : IManagerClient
@@ -81,6 +104,73 @@ public class ManagerClient : IManagerClient
             ParentMessageId = errorResponse.MessageId,
             EventTypeId = eventTypeId,
             OriginatingMessageId = errorResponse.OriginatingMessageId ?? errorResponse.MessageId
+        };
+
+        await using var sender = _serviceBusClient.CreateSender(endpoint);
+        await sender.SendMessageAsync(MessageHelper.ToServiceBusMessage(message));
+    }
+
+    public async Task CompleteHandoff(MessageEntity pendingEntry, string endpoint, string detailsJson = null)
+    {
+        if (pendingEntry.PendingSubStatus != "Handoff")
+            throw new InvalidOperationException($"CompleteHandoff requires PendingSubStatus='Handoff'; got '{pendingEntry.PendingSubStatus ?? "<null>"}' for EventId={pendingEntry.EventId}.");
+
+        _logger?.Verbose($"MANAGER COMPLETE HANDOFF: SessionId: {pendingEntry.SessionId} EventId: {pendingEntry.EventId} Endpoint: {endpoint} ");
+
+        var messageContent = new MessageContent();
+        if (!string.IsNullOrEmpty(detailsJson))
+        {
+            messageContent.EventContent = new EventContent
+            {
+                EventTypeId = pendingEntry.EventTypeId,
+                EventJson = detailsJson,
+            };
+        }
+
+        var message = new Message
+        {
+            CorrelationId = pendingEntry.CorrelationId,
+            EventId = pendingEntry.EventId,
+            SessionId = pendingEntry.SessionId,
+            To = endpoint,
+            From = Constants.ManagerId,
+            OriginatingMessageId = pendingEntry.OriginatingMessageId ?? pendingEntry.MessageId,
+            ParentMessageId = pendingEntry.MessageId,
+            MessageType = MessageType.HandoffCompletedRequest,
+            EventTypeId = pendingEntry.EventTypeId,
+            MessageContent = messageContent,
+        };
+
+        await using var sender = _serviceBusClient.CreateSender(endpoint);
+        await sender.SendMessageAsync(MessageHelper.ToServiceBusMessage(message));
+    }
+
+    public async Task FailHandoff(MessageEntity pendingEntry, string endpoint, string errorText, string errorType = null)
+    {
+        if (pendingEntry.PendingSubStatus != "Handoff")
+            throw new InvalidOperationException($"FailHandoff requires PendingSubStatus='Handoff'; got '{pendingEntry.PendingSubStatus ?? "<null>"}' for EventId={pendingEntry.EventId}.");
+
+        _logger?.Verbose($"MANAGER FAIL HANDOFF: SessionId: {pendingEntry.SessionId} EventId: {pendingEntry.EventId} Endpoint: {endpoint} ErrorType: {errorType} ");
+
+        var message = new Message
+        {
+            CorrelationId = pendingEntry.CorrelationId,
+            EventId = pendingEntry.EventId,
+            SessionId = pendingEntry.SessionId,
+            To = endpoint,
+            From = Constants.ManagerId,
+            OriginatingMessageId = pendingEntry.OriginatingMessageId ?? pendingEntry.MessageId,
+            ParentMessageId = pendingEntry.MessageId,
+            MessageType = MessageType.HandoffFailedRequest,
+            EventTypeId = pendingEntry.EventTypeId,
+            MessageContent = new MessageContent
+            {
+                ErrorContent = new ErrorContent
+                {
+                    ErrorText = errorText,
+                    ErrorType = errorType,
+                },
+            },
         };
 
         await using var sender = _serviceBusClient.CreateSender(endpoint);

--- a/src/NimBus.MessageStore.Abstractions/MessageEntity.cs
+++ b/src/NimBus.MessageStore.Abstractions/MessageEntity.cs
@@ -46,4 +46,11 @@ public class MessageEntity : IReceivedMessage
     public int? DeferralSequence { get; set; }
     public long? QueueTimeMs { get; set; }
     public long? ProcessingTimeMs { get; set; }
+
+    // PendingHandoff sub-status discriminator. null for ordinary Pending entries;
+    // "Handoff" when the audit row was projected from a PendingHandoffResponse.
+    public string PendingSubStatus { get; set; }
+    public string HandoffReason { get; set; }
+    public string ExternalJobId { get; set; }
+    public DateTime? ExpectedBy { get; set; }
 }

--- a/src/NimBus.MessageStore.Abstractions/States/UnresolvedEvent.cs
+++ b/src/NimBus.MessageStore.Abstractions/States/UnresolvedEvent.cs
@@ -48,5 +48,14 @@ namespace NimBus.MessageStore
         // documents written before this field existed deserialize as null.
         public long? QueueTimeMs { get; set; }
         public long? ProcessingTimeMs { get; set; }
+
+        // PendingHandoff sub-status discriminator. null for ordinary Pending
+        // entries; "Handoff" when the row was projected from a
+        // PendingHandoffResponse so the WebApp can render an "Awaiting external"
+        // badge without changing the ResolutionStatus enum.
+        public string PendingSubStatus { get; set; }
+        public string HandoffReason { get; set; }
+        public string ExternalJobId { get; set; }
+        public DateTime? ExpectedBy { get; set; }
     }
 }

--- a/src/NimBus.MessageStore.SqlServer/Schema/0009_Handoff.sql
+++ b/src/NimBus.MessageStore.SqlServer/Schema/0009_Handoff.sql
@@ -1,0 +1,13 @@
+-- Async-completion / PendingHandoff sub-status fields. All nullable so existing
+-- rows project unchanged: legacy Pending entries report PendingSubStatus=NULL,
+-- new entries projected from PendingHandoffResponse report 'Handoff' plus the
+-- handler-supplied metadata. Spec: docs/specs/002-async-message-completion.
+IF COL_LENGTH('[$schema$].[UnresolvedEvents]', 'PendingSubStatus') IS NULL
+BEGIN
+    ALTER TABLE [$schema$].[UnresolvedEvents] ADD
+        [PendingSubStatus]  NVARCHAR(50)   NULL,
+        [HandoffReason]     NVARCHAR(MAX)  NULL,
+        [ExternalJobId]     NVARCHAR(500)  NULL,
+        [ExpectedBy]        DATETIME2      NULL;
+END
+GO

--- a/src/NimBus.MessageStore.SqlServer/SqlServerMessageStore.cs
+++ b/src/NimBus.MessageStore.SqlServer/SqlServerMessageStore.cs
@@ -101,18 +101,26 @@ WHEN MATCHED THEN UPDATE SET
     FromAddress = @FromAddress,
     QueueTimeMs = @QueueTimeMs,
     ProcessingTimeMs = @ProcessingTimeMs,
+    PendingSubStatus = @PendingSubStatus,
+    HandoffReason = @HandoffReason,
+    ExternalJobId = @ExternalJobId,
+    ExpectedBy = @ExpectedBy,
     MessageContentJson = @MessageContentJson,
     Deleted = 0
 WHEN NOT MATCHED THEN INSERT (
     EventId, SessionId, EndpointId, Status, UpdatedAtUtc, EnqueuedTimeUtc, CorrelationId, EndpointRole,
     MessageType, RetryCount, RetryLimit, LastMessageId, OriginatingMessageId, ParentMessageId,
     OriginatingFrom, Reason, DeadLetterReason, DeadLetterErrorDescription, EventTypeId,
-    ToAddress, FromAddress, QueueTimeMs, ProcessingTimeMs, MessageContentJson)
+    ToAddress, FromAddress, QueueTimeMs, ProcessingTimeMs,
+    PendingSubStatus, HandoffReason, ExternalJobId, ExpectedBy,
+    MessageContentJson)
 VALUES (
     @EventId, @SessionId, @EndpointId, @Status, @UpdatedAt, @EnqueuedTimeUtc, @CorrelationId, @EndpointRole,
     @MessageType, @RetryCount, @RetryLimit, @LastMessageId, @OriginatingMessageId, @ParentMessageId,
     @OriginatingFrom, @Reason, @DeadLetterReason, @DeadLetterErrorDescription, @EventTypeId,
-    @ToAddress, @FromAddress, @QueueTimeMs, @ProcessingTimeMs, @MessageContentJson);";
+    @ToAddress, @FromAddress, @QueueTimeMs, @ProcessingTimeMs,
+    @PendingSubStatus, @HandoffReason, @ExternalJobId, @ExpectedBy,
+    @MessageContentJson);";
 
         await using var conn = Open();
         var rows = await conn.ExecuteAsync(sql, new
@@ -140,6 +148,10 @@ VALUES (
             FromAddress = content.From,
             QueueTimeMs = content.QueueTimeMs,
             ProcessingTimeMs = content.ProcessingTimeMs,
+            PendingSubStatus = content.PendingSubStatus,
+            HandoffReason = content.HandoffReason,
+            ExternalJobId = content.ExternalJobId,
+            ExpectedBy = content.ExpectedBy,
             MessageContentJson = JsonConvert.SerializeObject(content.MessageContent),
         }, commandTimeout: _commandTimeout);
 
@@ -667,10 +679,30 @@ OFFSET @Offset ROWS FETCH NEXT @PageSize ROWS ONLY";
             From = row.FromAddress ?? string.Empty,
             QueueTimeMs = row.QueueTimeMs,
             ProcessingTimeMs = row.ProcessingTimeMs,
+            PendingSubStatus = TryReadString(row, "PendingSubStatus"),
+            HandoffReason = TryReadString(row, "HandoffReason"),
+            ExternalJobId = TryReadString(row, "ExternalJobId"),
+            ExpectedBy = TryReadDateTime(row, "ExpectedBy"),
             MessageContent = string.IsNullOrEmpty((string?)row.MessageContentJson)
                 ? new MessageContent()
                 : JsonConvert.DeserializeObject<MessageContent>((string)row.MessageContentJson) ?? new MessageContent(),
         };
+    }
+
+    // Dapper exposes rows as DapperRow, which is dictionary-like. Reading a column that
+    // does not exist throws — guard with the dictionary view so old rows / older callers
+    // don't break when the new nullable columns aren't projected.
+    private static string TryReadString(dynamic row, string columnName)
+    {
+        var dict = (IDictionary<string, object>)row;
+        return dict.TryGetValue(columnName, out var value) ? value as string : null;
+    }
+
+    private static DateTime? TryReadDateTime(dynamic row, string columnName)
+    {
+        var dict = (IDictionary<string, object>)row;
+        if (!dict.TryGetValue(columnName, out var value) || value is null) return null;
+        return value is DateTime dt ? dt : (DateTime?)null;
     }
 
     // ───────── Lifecycle / cleanup ─────────

--- a/src/NimBus.Resolver/Services/ResolverService.cs
+++ b/src/NimBus.Resolver/Services/ResolverService.cs
@@ -27,6 +27,13 @@ namespace NimBus.Broker.Services
             [MessageType.RetryRequest] = ResolutionStatus.Pending,
             [MessageType.SkipRequest] = ResolutionStatus.Pending,
             [MessageType.ContinuationRequest] = ResolutionStatus.Pending,
+            // PendingHandoff control flow. The response from the subscriber records
+            // the audit row as Pending+Handoff; the two Manager-issued requests are
+            // recorded as Pending audit rows that flip when their resulting
+            // ResolutionResponse / ErrorResponse arrive (via the existing path).
+            [MessageType.PendingHandoffResponse] = ResolutionStatus.Pending,
+            [MessageType.HandoffCompletedRequest] = ResolutionStatus.Pending,
+            [MessageType.HandoffFailedRequest] = ResolutionStatus.Pending,
             [MessageType.ErrorResponse] = ResolutionStatus.Failed,
             [MessageType.ResolutionResponse] = ResolutionStatus.Completed,
             [MessageType.DeferralResponse] = ResolutionStatus.Deferred,
@@ -158,6 +165,15 @@ namespace NimBus.Broker.Services
                 // subscriber. Null on EventRequest / original publishes.
                 QueueTimeMs = message.QueueTimeMs,
                 ProcessingTimeMs = message.ProcessingTimeMs,
+                // PendingHandoff metadata. Sub-status is set only on the
+                // PendingHandoffResponse audit row (the original Pending+Handoff
+                // entry); the Manager-issued HandoffCompleted/HandoffFailed
+                // requests are recorded as plain Pending so the subsequent
+                // ResolutionResponse / ErrorResponse can flip the original.
+                HandoffReason = message.HandoffReason,
+                ExternalJobId = message.ExternalJobId,
+                ExpectedBy = message.ExpectedBy,
+                PendingSubStatus = message.MessageType == MessageType.PendingHandoffResponse ? "Handoff" : null,
             };
         }
 
@@ -181,7 +197,9 @@ namespace NimBus.Broker.Services
                      message.MessageType == MessageType.ContinuationRequest ||
                      message.MessageType == MessageType.RetryRequest ||
                      message.MessageType == MessageType.ResubmissionRequest ||
-                     message.MessageType == MessageType.SkipRequest)
+                     message.MessageType == MessageType.SkipRequest ||
+                     message.MessageType == MessageType.HandoffCompletedRequest ||
+                     message.MessageType == MessageType.HandoffFailedRequest)
             {
                 endpointId = message.To;
             }
@@ -226,6 +244,13 @@ namespace NimBus.Broker.Services
                 MessageContent = message.MessageContent,
                 QueueTimeMs = message.QueueTimeMs,
                 ProcessingTimeMs = message.ProcessingTimeMs,
+                // PendingHandoff metadata: copy through from the projected
+                // MessageEntity so the UnresolvedEvent (i.e. the audit row
+                // surfaced by the WebApp) carries them too.
+                PendingSubStatus = message.PendingSubStatus,
+                HandoffReason = message.HandoffReason,
+                ExternalJobId = message.ExternalJobId,
+                ExpectedBy = message.ExpectedBy,
             };
         }
 

--- a/src/NimBus.SDK/EventHandlers/EventJsonHandler.cs
+++ b/src/NimBus.SDK/EventHandlers/EventJsonHandler.cs
@@ -20,7 +20,13 @@ namespace NimBus.SDK.EventHandlers
         public Task Handle(IMessageContext context, CancellationToken cancellationToken = default)
         {
             var @event = JsonConvert.DeserializeObject<T_Event>(context.MessageContent.EventContent.EventJson);
-            var eventHandlercontext = new EventHandlerContext { CorrelationId = context.CorrelationId, EventId = context.EventId, EventType = context.MessageContent.EventContent.EventTypeId };
+            var eventHandlercontext = new EventHandlerContext(context)
+            {
+                CorrelationId = context.CorrelationId,
+                EventId = context.EventId,
+                EventType = context.MessageContent.EventContent.EventTypeId,
+                MessageId = context.MessageId,
+            };
             return _eventHandler.Handle(@event, eventHandlercontext, cancellationToken);
         }
     }

--- a/src/NimBus.SDK/EventHandlers/IEventHandlerContext.cs
+++ b/src/NimBus.SDK/EventHandlers/IEventHandlerContext.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System;
+using NimBus.Core.Messages;
 
 namespace NimBus.SDK.EventHandlers
 {
     public interface IEventHandlerContext
-    {   /// <summary>
+    {
+        /// <summary>
         /// The Id of the currently processed message.
         /// </summary>
         string MessageId { get; }
@@ -15,10 +15,48 @@ namespace NimBus.SDK.EventHandlers
         string EventType { get; }
 
         string CorrelationId { get; }
+
+        /// <summary>
+        /// The outcome signalled by the handler. Defaults to
+        /// <see cref="HandlerOutcome.Default"/>; flips to
+        /// <see cref="HandlerOutcome.PendingHandoff"/> after
+        /// <see cref="MarkPendingHandoff"/> is called.
+        /// </summary>
+        HandlerOutcome Outcome { get; }
+
+        /// <summary>
+        /// Metadata supplied by the handler via <see cref="MarkPendingHandoff"/>.
+        /// Null when <see cref="Outcome"/> is <see cref="HandlerOutcome.Default"/>.
+        /// </summary>
+        HandoffMetadata HandoffMetadata { get; }
+
+        /// <summary>
+        /// Signals that the handler has handed work off to a long-running
+        /// external system. The subscriber will send a PendingHandoffResponse
+        /// to the Resolver and block the session until the Manager settles
+        /// the message via CompleteHandoff or FailHandoff. Idempotent — if
+        /// called multiple times, the last call wins.
+        /// </summary>
+        /// <param name="reason">Free-text reason describing why the handler is handing off (required).</param>
+        /// <param name="externalJobId">Optional external-system identifier (e.g. a DMF job id).</param>
+        /// <param name="expectedBy">Optional duration after which the work is expected to settle.</param>
+        void MarkPendingHandoff(string reason, string externalJobId = null, TimeSpan? expectedBy = null);
     }
 
     public class EventHandlerContext : IEventHandlerContext
-    {   /// <summary>
+    {
+        private readonly IMessageContext _messageContext;
+
+        public EventHandlerContext()
+        {
+        }
+
+        public EventHandlerContext(IMessageContext messageContext)
+        {
+            _messageContext = messageContext;
+        }
+
+        /// <summary>
         /// The Id of the currently processed message.
         /// </summary>
         public string MessageId { get; set; }
@@ -28,5 +66,21 @@ namespace NimBus.SDK.EventHandlers
         public string EventType { get; set; }
 
         public string CorrelationId { get; set; }
+
+        public HandlerOutcome Outcome { get; private set; }
+
+        public HandoffMetadata HandoffMetadata { get; private set; }
+
+        public void MarkPendingHandoff(string reason, string externalJobId = null, TimeSpan? expectedBy = null)
+        {
+            Outcome = HandlerOutcome.PendingHandoff;
+            HandoffMetadata = new HandoffMetadata(reason, externalJobId, expectedBy);
+
+            if (_messageContext != null)
+            {
+                _messageContext.HandlerOutcome = HandlerOutcome.PendingHandoff;
+                _messageContext.HandoffMetadata = HandoffMetadata;
+            }
+        }
     }
 }

--- a/src/NimBus.ServiceBus/MessageContext.cs
+++ b/src/NimBus.ServiceBus/MessageContext.cs
@@ -53,6 +53,33 @@ namespace NimBus.ServiceBus
             get { try { return GetUserProperty(UserPropertyName.DeadLetterErrorDescription); } catch (InvalidMessageException) { return null; } }
         }
 
+        public string HandoffReason
+        {
+            get { try { return GetUserProperty(UserPropertyName.HandoffReason); } catch (InvalidMessageException) { return null; } }
+        }
+
+        public string ExternalJobId
+        {
+            get { try { return GetUserProperty(UserPropertyName.ExternalJobId); } catch (InvalidMessageException) { return null; } }
+        }
+
+        public DateTime? ExpectedBy
+        {
+            get
+            {
+                try
+                {
+                    var value = GetUserProperty(UserPropertyName.ExpectedBy);
+                    if (string.IsNullOrEmpty(value)) return null;
+                    return DateTime.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed)
+                        ? parsed
+                        : (DateTime?)null;
+                }
+                catch (InvalidMessageException) { return null; }
+                catch (FormatException) { return null; }
+            }
+        }
+
         public string OriginatingMessageId => _sbMessage.GetUserProperty(UserPropertyName.OriginatingMessageId) ?? Constants.Self;
 
         public string ParentMessageId => _sbMessage.GetUserProperty(UserPropertyName.ParentMessageId) ?? Constants.Self;

--- a/src/NimBus.ServiceBus/MessageContext.cs
+++ b/src/NimBus.ServiceBus/MessageContext.cs
@@ -157,6 +157,10 @@ namespace NimBus.ServiceBus
 
         public DateTime? HandlerStartedAtUtc { get; set; }
 
+        public HandlerOutcome HandlerOutcome { get; set; }
+
+        public HandoffMetadata HandoffMetadata { get; set; }
+
         private long? TryReadLong(UserPropertyName name)
         {
             try

--- a/src/NimBus.ServiceBus/MessageHelper.cs
+++ b/src/NimBus.ServiceBus/MessageHelper.cs
@@ -57,6 +57,22 @@ namespace NimBus.ServiceBus
                 result.ApplicationProperties[UserPropertyName.DeadLetterErrorDescription.ToString()] = message.DeadLetterErrorDescription;
             }
 
+            // PendingHandoff metadata: carried on the PendingHandoffResponse to the
+            // Resolver so the audit row records reason / external job id / deadline.
+            if (!string.IsNullOrEmpty(message.HandoffReason))
+            {
+                result.ApplicationProperties[UserPropertyName.HandoffReason.ToString()] = message.HandoffReason;
+            }
+            if (!string.IsNullOrEmpty(message.ExternalJobId))
+            {
+                result.ApplicationProperties[UserPropertyName.ExternalJobId.ToString()] = message.ExternalJobId;
+            }
+            if (message.ExpectedBy.HasValue)
+            {
+                result.ApplicationProperties[UserPropertyName.ExpectedBy.ToString()] =
+                    message.ExpectedBy.Value.ToUniversalTime().ToString("o", System.Globalization.CultureInfo.InvariantCulture);
+            }
+
             var diagnosticId = message.DiagnosticId ?? Activity.Current?.Id;
             if (!string.IsNullOrEmpty(diagnosticId))
                 result.ApplicationProperties[NimBusDiagnostics.DiagnosticIdProperty] = diagnosticId;

--- a/src/NimBus.Testing/Conformance/MessageTrackingStoreConformanceTests.cs
+++ b/src/NimBus.Testing/Conformance/MessageTrackingStoreConformanceTests.cs
@@ -392,6 +392,33 @@ public abstract class MessageTrackingStoreConformanceTests
     }
 
     [TestMethod]
+    public async Task PendingHandoff_fields_round_trip()
+    {
+        var store = CreateStore();
+        var endpointId = Id("ep-handoff");
+        var eventId = Id("handoff-1");
+        var sessionId = "session-handoff";
+        var expectedBy = new DateTime(2026, 06, 01, 09, 00, 00, DateTimeKind.Utc);
+
+        var sample = SampleEvent(endpointId, eventId, sessionId);
+        sample.MessageType = MessageType.PendingHandoffResponse;
+        sample.PendingSubStatus = "Handoff";
+        sample.HandoffReason = "DMF import in progress";
+        sample.ExternalJobId = "DMF-JOB-42";
+        sample.ExpectedBy = expectedBy;
+
+        await store.UploadPendingMessage(eventId, sessionId, endpointId, sample);
+
+        var fetched = await store.GetPendingEvent(endpointId, eventId, sessionId);
+
+        Assert.AreEqual("Handoff", fetched.PendingSubStatus);
+        Assert.AreEqual("DMF import in progress", fetched.HandoffReason);
+        Assert.AreEqual("DMF-JOB-42", fetched.ExternalJobId);
+        Assert.IsNotNull(fetched.ExpectedBy);
+        Assert.AreEqual(expectedBy, fetched.ExpectedBy.Value.ToUniversalTime());
+    }
+
+    [TestMethod]
     public async Task SearchAudits_returns_matching_audits()
     {
         var store = CreateStore();

--- a/src/NimBus.Testing/InMemoryMessageContext.cs
+++ b/src/NimBus.Testing/InMemoryMessageContext.cs
@@ -55,6 +55,8 @@ public class InMemoryMessageContext : IMessageContext
     public long? QueueTimeMs { get; set; }
     public long? ProcessingTimeMs { get; set; }
     public DateTime? HandlerStartedAtUtc { get; set; }
+    public HandlerOutcome HandlerOutcome { get; set; }
+    public HandoffMetadata HandoffMetadata { get; set; }
 
     public Task Complete(CancellationToken cancellationToken = default)
     {

--- a/src/NimBus.Testing/InMemoryMessageContext.cs
+++ b/src/NimBus.Testing/InMemoryMessageContext.cs
@@ -39,6 +39,9 @@ public class InMemoryMessageContext : IMessageContext
     public DateTime EnqueuedTimeUtc { get; }
     public string DeadLetterReason => DeadLetterReasonRecorded;
     public string DeadLetterErrorDescription => DeadLetterErrorDescriptionRecorded;
+    public string HandoffReason => _message.HandoffReason;
+    public string ExternalJobId => _message.ExternalJobId;
+    public DateTime? ExpectedBy => _message.ExpectedBy;
 
     // Observable state for test assertions
     public bool IsCompleted { get; private set; }

--- a/src/NimBus.WebApp/ClientApp/src/api-client/index.ts
+++ b/src/NimBus.WebApp/ClientApp/src/api-client/index.ts
@@ -3985,6 +3985,10 @@ export class Message implements IMessage {
     eventContent?: string;
     errorContent?: MessageErrorContent;
     originatingFrom?: string;
+    pendingSubStatus?: string | undefined;
+    handoffReason?: string | undefined;
+    externalJobId?: string | undefined;
+    expectedBy?: moment.Moment | undefined;
 
     [key: string]: any;
 
@@ -4019,6 +4023,10 @@ export class Message implements IMessage {
             this.eventContent = _data["eventContent"];
             this.errorContent = _data["errorContent"] ? MessageErrorContent.fromJS(_data["errorContent"]) : undefined as any;
             this.originatingFrom = _data["originatingFrom"];
+            this.pendingSubStatus = _data["pendingSubStatus"];
+            this.handoffReason = _data["handoffReason"];
+            this.externalJobId = _data["externalJobId"];
+            this.expectedBy = _data["expectedBy"] ? moment(_data["expectedBy"].toString()) : undefined as any;
         }
     }
 
@@ -4051,6 +4059,10 @@ export class Message implements IMessage {
         data["eventContent"] = this.eventContent;
         data["errorContent"] = this.errorContent ? this.errorContent.toJSON() : undefined as any;
         data["originatingFrom"] = this.originatingFrom;
+        data["pendingSubStatus"] = this.pendingSubStatus;
+        data["handoffReason"] = this.handoffReason;
+        data["externalJobId"] = this.externalJobId;
+        data["expectedBy"] = this.expectedBy ? this.expectedBy.toISOString() : undefined as any;
         return data;
     }
 
@@ -4079,6 +4091,10 @@ export interface IMessage {
     eventContent?: string;
     errorContent?: MessageErrorContent;
     originatingFrom?: string;
+    pendingSubStatus?: string | undefined;
+    handoffReason?: string | undefined;
+    externalJobId?: string | undefined;
+    expectedBy?: moment.Moment | undefined;
 
     [key: string]: any;
 }
@@ -5374,6 +5390,10 @@ export class Event implements IEvent {
     eventTypeId?: string;
     to?: string;
     from?: string;
+    pendingSubStatus?: string | undefined;
+    handoffReason?: string | undefined;
+    externalJobId?: string | undefined;
+    expectedBy?: moment.Moment | undefined;
     messageContent?: MessageContent;
 
     [key: string]: any;
@@ -5416,6 +5436,10 @@ export class Event implements IEvent {
             this.eventTypeId = _data["eventTypeId"];
             this.to = _data["to"];
             this.from = _data["from"];
+            this.pendingSubStatus = _data["pendingSubStatus"];
+            this.handoffReason = _data["handoffReason"];
+            this.externalJobId = _data["externalJobId"];
+            this.expectedBy = _data["expectedBy"] ? moment(_data["expectedBy"].toString()) : undefined as any;
             this.messageContent = _data["messageContent"] ? MessageContent.fromJS(_data["messageContent"]) : undefined as any;
         }
     }
@@ -5456,6 +5480,10 @@ export class Event implements IEvent {
         data["eventTypeId"] = this.eventTypeId;
         data["to"] = this.to;
         data["from"] = this.from;
+        data["pendingSubStatus"] = this.pendingSubStatus;
+        data["handoffReason"] = this.handoffReason;
+        data["externalJobId"] = this.externalJobId;
+        data["expectedBy"] = this.expectedBy ? this.expectedBy.toISOString() : undefined as any;
         data["messageContent"] = this.messageContent ? this.messageContent.toJSON() : undefined as any;
         return data;
     }
@@ -5492,6 +5520,10 @@ export interface IEvent {
     eventTypeId?: string;
     to?: string;
     from?: string;
+    pendingSubStatus?: string | undefined;
+    handoffReason?: string | undefined;
+    externalJobId?: string | undefined;
+    expectedBy?: moment.Moment | undefined;
     messageContent?: MessageContent;
 
     [key: string]: any;

--- a/src/NimBus.WebApp/ClientApp/src/components/endpoint-details/events-panel.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/endpoint-details/events-panel.tsx
@@ -13,6 +13,11 @@ import FilterContext, { IFilterContext } from "./filter/filtering-context";
 import TruncatedGuid from "components/common/truncated-guid";
 import ErrorGroupedView from "./error-grouped-view";
 import { useUrlFilters } from "hooks/use-url-filters";
+import { Badge } from "components/ui/badge";
+
+const isHandoffEvent = (event: api.Event): boolean =>
+  event.resolutionStatus === api.ResolutionStatus.Pending &&
+  (event.pendingSubStatus ?? "").toLowerCase() === "handoff";
 
 interface EventsPanelProps {
   endpointId: string;
@@ -180,6 +185,12 @@ const EventsPanel = (props: EventsPanelProps) => {
     if (!status) return false;
     return ACTIONABLE_STATUSES.includes(status as api.ResolutionStatus);
   };
+
+  // Pending+Handoff entries are healthy in-flight messages but operators retain
+  // manual override (FR-042) — they should expose the same Resubmit/Skip
+  // actions as the standard actionable statuses.
+  const isActionableEvent = (event: api.Event): boolean =>
+    isActionableStatus(event.resolutionStatus) || isHandoffEvent(event);
 
   const getSessions = (
     deferredEvents: string[],
@@ -355,7 +366,7 @@ const EventsPanel = (props: EventsPanelProps) => {
   };
 
   const getViableBodyActions = (event: api.Event): ITableBodyAction[] => {
-    if (!isActionableStatus(event.resolutionStatus)) {
+    if (!isActionableEvent(event)) {
       return [];
     }
 
@@ -429,7 +440,16 @@ const EventsPanel = (props: EventsPanelProps) => {
           [
             "status",
             {
-              value: item.resolutionStatus,
+              value: isHandoffEvent(item) ? (
+                <span className="inline-flex items-center gap-2">
+                  {item.resolutionStatus}
+                  <Badge variant="info" size="sm">
+                    Awaiting external
+                  </Badge>
+                </span>
+              ) : (
+                item.resolutionStatus
+              ),
               searchValue: item.resolutionStatus ?? "",
             },
           ],

--- a/src/NimBus.WebApp/ClientApp/src/components/event-details/message-listing.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/event-details/message-listing.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as api from "api-client";
+import { Badge } from "components/ui/badge";
 import { Button } from "components/ui/button";
 import {
   Modal,
@@ -108,6 +109,26 @@ export default function MessageListing(props: IMessageListingProps) {
     return status.toLowerCase() === "deferred";
   };
 
+  // PendingHandoff entries are healthy in-flight messages. Resubmit/Skip stay
+  // available so operators can override a stuck or wrong external job.
+  const isPendingHandoff = (
+    status: string | undefined,
+    pendingSubStatus: string | null | undefined,
+  ): boolean => {
+    if (!status || !pendingSubStatus) return false;
+    return (
+      status.toLowerCase() === "pending" &&
+      pendingSubStatus.toLowerCase() === "handoff"
+    );
+  };
+
+  const showOperatorActions =
+    isFailedMessage(props.eventDetails?.resolutionStatus) ||
+    isPendingHandoff(
+      props.eventDetails?.resolutionStatus,
+      props.eventDetails?.pendingSubStatus,
+    );
+
   const reprocessBtn: IButtonState = { isDisabled: false, text: "Reprocess" };
   const [reprocessButton, setReprocessButton] = useState(reprocessBtn);
 
@@ -184,7 +205,7 @@ export default function MessageListing(props: IMessageListingProps) {
     <div className="w-full">
       <h4 className="text-lg font-semibold flex items-center gap-4">
         Details
-        {isFailedMessage(props.eventDetails?.resolutionStatus) && (
+        {showOperatorActions && (
           <div className="flex gap-2">
             <Button
               size="xs"
@@ -211,7 +232,7 @@ export default function MessageListing(props: IMessageListingProps) {
             >
               {skipButton.text}
             </Button>
-            {props.deleteEvent && (
+            {props.deleteEvent && isFailedMessage(props.eventDetails?.resolutionStatus) && (
               <Button
                 size="xs"
                 colorScheme="red"
@@ -299,7 +320,19 @@ export default function MessageListing(props: IMessageListingProps) {
               <td className="py-2 pr-4">
                 <b>Status</b>
               </td>
-              <td className="py-2">{props.eventDetails?.resolutionStatus}</td>
+              <td className="py-2">
+                <span className="inline-flex items-center gap-2">
+                  {props.eventDetails?.resolutionStatus}
+                  {isPendingHandoff(
+                    props.eventDetails?.resolutionStatus,
+                    props.eventDetails?.pendingSubStatus,
+                  ) && (
+                    <Badge variant="info" size="sm">
+                      Awaiting external
+                    </Badge>
+                  )}
+                </span>
+              </td>
             </tr>
             <tr className="hover:bg-accent">
               <td className="py-2 pr-4">
@@ -328,6 +361,47 @@ export default function MessageListing(props: IMessageListingProps) {
           </tbody>
         </table>
         </div>
+        {(props.eventDetails?.handoffReason ||
+          props.eventDetails?.externalJobId ||
+          props.eventDetails?.expectedBy) && (
+          <div>
+            <h5 className="text-base font-semibold mb-3">Handoff details</h5>
+            <table className="w-full flex-1 text-sm mr-4">
+              <tbody>
+                {props.eventDetails?.handoffReason && (
+                  <tr className="hover:bg-accent">
+                    <td className="py-2 pr-4">
+                      <b>Reason</b>
+                    </td>
+                    <td className="py-2">
+                      {props.eventDetails?.handoffReason}
+                    </td>
+                  </tr>
+                )}
+                {props.eventDetails?.externalJobId && (
+                  <tr className="hover:bg-accent">
+                    <td className="py-2 pr-4">
+                      <b>External Job Id</b>
+                    </td>
+                    <td className="py-2">
+                      {props.eventDetails?.externalJobId}
+                    </td>
+                  </tr>
+                )}
+                {props.eventDetails?.expectedBy && (
+                  <tr className="hover:bg-accent">
+                    <td className="py-2 pr-4">
+                      <b>Expected By</b>
+                    </td>
+                    <td className="py-2">
+                      {formatMoment(props.eventDetails?.expectedBy)}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
       <br />
       {isFailedMessage(props.eventDetails?.resolutionStatus) && (

--- a/src/NimBus.WebApp/Controllers/ApiContract.g.cs
+++ b/src/NimBus.WebApp/Controllers/ApiContract.g.cs
@@ -2253,6 +2253,10 @@ namespace NimBus.WebApp.ManagementApi
         private string _eventContent;
         private MessageErrorContent _errorContent;
         private string _originatingFrom;
+        private string _pendingSubStatus;
+        private string _handoffReason;
+        private string _externalJobId;
+        private System.DateTime? _expectedBy;
 
         [Newtonsoft.Json.JsonProperty("eventId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string EventId    {
@@ -2459,6 +2463,58 @@ namespace NimBus.WebApp.ManagementApi
                 if (_originatingFrom != value)
                 {
                     _originatingFrom = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        [Newtonsoft.Json.JsonProperty("pendingSubStatus", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string PendingSubStatus    {
+            get { return _pendingSubStatus; }
+            set
+            {
+                if (_pendingSubStatus != value)
+                {
+                    _pendingSubStatus = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        [Newtonsoft.Json.JsonProperty("handoffReason", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string HandoffReason    {
+            get { return _handoffReason; }
+            set
+            {
+                if (_handoffReason != value)
+                {
+                    _handoffReason = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        [Newtonsoft.Json.JsonProperty("externalJobId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ExternalJobId    {
+            get { return _externalJobId; }
+            set
+            {
+                if (_externalJobId != value)
+                {
+                    _externalJobId = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        [Newtonsoft.Json.JsonProperty("expectedBy", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.DateTime? ExpectedBy    {
+            get { return _expectedBy; }
+            set
+            {
+                if (_expectedBy != value)
+                {
+                    _expectedBy = value;
                     RaisePropertyChanged();
                 }
             }
@@ -4172,6 +4228,10 @@ namespace NimBus.WebApp.ManagementApi
         private string _eventTypeId;
         private string _to;
         private string _from;
+        private string _pendingSubStatus;
+        private string _handoffReason;
+        private string _externalJobId;
+        private System.DateTime? _expectedBy;
         private MessageContent _messageContent;
 
         [Newtonsoft.Json.JsonProperty("updatedAt", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -4468,6 +4528,58 @@ namespace NimBus.WebApp.ManagementApi
                 if (_from != value)
                 {
                     _from = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        [Newtonsoft.Json.JsonProperty("pendingSubStatus", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string PendingSubStatus    {
+            get { return _pendingSubStatus; }
+            set
+            {
+                if (_pendingSubStatus != value)
+                {
+                    _pendingSubStatus = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        [Newtonsoft.Json.JsonProperty("handoffReason", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string HandoffReason    {
+            get { return _handoffReason; }
+            set
+            {
+                if (_handoffReason != value)
+                {
+                    _handoffReason = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        [Newtonsoft.Json.JsonProperty("externalJobId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ExternalJobId    {
+            get { return _externalJobId; }
+            set
+            {
+                if (_externalJobId != value)
+                {
+                    _externalJobId = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        [Newtonsoft.Json.JsonProperty("expectedBy", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.DateTime? ExpectedBy    {
+            get { return _expectedBy; }
+            set
+            {
+                if (_expectedBy != value)
+                {
+                    _expectedBy = value;
                     RaisePropertyChanged();
                 }
             }

--- a/src/NimBus.WebApp/Controllers/ApiContract/Mapper.cs
+++ b/src/NimBus.WebApp/Controllers/ApiContract/Mapper.cs
@@ -64,7 +64,11 @@ public static class Mapper
                     EventJson = @event.MessageContent?.EventContent?.EventJson,
                     EventTypeId = @event.MessageContent?.EventContent?.EventTypeId,
                 }
-            }
+            },
+            PendingSubStatus = @event.PendingSubStatus,
+            HandoffReason = @event.HandoffReason,
+            ExternalJobId = @event.ExternalJobId,
+            ExpectedBy = @event.ExpectedBy,
         };
     }
 
@@ -105,6 +109,11 @@ public static class Mapper
 
         if (messageEntity.MessageContent?.ErrorContent != null)
             message.ErrorContent = MessageErrorContentFromErroryContent(messageEntity.MessageContent?.ErrorContent);
+
+        message.PendingSubStatus = messageEntity.PendingSubStatus;
+        message.HandoffReason = messageEntity.HandoffReason;
+        message.ExternalJobId = messageEntity.ExternalJobId;
+        message.ExpectedBy = messageEntity.ExpectedBy;
 
         return message;
     }
@@ -214,6 +223,9 @@ public static class Mapper
         };
     }
 
+    // Pending+Handoff entries (PendingSubStatus = "Handoff") roll into PendingCount
+    // automatically because their ResolutionStatus is Pending — no change needed
+    // here for the FR-040 dashboard-count requirement.
     internal static EndpointStatusCount EndpointStatusCountFromEndpointStateCount(EndpointStateCount state)
     {
         return new EndpointStatusCount

--- a/src/NimBus.WebApp/api-spec.yaml
+++ b/src/NimBus.WebApp/api-spec.yaml
@@ -1800,6 +1800,19 @@ components:
           $ref: '#/components/schemas/MessageErrorContent'
         originatingFrom:
           type: string
+        pendingSubStatus:
+          type: string
+          nullable: true
+        handoffReason:
+          type: string
+          nullable: true
+        externalJobId:
+          type: string
+          nullable: true
+        expectedBy:
+          type: string
+          format: date-time
+          nullable: true
     UnresolvedEvents:
       type: array
       items:
@@ -2116,6 +2129,19 @@ components:
           type: string
         from:
           type: string
+        pendingSubStatus:
+          type: string
+          nullable: true
+        handoffReason:
+          type: string
+          nullable: true
+        externalJobId:
+          type: string
+          nullable: true
+        expectedBy:
+          type: string
+          format: date-time
+          nullable: true
         messageContent:
           type: object
           properties:

--- a/tests/NimBus.Core.Tests/BuiltInMiddlewareTests.cs
+++ b/tests/NimBus.Core.Tests/BuiltInMiddlewareTests.cs
@@ -36,6 +36,9 @@ file sealed class TestMessageContext : IMessageContext
     public string From { get; set; } = string.Empty;
     public string DeadLetterReason { get; set; }
     public string DeadLetterErrorDescription { get; set; }
+    public string HandoffReason { get; set; }
+    public string ExternalJobId { get; set; }
+    public DateTime? ExpectedBy { get; set; }
     public bool IsDeferred { get; set; }
     public int ThrottleRetryCount { get; set; }
     public long? QueueTimeMs { get; set; }

--- a/tests/NimBus.Core.Tests/BuiltInMiddlewareTests.cs
+++ b/tests/NimBus.Core.Tests/BuiltInMiddlewareTests.cs
@@ -44,6 +44,8 @@ file sealed class TestMessageContext : IMessageContext
     public long? QueueTimeMs { get; set; }
     public long? ProcessingTimeMs { get; set; }
     public DateTime? HandlerStartedAtUtc { get; set; }
+    public HandlerOutcome HandlerOutcome { get; set; }
+    public HandoffMetadata HandoffMetadata { get; set; }
 
     public int DeadLetterCalls { get; private set; }
     public int CompleteCalls { get; private set; }

--- a/tests/NimBus.Core.Tests/ExtensionFrameworkTests.cs
+++ b/tests/NimBus.Core.Tests/ExtensionFrameworkTests.cs
@@ -153,6 +153,9 @@ public class MessagePipelineTests
         public string From { get; set; } = string.Empty;
         public string DeadLetterReason { get; set; }
         public string DeadLetterErrorDescription { get; set; }
+        public string HandoffReason { get; set; }
+        public string ExternalJobId { get; set; }
+        public DateTime? ExpectedBy { get; set; }
         public bool IsDeferred { get; set; }
         public int ThrottleRetryCount { get; set; }
         public long? QueueTimeMs { get; set; }

--- a/tests/NimBus.Core.Tests/ExtensionFrameworkTests.cs
+++ b/tests/NimBus.Core.Tests/ExtensionFrameworkTests.cs
@@ -161,6 +161,8 @@ public class MessagePipelineTests
         public long? QueueTimeMs { get; set; }
         public long? ProcessingTimeMs { get; set; }
         public DateTime? HandlerStartedAtUtc { get; set; }
+        public HandlerOutcome HandlerOutcome { get; set; }
+        public HandoffMetadata HandoffMetadata { get; set; }
 
         public Task Complete(CancellationToken ct = default) => Task.CompletedTask;
         public Task Abandon(TransientException ex) => Task.CompletedTask;

--- a/tests/NimBus.Core.Tests/ResponseServiceTests.cs
+++ b/tests/NimBus.Core.Tests/ResponseServiceTests.cs
@@ -443,6 +443,9 @@ public class ResponseServiceTests
         public string From { get; set; } = string.Empty;
         public string DeadLetterReason { get; set; }
         public string DeadLetterErrorDescription { get; set; }
+        public string HandoffReason { get; set; }
+        public string ExternalJobId { get; set; }
+        public DateTime? ExpectedBy { get; set; }
         public bool IsDeferred { get; set; }
         public int ThrottleRetryCount { get; set; }
         public long? QueueTimeMs { get; set; }

--- a/tests/NimBus.Core.Tests/ResponseServiceTests.cs
+++ b/tests/NimBus.Core.Tests/ResponseServiceTests.cs
@@ -451,6 +451,8 @@ public class ResponseServiceTests
         public long? QueueTimeMs { get; set; }
         public long? ProcessingTimeMs { get; set; }
         public DateTime? HandlerStartedAtUtc { get; set; }
+        public HandlerOutcome HandlerOutcome { get; set; }
+        public HandoffMetadata HandoffMetadata { get; set; }
 
         public Task Complete(CancellationToken ct = default) => Task.CompletedTask;
         public Task Abandon(TransientException ex) => Task.CompletedTask;

--- a/tests/NimBus.Core.Tests/StrictMessageHandlerTests.cs
+++ b/tests/NimBus.Core.Tests/StrictMessageHandlerTests.cs
@@ -634,6 +634,9 @@ public class StrictMessageHandlerTests
         public string From { get; set; } = string.Empty;
         public string DeadLetterReason { get; set; }
         public string DeadLetterErrorDescription { get; set; }
+        public string HandoffReason { get; set; }
+        public string ExternalJobId { get; set; }
+        public DateTime? ExpectedBy { get; set; }
         public bool IsDeferred { get; set; }
         public int ThrottleRetryCount { get; set; }
         public long? QueueTimeMs { get; set; }

--- a/tests/NimBus.Core.Tests/StrictMessageHandlerTests.cs
+++ b/tests/NimBus.Core.Tests/StrictMessageHandlerTests.cs
@@ -106,6 +106,181 @@ public class StrictMessageHandlerTests
         Assert.AreEqual(0, ctx.DeadLetterCalls);
     }
 
+    // ── PendingHandoff outcome ──────────────────────────────────────────
+
+    [TestMethod]
+    public async Task HandleEventRequest_HandlerSignalsPendingHandoff_SendsHandoffResponseAndBlocksSession()
+    {
+        var ctx = CreateContext(messageType: MessageType.EventRequest);
+        var metadata = new HandoffMetadata("DMF import in flight", "JOB-42", TimeSpan.FromMinutes(5));
+        var handler = new FakeEventContextHandler
+        {
+            OnHandle = c =>
+            {
+                c.HandlerOutcome = HandlerOutcome.PendingHandoff;
+                c.HandoffMetadata = metadata;
+            },
+        };
+        var response = new FakeResponseService();
+        var sut = CreateHandler(handler, response);
+
+        await sut.Handle(ctx);
+
+        Assert.AreEqual(1, handler.HandleCalls);
+        Assert.AreEqual(1, response.PendingHandoffCalls, "PendingHandoffResponse should fire");
+        Assert.AreEqual(0, response.ResolutionCalls, "ResolutionResponse must NOT fire when handler signals PendingHandoff");
+        Assert.AreSame(metadata, response.LastPendingHandoffMetadata);
+        Assert.AreEqual(1, ctx.BlockSessionCalls, "Session must be blocked so siblings defer");
+        Assert.AreEqual(1, ctx.CompletedCalls);
+    }
+
+    [TestMethod]
+    public async Task HandleEventRequest_HandlerSignalsPendingHandoffThenThrows_FailurePathWins()
+    {
+        var ctx = CreateContext(messageType: MessageType.EventRequest);
+        var handler = new FakeEventContextHandler
+        {
+            OnHandle = c =>
+            {
+                c.HandlerOutcome = HandlerOutcome.PendingHandoff;
+                c.HandoffMetadata = new HandoffMetadata("about to fail", null, null);
+            },
+            ThrowOnHandle = new InvalidOperationException("boom"),
+        };
+        var response = new FakeResponseService();
+        var sut = CreateHandler(handler, response);
+
+        await sut.Handle(ctx);
+
+        Assert.AreEqual(0, response.PendingHandoffCalls, "PendingHandoff must not fire when handler throws");
+        Assert.AreEqual(1, response.ErrorCalls, "Failure path wins");
+        Assert.AreEqual(1, ctx.BlockSessionCalls);
+        Assert.AreEqual(1, ctx.CompletedCalls);
+    }
+
+    [TestMethod]
+    public async Task HandleEventRequest_HandlerCallsMarkPendingHandoffTwice_LastCallWins()
+    {
+        var ctx = CreateContext(messageType: MessageType.EventRequest);
+        var first = new HandoffMetadata("first", "JOB-1", TimeSpan.FromMinutes(1));
+        var second = new HandoffMetadata("second", "JOB-2", TimeSpan.FromMinutes(10));
+        var handler = new FakeEventContextHandler
+        {
+            OnHandle = c =>
+            {
+                c.HandlerOutcome = HandlerOutcome.PendingHandoff;
+                c.HandoffMetadata = first;
+                // Simulate a second MarkPendingHandoff call — last write wins.
+                c.HandoffMetadata = second;
+            },
+        };
+        var response = new FakeResponseService();
+        var sut = CreateHandler(handler, response);
+
+        await sut.Handle(ctx);
+
+        Assert.AreEqual(1, response.PendingHandoffCalls);
+        Assert.AreSame(second, response.LastPendingHandoffMetadata, "Second MarkPendingHandoff call must overwrite the first");
+        Assert.AreSame(second, ctx.HandoffMetadata);
+    }
+
+    // ── HandleHandoffCompletedRequest ───────────────────────────────────
+
+    [TestMethod]
+    public async Task HandleHandoffCompletedRequest_AuthorizedAndBlockedByThis_UnblocksAndSendsResolution()
+    {
+        var ctx = CreateContext(messageType: MessageType.HandoffCompletedRequest, from: "Manager");
+        ctx.IsSessionBlockedByThisResult = true;
+        var handler = new FakeEventContextHandler();
+        var response = new FakeResponseService();
+        var sut = CreateHandler(handler, response);
+
+        await sut.Handle(ctx);
+
+        Assert.AreEqual(1, ctx.UnblockSessionCalls);
+        Assert.AreEqual(1, response.ResolutionCalls, "Resolver-bound ResolutionResponse flips Pending → Completed");
+        Assert.AreEqual(1, ctx.CompletedCalls);
+    }
+
+    [TestMethod]
+    public async Task HandleHandoffCompletedRequest_FromNonManager_DeadLetters()
+    {
+        var ctx = CreateContext(messageType: MessageType.HandoffCompletedRequest, from: "SomeEndpoint");
+        ctx.IsSessionBlockedByThisResult = true;
+        var handler = new FakeEventContextHandler();
+        var response = new FakeResponseService();
+        var sut = CreateHandler(handler, response);
+
+        await sut.Handle(ctx);
+
+        // UnauthorizedAccessException flows through the base MessageHandler -> dead-letters
+        Assert.AreEqual(1, ctx.DeadLetterCalls);
+        Assert.AreEqual(0, ctx.UnblockSessionCalls);
+        Assert.AreEqual(0, response.ResolutionCalls);
+    }
+
+    [TestMethod]
+    public async Task HandleHandoffCompletedRequest_NotBlockedByThis_DoesNothing()
+    {
+        var ctx = CreateContext(messageType: MessageType.HandoffCompletedRequest, from: "Manager");
+        ctx.IsSessionBlockedByThisResult = false;
+        ctx.BlockedByEventId = "different-event";
+        var handler = new FakeEventContextHandler();
+        var response = new FakeResponseService();
+        var sut = CreateHandler(handler, response);
+
+        await sut.Handle(ctx);
+
+        // VerifySessionIsBlockedByThis throws SessionBlockedException, which the
+        // base MessageHandler swallows. No state changes — the message is left
+        // for redelivery (per the existing pattern for other control flows).
+        Assert.AreEqual(0, ctx.UnblockSessionCalls);
+        Assert.AreEqual(0, response.ResolutionCalls);
+        Assert.AreEqual(0, ctx.CompletedCalls);
+    }
+
+    [TestMethod]
+    public async Task HandleHandoffFailedRequest_AuthorizedAndBlockedByThis_SendsErrorAndKeepsSessionBlocked()
+    {
+        var ctx = CreateContext(messageType: MessageType.HandoffFailedRequest, from: "Manager");
+        ctx.IsSessionBlockedByThisResult = true;
+        ctx.MessageContent = new MessageContent
+        {
+            EventContent = new EventContent { EventTypeId = "OrderPlaced", EventJson = "{}" },
+            ErrorContent = new ErrorContent
+            {
+                ErrorText = "DMF rejected: invalid postal code",
+                ErrorType = "DmfValidationError",
+            },
+        };
+        var handler = new FakeEventContextHandler();
+        var response = new FakeResponseService();
+        var sut = CreateHandler(handler, response);
+
+        await sut.Handle(ctx);
+
+        Assert.AreEqual(1, response.ErrorCalls, "Resolver-bound ErrorResponse flips Pending → Failed");
+        Assert.AreEqual(0, ctx.UnblockSessionCalls, "Session stays blocked — operator decides Resubmit/Skip");
+        Assert.AreEqual(1, ctx.CompletedCalls);
+        Assert.IsNotNull(response.LastErrorException);
+        var errorMessage = response.LastErrorException.InnerException?.Message ?? response.LastErrorException.Message;
+        StringAssert.Contains(errorMessage, "DMF rejected: invalid postal code", "Operator-supplied errorText must be preserved verbatim");
+    }
+
+    [TestMethod]
+    public async Task HandleHandoffCompletedRequest_DoesNotInvokeUserHandler()
+    {
+        var ctx = CreateContext(messageType: MessageType.HandoffCompletedRequest, from: "Manager");
+        ctx.IsSessionBlockedByThisResult = true;
+        var handler = new FakeEventContextHandler();
+        var response = new FakeResponseService();
+        var sut = CreateHandler(handler, response);
+
+        await sut.Handle(ctx);
+
+        Assert.AreEqual(0, handler.HandleCalls, "HandoffCompleted must NOT re-invoke the user handler");
+    }
+
     // ── Dead-letter Resolver notification ───────────────────────────────
 
     [TestMethod]
@@ -555,10 +730,12 @@ public class StrictMessageHandlerTests
     {
         public int HandleCalls { get; private set; }
         public Exception ThrowOnHandle { get; set; }
+        public Action<IMessageContext> OnHandle { get; set; }
 
         public Task Handle(IMessageContext context, CancellationToken cancellationToken = default)
         {
             HandleCalls++;
+            OnHandle?.Invoke(context);
             if (ThrowOnHandle != null)
                 throw ThrowOnHandle;
             return Task.CompletedTask;
@@ -577,13 +754,16 @@ public class StrictMessageHandlerTests
         public int SendToDeferredSubscriptionCalls { get; private set; }
         public int ProcessDeferredCalls { get; private set; }
         public int DeadLetterCalls { get; private set; }
+        public int PendingHandoffCalls { get; private set; }
+        public HandoffMetadata LastPendingHandoffMetadata { get; private set; }
         public string LastDeadLetterReason { get; private set; }
         public Exception LastDeadLetterException { get; private set; }
+        public Exception LastErrorException { get; private set; }
         public int? LastRetryDelayMinutes { get; private set; }
 
         public Task SendResolutionResponse(IMessageContext mc, CancellationToken ct = default) { ResolutionCalls++; return Task.CompletedTask; }
         public Task SendSkipResponse(IMessageContext mc, CancellationToken ct = default) { SkipCalls++; return Task.CompletedTask; }
-        public Task SendErrorResponse(IMessageContext mc, Exception ex, CancellationToken ct = default) { ErrorCalls++; return Task.CompletedTask; }
+        public Task SendErrorResponse(IMessageContext mc, Exception ex, CancellationToken ct = default) { ErrorCalls++; LastErrorException = ex; return Task.CompletedTask; }
         public Task SendDeadLetterResponse(IMessageContext mc, string reason, Exception ex, CancellationToken ct = default)
         {
             DeadLetterCalls++;
@@ -597,6 +777,12 @@ public class StrictMessageHandlerTests
         public Task SendContinuationRequestToSelf(IMessageContext mc, CancellationToken ct = default) { ContinuationCalls++; return Task.CompletedTask; }
         public Task SendToDeferredSubscription(IMessageContext mc, int seq, CancellationToken ct = default) { SendToDeferredSubscriptionCalls++; return Task.CompletedTask; }
         public Task SendProcessDeferredRequest(IMessageContext mc, CancellationToken ct = default) { ProcessDeferredCalls++; return Task.CompletedTask; }
+        public Task SendPendingHandoffResponse(IMessageContext mc, HandoffMetadata handoff, CancellationToken ct = default)
+        {
+            PendingHandoffCalls++;
+            LastPendingHandoffMetadata = handoff;
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class FakeDeferredMessageProcessor : IDeferredMessageProcessor
@@ -642,6 +828,8 @@ public class StrictMessageHandlerTests
         public long? QueueTimeMs { get; set; }
         public long? ProcessingTimeMs { get; set; }
         public DateTime? HandlerStartedAtUtc { get; set; }
+        public HandlerOutcome HandlerOutcome { get; set; }
+        public HandoffMetadata HandoffMetadata { get; set; }
 
         // Configurable behavior
         public string BlockedByEventId { get; set; }

--- a/tests/NimBus.EndToEnd.Tests/AsyncCompletionTests.cs
+++ b/tests/NimBus.EndToEnd.Tests/AsyncCompletionTests.cs
@@ -1,0 +1,403 @@
+#pragma warning disable CA1707, CA2007
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NimBus.Core.Messages;
+using NimBus.EndToEnd.Tests.Infrastructure;
+using NimBus.SDK.EventHandlers;
+
+namespace NimBus.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end coverage for the PendingHandoff outcome (issue #15 / spec 002).
+///
+/// Test 1 (SC-008) — handler signals PendingHandoff, siblings defer, the
+/// Manager completes the handoff, and deferred siblings replay in FIFO.
+/// Critically asserts the user handler is NOT re-invoked on settlement (SC-003).
+///
+/// Test 2 (SC-009) — handler signals PendingHandoff, the Manager fails the
+/// handoff carrying DMF-shaped error text. Asserts the operator-supplied
+/// errorText is preserved verbatim on the resulting ErrorResponse audit row
+/// (SC-004 / NFR-004), then drives an operator Skip and asserts siblings
+/// replay through the existing skip flow (SC-006).
+///
+/// Settlement messages (HandoffCompletedRequest / HandoffFailedRequest) are
+/// constructed directly to mirror what <c>NimBus.Manager.ManagerClient</c>
+/// would emit — the in-memory fixture has no <c>ServiceBusClient</c>, so
+/// invoking <c>ManagerClient</c> directly is not possible here.
+/// </summary>
+[TestClass]
+public class AsyncCompletionTests
+{
+    private const string EndpointName = "OrderPlaced";
+
+    [TestMethod]
+    public async Task PendingHandoff_DefersSiblings_Then_CompleteHandoff_ReplaysInFifoOrder()
+    {
+        // Arrange — handler that hands off the FIRST event it sees, returns
+        // normally on subsequent invocations. Records every call so we can
+        // verify the original event is NOT re-invoked on settlement (SC-003).
+        const string sessionId = "session-handoff-complete";
+        var fixture = new EndToEndFixture();
+        var handler = new HandoffOnFirstHandler
+        {
+            HandoffReason = "DMF import in flight",
+            ExternalJobId = "JOB-1",
+            ExpectedBy = TimeSpan.FromMinutes(2),
+        };
+        fixture.RegisterHandler(() => handler);
+
+        // Act 1 — publish three messages on the same session. The first
+        // triggers MarkPendingHandoff; the next two should park on the
+        // Deferred subscription.
+        await fixture.Publisher.Publish(new OrderPlaced(sessionId) { OrderId = "ORD-CREATE-42" });
+        await fixture.Publisher.Publish(new OrderPlaced(sessionId) { OrderId = "ORD-UPDATE-A" });
+        await fixture.Publisher.Publish(new OrderPlaced(sessionId) { OrderId = "ORD-UPDATE-B" });
+        await fixture.DeliverAll();
+
+        // Assert intermediate state.
+        Assert.AreEqual(1, handler.HandleCalls,
+            "Only the first message should have invoked the handler; siblings must defer.");
+
+        var responses = fixture.ResponseBus.SentMessages;
+
+        var pendingHandoff = responses.SingleOrDefault(r => r.MessageType == MessageType.PendingHandoffResponse);
+        Assert.IsNotNull(pendingHandoff, "Subscriber should emit a PendingHandoffResponse for the first event.");
+        Assert.AreEqual("DMF import in flight", pendingHandoff.HandoffReason);
+        Assert.AreEqual("JOB-1", pendingHandoff.ExternalJobId);
+        Assert.IsNotNull(pendingHandoff.ExpectedBy, "ExpectedBy must be projected on the PendingHandoff response.");
+
+        var pendingEventId = pendingHandoff.EventId;
+        var pendingMessageId = pendingHandoff.CorrelationId;
+        var pendingOriginatingMessageId = pendingHandoff.OriginatingMessageId;
+
+        var deferralResponses = responses.Where(r => r.MessageType == MessageType.DeferralResponse).ToList();
+        Assert.AreEqual(2, deferralResponses.Count,
+            "Both sibling messages should have produced DeferralResponse audit rows.");
+
+        var deferredEnvelopes = responses
+            .Where(r => r.MessageType == MessageType.EventRequest && r.To == Constants.DeferredSubscriptionName)
+            .ToList();
+        Assert.AreEqual(2, deferredEnvelopes.Count,
+            "Both siblings should have been parked on the Deferred subscription.");
+
+        Assert.IsFalse(responses.Any(r => r.MessageType == MessageType.ResolutionResponse),
+            "ResolutionResponse must NOT fire while the handoff is in flight.");
+
+        // Capture the parked sibling envelopes in order (FIFO) so we can
+        // simulate the DeferredProcessor's republish step below.
+        var deferredSiblingsInOrder = deferredEnvelopes
+            .OrderBy(r => r.DeferralSequence ?? 0)
+            .ToList();
+
+        // Act 2 — Manager settles the handoff via CompleteHandoff. Construct
+        // the message directly (mirrors ManagerClient.CompleteHandoff).
+        var handoffCompleted = CreateHandoffCompletedRequest(
+            sessionId,
+            pendingEventId,
+            pendingMessageId,
+            pendingOriginatingMessageId,
+            EndpointName);
+        await fixture.PublishBus.Send(handoffCompleted);
+        await fixture.DeliverAll();
+
+        // Assert — the original event flips to Completed without re-invoking
+        // the user handler (SC-003).
+        Assert.AreEqual(1, handler.HandleCalls,
+            "HandoffCompleted must NOT re-invoke the user handler on the original event.");
+        Assert.IsTrue(fixture.ResponseBus.SentMessages.Any(r =>
+            r.MessageType == MessageType.ResolutionResponse && r.EventId == pendingEventId),
+            "HandoffCompleted should produce a ResolutionResponse for the original EventId (Pending → Completed).");
+        Assert.IsTrue(fixture.ResponseBus.SentMessages.Any(r => r.MessageType == MessageType.ProcessDeferredRequest),
+            "HandoffCompleted should ask the DeferredProcessor to drain parked siblings.");
+
+        // Act 3 — simulate DeferredProcessor republish (mirrors how the
+        // existing skip / resubmit flow is exercised in EventRoutingTests).
+        // Siblings are republished in FIFO order; each becomes a fresh
+        // EventRequest on the main subscription.
+        foreach (var sibling in deferredSiblingsInOrder)
+        {
+            await fixture.PublishBus.Send(CreateRepublishedDeferredEventRequest(sibling));
+        }
+        await fixture.DeliverAll();
+        await DrainUntilEmpty(fixture);
+
+        // Assert — siblings replayed in FIFO and the original handler
+        // invocation count is unchanged.
+        Assert.AreEqual(3, handler.HandleCalls,
+            "Handler should now be invoked once per event: 1 original (handed off) + 2 replayed siblings.");
+        Assert.AreEqual(1, handler.HandoffCallCount,
+            "MarkPendingHandoff should fire exactly once — only the first message hands off.");
+        CollectionAssert.AreEqual(
+            new[] { "ORD-CREATE-42", "ORD-UPDATE-A", "ORD-UPDATE-B" },
+            handler.ReceivedOrderIds,
+            "Siblings must replay in FIFO order behind the original event.");
+
+        var resolutionResponses = fixture.ResponseBus.SentMessages
+            .Where(r => r.MessageType == MessageType.ResolutionResponse).ToList();
+        Assert.IsTrue(resolutionResponses.Any(r => r.EventId == pendingEventId),
+            "Original EventId must produce a ResolutionResponse (Pending → Completed).");
+        Assert.IsTrue(resolutionResponses.Count >= 3,
+            $"Expected at least 3 ResolutionResponses (original + 2 siblings); got {resolutionResponses.Count}.");
+    }
+
+    [TestMethod]
+    public async Task PendingHandoff_FailHandoff_PreservesErrorText_ThenOperatorSkip()
+    {
+        // Arrange — handler always hands off (only one event reaches it,
+        // siblings defer behind the blocked session).
+        const string sessionId = "session-handoff-fail";
+        const string dmfErrorText = "DMF rejected: invalid postal code";
+        const string dmfErrorType = "DmfValidationError";
+
+        var fixture = new EndToEndFixture();
+        var handler = new HandoffOnFirstHandler
+        {
+            HandoffReason = "DMF import in flight",
+            ExternalJobId = "JOB-FAIL",
+            ExpectedBy = null,
+        };
+        fixture.RegisterHandler(() => handler);
+
+        await fixture.Publisher.Publish(new OrderPlaced(sessionId) { OrderId = "ORD-CREATE-42" });
+        await fixture.Publisher.Publish(new OrderPlaced(sessionId) { OrderId = "ORD-UPDATE-A" });
+        await fixture.DeliverAll();
+
+        Assert.AreEqual(1, handler.HandleCalls);
+
+        var responses = fixture.ResponseBus.SentMessages;
+        var pendingHandoff = responses.Single(r => r.MessageType == MessageType.PendingHandoffResponse);
+        var pendingEventId = pendingHandoff.EventId;
+        var pendingMessageId = pendingHandoff.CorrelationId;
+        var pendingOriginatingMessageId = pendingHandoff.OriginatingMessageId;
+
+        var deferredSibling = responses.Single(r =>
+            r.MessageType == MessageType.EventRequest &&
+            r.To == Constants.DeferredSubscriptionName &&
+            r.MessageContent?.EventContent?.EventJson?.Contains("ORD-UPDATE-A", StringComparison.Ordinal) == true);
+
+        // Act 1 — Manager fails the handoff with operator-supplied error text
+        // (mirrors ManagerClient.FailHandoff).
+        var handoffFailed = CreateHandoffFailedRequest(
+            sessionId,
+            pendingEventId,
+            pendingMessageId,
+            pendingOriginatingMessageId,
+            EndpointName,
+            dmfErrorText,
+            dmfErrorType);
+        await fixture.PublishBus.Send(handoffFailed);
+        await fixture.DeliverAll();
+        await DrainUntilEmpty(fixture);
+
+        // Assert — handler must NOT have been re-invoked by FailHandoff.
+        Assert.AreEqual(1, handler.HandleCalls,
+            "FailHandoff must not re-invoke the user handler.");
+
+        // Locate the ErrorResponse caused by HandoffFailedRequest.
+        var errorResponse = fixture.ResponseBus.SentMessages
+            .Where(r => r.MessageType == MessageType.ErrorResponse && r.EventId == pendingEventId)
+            .OrderBy(r => r.MessageId)
+            .LastOrDefault();
+        Assert.IsNotNull(errorResponse, "FailHandoff should produce an ErrorResponse to the Resolver.");
+
+        // SC-004 / NFR-004: errorText is preserved verbatim. ErrorType wraps
+        // a synthetic HandoffFailedException by intent — see ADR-012.
+        var errorContent = errorResponse.MessageContent?.ErrorContent;
+        Assert.IsNotNull(errorContent, "ErrorContent must be populated.");
+        Assert.IsNotNull(errorContent.ErrorText, "ErrorText must not be null.");
+        StringAssert.Contains(errorContent.ErrorText, dmfErrorText,
+            $"Operator-supplied errorText must be preserved verbatim. Got: {errorContent.ErrorText}");
+
+        // Act 2 — operator-initiated Skip on the failed handoff entry,
+        // mirroring ManagerClient.Skip. Existing skip → unblock → replay flow
+        // must work without modification (SC-006).
+        var skipRequest = CreateSkipRequest(
+            sessionId,
+            pendingEventId,
+            pendingMessageId,
+            pendingOriginatingMessageId,
+            EndpointName);
+        await fixture.PublishBus.Send(skipRequest);
+        await fixture.DeliverAll();
+
+        Assert.IsTrue(
+            fixture.ResponseBus.SentMessages.Any(r => r.MessageType == MessageType.SkipResponse),
+            "Skip should produce a SkipResponse audit row.");
+        Assert.IsTrue(
+            fixture.ResponseBus.SentMessages.Any(r => r.MessageType == MessageType.ProcessDeferredRequest),
+            "Skip should ask the DeferredProcessor to drain parked siblings.");
+
+        // Act 3 — simulate DeferredProcessor republish.
+        await fixture.PublishBus.Send(CreateRepublishedDeferredEventRequest(deferredSibling));
+        await fixture.DeliverAll();
+        await DrainUntilEmpty(fixture);
+
+        // Assert — sibling replays after the skip and reaches Completed.
+        Assert.IsTrue(handler.ReceivedOrderIds.Contains("ORD-UPDATE-A"),
+            "Sibling must replay after operator skip.");
+        Assert.IsTrue(
+            fixture.ResponseBus.SentMessages.Any(r =>
+                r.MessageType == MessageType.ResolutionResponse &&
+                r.MessageContent?.EventContent?.EventJson?.Contains("ORD-UPDATE-A", StringComparison.Ordinal) == true),
+            "Sibling should produce a ResolutionResponse after replay.");
+    }
+
+    /// <summary>
+    /// Drives the bus repeatedly until no further messages are produced.
+    /// HandoffCompletedRequest replay generates ContinuationRequests, which
+    /// generate further work; one DeliverAll pass is not always enough.
+    /// </summary>
+    private static async Task DrainUntilEmpty(EndToEndFixture fixture)
+    {
+        for (var i = 0; i < 10; i++)
+        {
+            if (fixture.PublishBus.MessageCount == 0)
+                return;
+            await fixture.DeliverAll();
+        }
+
+        Assert.IsTrue(fixture.PublishBus.MessageCount == 0,
+            "Bus did not quiesce within 10 drain passes.");
+    }
+
+    private static Message CreateHandoffCompletedRequest(
+        string sessionId,
+        string eventId,
+        string parentMessageId,
+        string originatingMessageId,
+        string endpoint)
+    {
+        return new Message
+        {
+            To = endpoint,
+            From = Constants.ManagerId,
+            SessionId = sessionId,
+            CorrelationId = Guid.NewGuid().ToString(),
+            MessageId = Guid.NewGuid().ToString(),
+            EventId = eventId,
+            EventTypeId = "OrderPlaced",
+            MessageType = MessageType.HandoffCompletedRequest,
+            OriginatingMessageId = originatingMessageId ?? parentMessageId,
+            ParentMessageId = parentMessageId,
+            MessageContent = new MessageContent
+            {
+                EventContent = new EventContent
+                {
+                    EventTypeId = "OrderPlaced",
+                    EventJson = "{}",
+                },
+            },
+        };
+    }
+
+    private static Message CreateHandoffFailedRequest(
+        string sessionId,
+        string eventId,
+        string parentMessageId,
+        string originatingMessageId,
+        string endpoint,
+        string errorText,
+        string errorType)
+    {
+        return new Message
+        {
+            To = endpoint,
+            From = Constants.ManagerId,
+            SessionId = sessionId,
+            CorrelationId = Guid.NewGuid().ToString(),
+            MessageId = Guid.NewGuid().ToString(),
+            EventId = eventId,
+            EventTypeId = "OrderPlaced",
+            MessageType = MessageType.HandoffFailedRequest,
+            OriginatingMessageId = originatingMessageId ?? parentMessageId,
+            ParentMessageId = parentMessageId,
+            MessageContent = new MessageContent
+            {
+                ErrorContent = new ErrorContent
+                {
+                    ErrorText = errorText,
+                    ErrorType = errorType,
+                },
+            },
+        };
+    }
+
+    private static Message CreateRepublishedDeferredEventRequest(IMessage deferredMessage)
+    {
+        return new Message
+        {
+            To = deferredMessage.EventTypeId,
+            SessionId = deferredMessage.SessionId,
+            CorrelationId = deferredMessage.CorrelationId,
+            MessageId = Guid.NewGuid().ToString(),
+            EventId = deferredMessage.EventId,
+            EventTypeId = deferredMessage.EventTypeId,
+            MessageType = MessageType.EventRequest,
+            From = deferredMessage.From,
+            OriginatingFrom = deferredMessage.OriginatingFrom,
+            OriginatingMessageId = deferredMessage.OriginatingMessageId,
+            ParentMessageId = deferredMessage.ParentMessageId,
+            RetryCount = deferredMessage.RetryCount,
+            MessageContent = deferredMessage.MessageContent,
+            DiagnosticId = deferredMessage.DiagnosticId,
+        };
+    }
+
+    private static Message CreateSkipRequest(
+        string sessionId,
+        string eventId,
+        string parentMessageId,
+        string originatingMessageId,
+        string endpoint)
+    {
+        return new Message
+        {
+            To = endpoint,
+            From = Constants.ManagerId,
+            SessionId = sessionId,
+            CorrelationId = Guid.NewGuid().ToString(),
+            MessageId = Guid.NewGuid().ToString(),
+            EventId = eventId,
+            EventTypeId = "OrderPlaced",
+            MessageType = MessageType.SkipRequest,
+            OriginatingMessageId = originatingMessageId ?? parentMessageId,
+            ParentMessageId = parentMessageId,
+            MessageContent = new MessageContent
+            {
+                EventContent = new EventContent
+                {
+                    EventTypeId = "OrderPlaced",
+                    EventJson = "{}",
+                },
+            },
+        };
+    }
+
+    /// <summary>
+    /// Hands off on the first invocation, returns normally afterwards.
+    /// Records every order id seen, plus a separate counter for handoff calls.
+    /// </summary>
+    private sealed class HandoffOnFirstHandler : IEventHandler<OrderPlaced>
+    {
+        public string HandoffReason { get; set; } = "test reason";
+        public string ExternalJobId { get; set; }
+        public TimeSpan? ExpectedBy { get; set; }
+
+        public List<string> ReceivedOrderIds { get; } = new();
+        public int HandleCalls { get; private set; }
+        public int HandoffCallCount { get; private set; }
+
+        public Task Handle(OrderPlaced message, IEventHandlerContext context, CancellationToken cancellationToken = default)
+        {
+            HandleCalls++;
+            ReceivedOrderIds.Add(message.OrderId);
+
+            if (HandoffCallCount == 0)
+            {
+                context.MarkPendingHandoff(HandoffReason, ExternalJobId, ExpectedBy);
+                HandoffCallCount++;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/NimBus.Resolver.Tests/ResolverServiceTests.cs
+++ b/tests/NimBus.Resolver.Tests/ResolverServiceTests.cs
@@ -183,6 +183,9 @@ public class ResolverServiceTests
         public string From { get; set; } = string.Empty;
         public string DeadLetterReason { get; set; } = null!;
         public string DeadLetterErrorDescription { get; set; } = null!;
+        public string HandoffReason { get; set; }
+        public string ExternalJobId { get; set; }
+        public DateTime? ExpectedBy { get; set; }
         public bool IsDeferred { get; set; }
         public int ThrottleRetryCount { get; set; }
         public long? QueueTimeMs { get; set; }

--- a/tests/NimBus.Resolver.Tests/ResolverServiceTests.cs
+++ b/tests/NimBus.Resolver.Tests/ResolverServiceTests.cs
@@ -191,6 +191,8 @@ public class ResolverServiceTests
         public long? QueueTimeMs { get; set; }
         public long? ProcessingTimeMs { get; set; }
         public DateTime? HandlerStartedAtUtc { get; set; }
+        public HandlerOutcome HandlerOutcome { get; set; }
+        public HandoffMetadata HandoffMetadata { get; set; }
 
         public int CompletedCalls { get; private set; }
         public int DeadLetterCalls { get; private set; }

--- a/tests/NimBus.ServiceBus.Tests/SdkAndManagerTests.cs
+++ b/tests/NimBus.ServiceBus.Tests/SdkAndManagerTests.cs
@@ -1,5 +1,6 @@
-#pragma warning disable CA1707
+#pragma warning disable CA1707, CA2007
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using NimBus.Core.Messages;
 using NimBus.Manager;
 using NimBus.MessageStore;
@@ -8,6 +9,7 @@ using System.Reflection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace NimBus.ServiceBus.Tests;
@@ -71,6 +73,161 @@ public class SdkAndManagerTests
         Assert.AreEqual("message-1", sentMessage.ApplicationProperties["ParentMessageId"]);
         Assert.AreEqual("session-1", sentMessage.SessionId);
         Assert.AreEqual("message-1", sentMessage.CorrelationId);
+    }
+
+    [TestMethod]
+    public async Task ManagerClient_CompleteHandoff_HappyPath_SendsHandoffCompletedRequestToEndpoint()
+    {
+        var client = new RecordingServiceBusClient();
+        var sut = new ManagerClient(client);
+        var pendingEntry = new MessageEntity
+        {
+            CorrelationId = "correlation-1",
+            EventId = "event-1",
+            EventTypeId = "OrderPlaced",
+            SessionId = "session-1",
+            MessageId = "message-1",
+            OriginatingMessageId = "originating-1",
+            PendingSubStatus = "Handoff",
+        };
+
+        await sut.CompleteHandoff(pendingEntry, "billing", "{\"jobId\":\"abc\"}");
+
+        Assert.AreEqual("billing", client.LastSenderEntityPath);
+        Assert.AreEqual(1, client.Sender.SentMessages.Count);
+
+        var sentMessage = client.Sender.SentMessages.Single();
+        Assert.AreEqual("billing", sentMessage.ApplicationProperties["To"]);
+        Assert.AreEqual(Constants.ManagerId, sentMessage.ApplicationProperties["From"]);
+        Assert.AreEqual("OrderPlaced", sentMessage.ApplicationProperties["EventTypeId"]);
+        Assert.AreEqual(MessageType.HandoffCompletedRequest.ToString(), sentMessage.ApplicationProperties["MessageType"]);
+        Assert.AreEqual("event-1", sentMessage.ApplicationProperties["EventId"]);
+        Assert.AreEqual("originating-1", sentMessage.ApplicationProperties["OriginatingMessageId"]);
+        Assert.AreEqual("message-1", sentMessage.ApplicationProperties["ParentMessageId"]);
+        Assert.AreEqual("session-1", sentMessage.SessionId);
+        Assert.AreEqual("correlation-1", sentMessage.CorrelationId);
+
+        var content = JsonConvert.DeserializeObject<MessageContent>(Encoding.UTF8.GetString(sentMessage.Body.ToArray()));
+        Assert.IsNotNull(content);
+        Assert.IsNotNull(content.EventContent);
+        Assert.AreEqual("OrderPlaced", content.EventContent.EventTypeId);
+        Assert.AreEqual("{\"jobId\":\"abc\"}", content.EventContent.EventJson);
+        Assert.IsNull(content.ErrorContent);
+    }
+
+    [TestMethod]
+    public async Task ManagerClient_CompleteHandoff_NullDetailsJson_OmitsEventContent()
+    {
+        var client = new RecordingServiceBusClient();
+        var sut = new ManagerClient(client);
+        var pendingEntry = new MessageEntity
+        {
+            EventId = "event-1",
+            EventTypeId = "OrderPlaced",
+            SessionId = "session-1",
+            MessageId = "message-1",
+            OriginatingMessageId = "originating-1",
+            PendingSubStatus = "Handoff",
+        };
+
+        await sut.CompleteHandoff(pendingEntry, "billing");
+
+        Assert.AreEqual(1, client.Sender.SentMessages.Count);
+        var sentMessage = client.Sender.SentMessages.Single();
+        var content = JsonConvert.DeserializeObject<MessageContent>(Encoding.UTF8.GetString(sentMessage.Body.ToArray()));
+        Assert.IsNotNull(content);
+        Assert.IsNull(content.EventContent);
+        Assert.IsNull(content.ErrorContent);
+    }
+
+    [TestMethod]
+    public async Task ManagerClient_CompleteHandoff_NonHandoffSubStatus_ThrowsAndDoesNotSend()
+    {
+        var client = new RecordingServiceBusClient();
+        var sut = new ManagerClient(client);
+        var pendingEntry = new MessageEntity
+        {
+            EventId = "event-1",
+            SessionId = "session-1",
+            MessageId = "message-1",
+            PendingSubStatus = null,
+        };
+
+        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => sut.CompleteHandoff(pendingEntry, "billing", "{}"));
+
+        StringAssert.Contains(ex.Message, "CompleteHandoff requires PendingSubStatus='Handoff'");
+        StringAssert.Contains(ex.Message, "<null>");
+        StringAssert.Contains(ex.Message, "event-1");
+        Assert.IsNull(client.LastSenderEntityPath);
+        Assert.AreEqual(0, client.Sender.SentMessages.Count);
+
+        pendingEntry.PendingSubStatus = "Other";
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => sut.CompleteHandoff(pendingEntry, "billing", "{}"));
+        Assert.AreEqual(0, client.Sender.SentMessages.Count);
+    }
+
+    [TestMethod]
+    public async Task ManagerClient_FailHandoff_HappyPath_IncludesErrorTextAndTypeInErrorContent()
+    {
+        var client = new RecordingServiceBusClient();
+        var sut = new ManagerClient(client);
+        var pendingEntry = new MessageEntity
+        {
+            CorrelationId = "correlation-1",
+            EventId = "event-1",
+            EventTypeId = "OrderPlaced",
+            SessionId = "session-1",
+            MessageId = "message-1",
+            OriginatingMessageId = "originating-1",
+            PendingSubStatus = "Handoff",
+        };
+
+        await sut.FailHandoff(pendingEntry, "billing", "downstream rejected", "DownstreamRejected");
+
+        Assert.AreEqual("billing", client.LastSenderEntityPath);
+        Assert.AreEqual(1, client.Sender.SentMessages.Count);
+
+        var sentMessage = client.Sender.SentMessages.Single();
+        Assert.AreEqual("billing", sentMessage.ApplicationProperties["To"]);
+        Assert.AreEqual(Constants.ManagerId, sentMessage.ApplicationProperties["From"]);
+        Assert.AreEqual("OrderPlaced", sentMessage.ApplicationProperties["EventTypeId"]);
+        Assert.AreEqual(MessageType.HandoffFailedRequest.ToString(), sentMessage.ApplicationProperties["MessageType"]);
+        Assert.AreEqual("originating-1", sentMessage.ApplicationProperties["OriginatingMessageId"]);
+        Assert.AreEqual("message-1", sentMessage.ApplicationProperties["ParentMessageId"]);
+        Assert.AreEqual("session-1", sentMessage.SessionId);
+        Assert.AreEqual("correlation-1", sentMessage.CorrelationId);
+
+        var content = JsonConvert.DeserializeObject<MessageContent>(Encoding.UTF8.GetString(sentMessage.Body.ToArray()));
+        Assert.IsNotNull(content);
+        Assert.IsNotNull(content.ErrorContent);
+        Assert.AreEqual("downstream rejected", content.ErrorContent.ErrorText);
+        Assert.AreEqual("DownstreamRejected", content.ErrorContent.ErrorType);
+        Assert.IsNull(content.EventContent);
+    }
+
+    [TestMethod]
+    public async Task ManagerClient_FailHandoff_NonHandoffSubStatus_ThrowsAndDoesNotSend()
+    {
+        var client = new RecordingServiceBusClient();
+        var sut = new ManagerClient(client);
+        var pendingEntry = new MessageEntity
+        {
+            EventId = "event-1",
+            SessionId = "session-1",
+            MessageId = "message-1",
+            PendingSubStatus = "Other",
+        };
+
+        var ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => sut.FailHandoff(pendingEntry, "billing", "boom", "Some.Error"));
+
+        StringAssert.Contains(ex.Message, "FailHandoff requires PendingSubStatus='Handoff'");
+        StringAssert.Contains(ex.Message, "Other");
+        StringAssert.Contains(ex.Message, "event-1");
+        Assert.IsNull(client.LastSenderEntityPath);
+        Assert.AreEqual(0, client.Sender.SentMessages.Count);
     }
 
     [TestMethod]


### PR DESCRIPTION
Closes #15.

Spec: [`docs/specs/002-async-message-completion/spec.md`](docs/specs/002-async-message-completion/spec.md)
ADR: [`docs/adr/012-pending-handoff.md`](docs/adr/012-pending-handoff.md)
Showcase: [`samples/CrmErpDemo/README.md#showcase-pendinghandoff-async-erp-imports`](samples/CrmErpDemo/README.md)

## Summary

Adds a new handler outcome — **PendingHandoff** — for adapters whose unit of work is an external long-running job (e.g. D365 F&O DMF imports). The handler signals async handoff via `ctx.MarkPendingHandoff(reason, externalJobId, expectedBy)` and returns normally. The subscriber settles the inbound Service Bus message immediately, blocks the session so siblings defer in FIFO order, and emits a `PendingHandoffResponse` so the audit row reads `Pending` (with `PendingSubStatus = "Handoff"`) — not `Failed`. A status checker later issues `ManagerClient.CompleteHandoff` / `FailHandoff`, which drive Pending → Completed / Failed **without re-invoking the user handler**.

Purely additive — adapters that don't call `MarkPendingHandoff` see zero behaviour change.

The PR also wires the feature into the **CRM/ERP demo** so a reviewer can flip a switch in `Erp.Web`, watch `CrmAccountCreated` enter Pending+Handoff in NimBus.WebApp, see sibling updates park as Deferred, then watch them replay on completion (or stay blocked on failure).

### Resolved scope decisions
- Optional Resolver-side timeout sweeper (FR-050..053) is **out of v1**, deferred to a follow-up issue.
- `CompleteHandoff` / `FailHandoff` against a non-PendingHandoff state → **hard error in `ManagerClient`** before any Service Bus traffic.

## Phase breakdown — 12 commits

### Feature implementation (PR #15 scope)

| Commit | Phase |
|---|---|
| `b792272` | Spec brought into branch |
| `9bd3d9f` | A — Wire & storage foundations (3 new `MessageType` values, 4 nullable fields on `MessageEntity` / `UnresolvedEvent`, SQL schema `0009_Handoff.sql`, Resolver mapping, conformance round-trip test) |
| `1a55199` | C — Manager API (`CompleteHandoff` / `FailHandoff` with upfront `PendingSubStatus="Handoff"` validation; `Resubmit` / `Skip` untouched) |
| `be146fb` | D — WebApp surfacing (api-spec.yaml + NSwag regen, "Awaiting external" badge, "Handoff details" section, Resubmit/Skip available on Pending+Handoff rows) |
| `8275526` | B — Subscriber handler API & flow (`HandlerOutcome` / `HandoffMetadata`, `IEventHandlerContext.MarkPendingHandoff`, `IMessageContext` outcome bridge, `ResponseService.SendPendingHandoffResponse`, `StrictMessageHandler` PendingHandoff branch + two new control-message overrides) |
| `e25d48b` | E — E2E tests (defer→complete→FIFO replay; fail→preserve errorText→skip) |
| `3073223` | F — ADR-012, error-handling, message-flows, SDK reference, roadmap |

### CRM/ERP demo showcase

| Commit | Phase |
|---|---|
| `891aea8` | 1 — `Erp.Api` handoff mode state, admin endpoints, in-memory job tracker, BackgroundService that drains expired jobs and calls `IManagerClient.CompleteHandoff` / `FailHandoff` based on configurable `failureRate` |
| `da49944` | 2 — `Erp.Adapter.Functions` handoff branch on `CrmAccountCreatedHandler` (mirrors existing `IServiceModeClient` / `ErrorModeGuard` patterns; Erp.Api outage falls back to synchronous path) |
| `37d07be` | 3 — `Erp.Web` admin panel: enable toggle, duration slider (1–60 s), failure-rate slider (0–100 %), live in-flight jobs panel with countdown |
| `804fa2d` | 4 — Two new Playwright E2E specs (success: 3 messages on one session → first hands off, two sibling updates defer, all replay in FIFO; failure: errorText preserved verbatim, operator Skip drains parked siblings). Includes a one-line AppHost fix to wire `EnableLocalDevAuthentication=true` for `nimbus-ops` (was missing — e2e suite couldn't reach NimBus.WebApp APIs without it). |
| `ea79100` | 5 — README walk-through + cross-link from `docs/sdk-api-reference.md` |

## Test plan

- [x] `dotnet build src/NimBus.sln` — 0 errors
- [x] `dotnet build` of `samples/CrmErpDemo/` — 0 errors
- [x] `dotnet test src/NimBus.sln` — **399 passed, 70 skipped, 0 failed**
  - NimBus.Core.Tests: 134 (126 baseline + 8 new for PendingHandoff)
  - NimBus.ServiceBus.Tests: 133 (incl. 5 new ManagerClient tests)
  - NimBus.EndToEnd.Tests: 58 (incl. 2 new AsyncCompletionTests covering SC-008/009)
  - NimBus.MessageStore.InMemory.Tests: 34 (incl. new `PendingHandoff_fields_round_trip` conformance test)
  - NimBus.CommandLine.Tests: 33 / NimBus.Resolver.Tests: 7
  - NimBus.MessageStore.{CosmosDb,SqlServer}.Tests: 70 skipped (no provider locally — run in CI)
- [x] WebApp `npm run build` clean; `npm test --run` 1/1 passing
- [x] CrmErpDemo Erp.Web `npm run build` clean
- [x] CrmErpDemo Playwright e2e — 7/7 specs passing (3 existing + 2 new + 2 sub-tests in spec 01)
- [x] All success criteria SC-001..SC-010 from the spec satisfied
- [ ] CI runs the SQL Server + Cosmos conformance suite against real providers

## Manual smoke (the canonical demo loop)

1. `dotnet run --project samples/CrmErpDemo/CrmErpDemo.AppHost`
2. Open Erp.Web → Admin → flip handoff mode ON, 30 s, 0 % failure
3. Open Crm.Web → create account "Acme"
4. NimBus.WebApp → see `CrmAccountCreated` row marked **Pending** with **Awaiting external** badge; click for Reason / ExternalJobId / ExpectedBy
5. Crm.Web → update "Acme" twice
6. NimBus.WebApp → both updates show **Deferred**
7. Wait ~30 s → all three rows flip to **Completed**, deferred replay in FIFO, ERP customer reflects latest update
8. Re-flip Erp.Web admin: `failureRate = 100 %`, create another account → after 30 s the row is **Failed** with `ErrorContent.ErrorText` matching the DMF-style canned message verbatim → click **Skip** → flips to **Skipped**

## Out of scope (separate follow-ups)

- Optional Resolver-side timeout sweeper (FR-050..053).
- Operator-initiated `CompleteHandoff` / `FailHandoff` buttons in the WebApp (operator path stays Resubmit / Skip per spec).