### PR TITLE
fix(webapp): show proper labels for handoff message types

### DIFF
--- a/src/NimBus.WebApp/ClientApp/src/api-client/index.ts
+++ b/src/NimBus.WebApp/ClientApp/src/api-client/index.ts
@@ -9171,6 +9171,9 @@ export enum MessageType {
     SkipRequest = "skipRequest",
     ContinuationRequest = "continuationRequest",
     UnsupportedRequest = "unsupportedRequest",
+    PendingHandoffResponse = "pendingHandoffResponse",
+    HandoffCompletedRequest = "handoffCompletedRequest",
+    HandoffFailedRequest = "handoffFailedRequest",
 }
 
 export enum MessageEndpointRole {
@@ -9276,6 +9279,9 @@ export enum MessageSearchFilterMessageType {
     SkipRequest = "skipRequest",
     ContinuationRequest = "continuationRequest",
     UnsupportedRequest = "unsupportedRequest",
+    PendingHandoffResponse = "pendingHandoffResponse",
+    HandoffCompletedRequest = "handoffCompletedRequest",
+    HandoffFailedRequest = "handoffFailedRequest",
 }
 
 export enum AuditSearchFilterAuditType {

--- a/src/NimBus.WebApp/ClientApp/src/components/event-details/flow-timeline.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/event-details/flow-timeline.tsx
@@ -33,6 +33,9 @@ const MESSAGE_COLORS: Record<string, { bg: string; border: string; dot: string; 
   SkipRequest:         { bg: "bg-gray-50",    border: "border-gray-300",    dot: "bg-gray-400",    label: "Skip Request" },
   ContinuationRequest: { bg: "bg-indigo-50",  border: "border-indigo-300",  dot: "bg-indigo-500",  label: "Continuation" },
   UnsupportedRequest:  { bg: "bg-orange-50",  border: "border-orange-300",  dot: "bg-orange-500",  label: "Unsupported" },
+  PendingHandoffResponse:  { bg: "bg-sky-50",     border: "border-sky-300",     dot: "bg-sky-500",     label: "Awaiting External" },
+  HandoffCompletedRequest: { bg: "bg-teal-50",    border: "border-teal-300",    dot: "bg-teal-500",    label: "Handoff Completed" },
+  HandoffFailedRequest:    { bg: "bg-orange-50",  border: "border-orange-300",  dot: "bg-orange-500",  label: "Handoff Failed" },
 };
 
 const AUDIT_COLOR = { bg: "bg-sky-50", border: "border-sky-200", dot: "bg-sky-400" };

--- a/src/NimBus.WebApp/Controllers/ApiContract.g.cs
+++ b/src/NimBus.WebApp/Controllers/ApiContract.g.cs
@@ -9150,6 +9150,15 @@ namespace NimBus.WebApp.ManagementApi
         [System.Runtime.Serialization.EnumMember(Value = @"unsupportedRequest")]
         UnsupportedRequest = 10,
 
+        [System.Runtime.Serialization.EnumMember(Value = @"pendingHandoffResponse")]
+        PendingHandoffResponse = 11,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"handoffCompletedRequest")]
+        HandoffCompletedRequest = 12,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"handoffFailedRequest")]
+        HandoffFailedRequest = 13,
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.3.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -9335,6 +9344,15 @@ namespace NimBus.WebApp.ManagementApi
 
         [System.Runtime.Serialization.EnumMember(Value = @"unsupportedRequest")]
         UnsupportedRequest = 10,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"pendingHandoffResponse")]
+        PendingHandoffResponse = 11,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"handoffCompletedRequest")]
+        HandoffCompletedRequest = 12,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"handoffFailedRequest")]
+        HandoffFailedRequest = 13,
 
     }
 

--- a/src/NimBus.WebApp/api-spec.yaml
+++ b/src/NimBus.WebApp/api-spec.yaml
@@ -1785,6 +1785,9 @@ components:
             - skipRequest
             - continuationRequest
             - unsupportedRequest
+            - pendingHandoffResponse
+            - handoffCompletedRequest
+            - handoffFailedRequest
         endpointRole:
           type: string
           enum:
@@ -2421,6 +2424,9 @@ components:
             - skipRequest
             - continuationRequest
             - unsupportedRequest
+            - pendingHandoffResponse
+            - handoffCompletedRequest
+            - handoffFailedRequest
         enqueuedAtFrom:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary

- Handoff messages (`PendingHandoffResponse`, `HandoffCompletedRequest`, `HandoffFailedRequest`) were rendered as **Unknown** in the Messages list and the event Flow timeline.
- Root cause: `MessageType` enum in `api-spec.yaml` was never extended for PR #29. `Mapper.MessageFromMessageEntity` parses the core enum value into the API contract enum and falls back to `MessageType.Unknown` when parsing fails — so the new types silently degraded to "Unknown".
- Added the three handoff values to both `messageType` enums in `api-spec.yaml` (Message + MessageSearchFilter), regenerated the NSwag contracts, and added color/label entries to `flow-timeline.tsx` (Awaiting External, Handoff Completed, Handoff Failed).

## Test plan

- [ ] Restart the WebApp and rebuild the SPA (`npm run build` in `ClientApp/`)
- [ ] Trigger a CrmErpDemo handoff-failure scenario and confirm the event Flow timeline shows "Awaiting External" and "Handoff Failed" badges instead of "Unknown"
- [ ] Confirm the Messages list Type column shows `PendingHandoffResponse` / `HandoffFailedRequest` for the corresponding rows
- [ ] Confirm the Message Type filter dropdown on the Messages page lists the three new types