### PR TITLE
CrmErpDemo polish + audit log + small NimBus fixes

### DIFF
--- a/samples/CrmErpDemo/Crm.Api/CrmDbContext.cs
+++ b/samples/CrmErpDemo/Crm.Api/CrmDbContext.cs
@@ -1,5 +1,7 @@
 using Crm.Api.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Newtonsoft.Json;
 
 namespace Crm.Api;
 
@@ -7,6 +9,13 @@ public class CrmDbContext(DbContextOptions<CrmDbContext> options) : DbContext(op
 {
     public DbSet<Account> Accounts => Set<Account>();
     public DbSet<Contact> Contacts => Set<Contact>();
+    public DbSet<Audit> Audits => Set<Audit>();
+
+    // Properties that are bookkeeping rather than user-visible state — never
+    // emit a field-diff audit row for these. IsDeleted flips become a single
+    // Deleted summary row instead (see ProjectAuditEntries).
+    private static readonly HashSet<string> IgnoredProperties =
+        new(StringComparer.Ordinal) { "Id", "CreatedAt", "UpdatedAt", "IsDeleted" };
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -28,5 +37,136 @@ public class CrmDbContext(DbContextOptions<CrmDbContext> options) : DbContext(op
             e.Property(x => x.Phone).HasMaxLength(40);
             e.HasIndex(x => x.AccountId);
         });
+
+        modelBuilder.Entity<Audit>(e =>
+        {
+            e.HasKey(x => x.Id);
+            e.Property(x => x.EntityType).IsRequired().HasMaxLength(50);
+            e.Property(x => x.Action).IsRequired().HasMaxLength(20);
+            e.Property(x => x.FieldName).HasMaxLength(100);
+            e.Property(x => x.Origin).HasMaxLength(10);
+            e.HasIndex(x => new { x.EntityType, x.EntityId });
+        });
+    }
+
+    public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        ProjectAuditEntries();
+        return await base.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private void ProjectAuditEntries()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var rows = new List<Audit>();
+
+        foreach (var entry in ChangeTracker.Entries().ToList())
+        {
+            // Only audit the entity types the demo cares about; never audit
+            // Audit rows themselves (would loop and double-write on every save).
+            var (entityType, entityId, origin) = ResolveEntity(entry.Entity);
+            if (entityType is null) continue;
+
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                    rows.Add(new Audit
+                    {
+                        Id = Guid.NewGuid(),
+                        EntityType = entityType,
+                        EntityId = entityId,
+                        Action = "Created",
+                        NewValue = SnapshotJson(entry),
+                        Timestamp = now,
+                        Origin = origin,
+                    });
+                    break;
+
+                case EntityState.Modified:
+                    var deletedFlagChanged = false;
+                    foreach (var prop in entry.Properties)
+                    {
+                        var name = prop.Metadata.Name;
+                        if (name == "IsDeleted" && prop.IsModified
+                            && Equals(prop.OriginalValue, false) && Equals(prop.CurrentValue, true))
+                        {
+                            deletedFlagChanged = true;
+                            continue;
+                        }
+                        if (IgnoredProperties.Contains(name)) continue;
+                        if (!prop.IsModified) continue;
+                        if (Equals(prop.OriginalValue, prop.CurrentValue)) continue;
+
+                        rows.Add(new Audit
+                        {
+                            Id = Guid.NewGuid(),
+                            EntityType = entityType,
+                            EntityId = entityId,
+                            Action = "Updated",
+                            FieldName = name,
+                            OldValue = Format(prop.OriginalValue),
+                            NewValue = Format(prop.CurrentValue),
+                            Timestamp = now,
+                            Origin = origin,
+                        });
+                    }
+                    if (deletedFlagChanged)
+                    {
+                        rows.Add(new Audit
+                        {
+                            Id = Guid.NewGuid(),
+                            EntityType = entityType,
+                            EntityId = entityId,
+                            Action = "Deleted",
+                            Timestamp = now,
+                            Origin = origin,
+                        });
+                    }
+                    break;
+
+                case EntityState.Deleted:
+                    rows.Add(new Audit
+                    {
+                        Id = Guid.NewGuid(),
+                        EntityType = entityType,
+                        EntityId = entityId,
+                        Action = "Deleted",
+                        Timestamp = now,
+                        Origin = origin,
+                    });
+                    break;
+            }
+        }
+
+        if (rows.Count > 0) Audits.AddRange(rows);
+    }
+
+    private static (string? type, Guid id, string? origin) ResolveEntity(object entity) => entity switch
+    {
+        Account a => ("Account", a.Id, NullIfEmpty(a.Origin)),
+        Contact c => ("Contact", c.Id, NullIfEmpty(c.Origin)),
+        _ => (null, Guid.Empty, null),
+    };
+
+    private static string? NullIfEmpty(string s) => string.IsNullOrWhiteSpace(s) ? null : s;
+
+    private static string? Format(object? value) => value switch
+    {
+        null => null,
+        DateTimeOffset dto => dto.ToString("O"),
+        DateTime dt => dt.ToString("O"),
+        _ => value.ToString(),
+    };
+
+    private static string SnapshotJson(EntityEntry entry)
+    {
+        var bag = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var prop in entry.Properties)
+        {
+            var name = prop.Metadata.Name;
+            if (IgnoredProperties.Contains(name)) continue;
+            bag[name] = prop.CurrentValue;
+        }
+        return JsonConvert.SerializeObject(bag);
     }
 }

--- a/samples/CrmErpDemo/Crm.Api/Endpoints/AuditEndpoints.cs
+++ b/samples/CrmErpDemo/Crm.Api/Endpoints/AuditEndpoints.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Crm.Api.Endpoints;
+
+public static class AuditEndpoints
+{
+    public static void MapAuditEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/audit");
+
+        // Latest audit rows first so the UI can render a top-down timeline
+        // without re-sorting. EntityType is "Account" or "Contact" — see
+        // CrmDbContext.ResolveEntity for the canonical names.
+        group.MapGet("/{entityType}/{entityId:guid}", async (string entityType, Guid entityId, CrmDbContext db) =>
+        {
+            var rows = await db.Audits
+                .AsNoTracking()
+                .Where(a => a.EntityType == entityType && a.EntityId == entityId)
+                .OrderByDescending(a => a.Timestamp)
+                .ThenByDescending(a => a.Id)
+                .ToListAsync();
+            return Results.Ok(rows);
+        });
+    }
+}

--- a/samples/CrmErpDemo/Crm.Api/Entities/Audit.cs
+++ b/samples/CrmErpDemo/Crm.Api/Entities/Audit.cs
@@ -1,0 +1,18 @@
+namespace Crm.Api.Entities;
+
+// Per-record audit row. One row per changed field on Updated, plus a single
+// Created/Deleted summary row when the entity enters or leaves the system.
+// Populated automatically by CrmDbContext.SaveChangesAsync — every endpoint
+// and adapter-driven mutation produces audit rows for free.
+public class Audit
+{
+    public Guid Id { get; set; }
+    public string EntityType { get; set; } = string.Empty;
+    public Guid EntityId { get; set; }
+    public string Action { get; set; } = string.Empty;
+    public string? FieldName { get; set; }
+    public string? OldValue { get; set; }
+    public string? NewValue { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+    public string? Origin { get; set; }
+}

--- a/samples/CrmErpDemo/Crm.Api/Program.cs
+++ b/samples/CrmErpDemo/Crm.Api/Program.cs
@@ -90,7 +90,22 @@ for (var attempt = 1; attempt <= 10 && !initSucceeded; attempt++)
             IF COL_LENGTH('dbo.Accounts', 'IsDeleted') IS NULL
                 ALTER TABLE dbo.Accounts ADD IsDeleted BIT NOT NULL CONSTRAINT DF_Accounts_IsDeleted DEFAULT 0;
             IF COL_LENGTH('dbo.Contacts', 'IsDeleted') IS NULL
-                ALTER TABLE dbo.Contacts ADD IsDeleted BIT NOT NULL CONSTRAINT DF_Contacts_IsDeleted DEFAULT 0;");
+                ALTER TABLE dbo.Contacts ADD IsDeleted BIT NOT NULL CONSTRAINT DF_Contacts_IsDeleted DEFAULT 0;
+            IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Audits' AND schema_id = SCHEMA_ID('dbo'))
+            BEGIN
+                CREATE TABLE dbo.Audits (
+                    Id UNIQUEIDENTIFIER NOT NULL CONSTRAINT PK_Audits PRIMARY KEY,
+                    EntityType NVARCHAR(50) NOT NULL,
+                    EntityId UNIQUEIDENTIFIER NOT NULL,
+                    Action NVARCHAR(20) NOT NULL,
+                    FieldName NVARCHAR(100) NULL,
+                    OldValue NVARCHAR(MAX) NULL,
+                    NewValue NVARCHAR(MAX) NULL,
+                    Timestamp DATETIMEOFFSET NOT NULL,
+                    Origin NVARCHAR(10) NULL
+                );
+                CREATE INDEX IX_Audits_Entity ON dbo.Audits (EntityType, EntityId, Timestamp DESC);
+            END");
 
         var outbox = (SqlServerOutbox)scope.ServiceProvider.GetRequiredService<NimBus.Core.Outbox.IOutbox>();
         await outbox.EnsureTableExistsAsync();
@@ -107,5 +122,6 @@ if (!initSucceeded)
 
 app.MapAccountEndpoints();
 app.MapContactEndpoints();
+app.MapAuditEndpoints();
 
 app.Run();

--- a/samples/CrmErpDemo/Crm.Web/src/api.ts
+++ b/samples/CrmErpDemo/Crm.Web/src/api.ts
@@ -11,6 +11,18 @@ export interface Account {
   isDeleted?: boolean;
 }
 
+export interface AuditEntry {
+  id: string;
+  entityType: string;
+  entityId: string;
+  action: 'Created' | 'Updated' | 'Deleted' | string;
+  fieldName?: string | null;
+  oldValue?: string | null;
+  newValue?: string | null;
+  timestamp: string;
+  origin?: string | null;
+}
+
 export interface Contact {
   id: string;
   accountId?: string | null;
@@ -67,4 +79,7 @@ export const api = {
     }).then(json<Contact>),
   deleteContact: (id: string) =>
     fetch(`/api/contacts/${id}`, { method: 'DELETE' }).then(json<Contact>),
+
+  getAuditLog: (entityType: 'Account' | 'Contact', entityId: string) =>
+    fetch(`/api/audit/${entityType}/${entityId}`).then(json<AuditEntry[]>),
 };

--- a/samples/CrmErpDemo/Crm.Web/src/components/AuditLog.tsx
+++ b/samples/CrmErpDemo/Crm.Web/src/components/AuditLog.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+import { AuditEntry, api } from '../api';
+
+interface Props {
+  entityType: 'Account' | 'Contact';
+  entityId: string | undefined;
+}
+
+interface Group {
+  key: string;
+  timestamp: string;
+  origin?: string | null;
+  rows: AuditEntry[];
+  action: string;
+}
+
+// Reads /api/audit/{entityType}/{entityId} and renders the change history as
+// a vertical timeline. Updated rows are grouped by their (timestamp, action)
+// because a single SaveChanges may produce many field rows that share the
+// same instant — we want them under one "06/05/26 12:34:56 — Updated" header
+// rather than one bullet per field.
+export default function AuditLog({ entityType, entityId }: Props) {
+  const [entries, setEntries] = useState<AuditEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!entityId) return;
+    let cancelled = false;
+    setError(null);
+    api
+      .getAuditLog(entityType, entityId)
+      .then(rs => { if (!cancelled) setEntries(rs); })
+      .catch(err => { if (!cancelled) setError(err instanceof Error ? err.message : String(err)); });
+    return () => { cancelled = true; };
+  }, [entityType, entityId]);
+
+  if (!entityId) return null;
+
+  const groups = group(entries ?? []);
+
+  return (
+    <section className="bg-white rounded-lg shadow-sm border border-slate-200 p-6 space-y-3">
+      <h2 className="text-base font-semibold text-slate-700">Audit log</h2>
+      {error && <div className="text-sm text-red-700">Failed to load audit history: {error}</div>}
+      {entries === null && !error && <div className="text-sm text-slate-400">Loading…</div>}
+      {entries !== null && groups.length === 0 && (
+        <div className="text-sm text-slate-400">No history yet.</div>
+      )}
+      {groups.length > 0 && (
+        <ol className="relative pl-6 space-y-4 before:absolute before:left-2 before:top-1 before:bottom-1 before:w-px before:bg-slate-200">
+          {groups.map(g => (
+            <li key={g.key} className="relative">
+              <span className={`absolute left-[-22px] top-1.5 w-3 h-3 rounded-full border-2 border-white ${dotClass(g.action)}`} />
+              <div className="flex flex-wrap items-center gap-2 text-xs">
+                <span className={`px-1.5 py-0.5 rounded font-semibold uppercase tracking-wide ${badgeClass(g.action)}`}>{g.action}</span>
+                <span className="font-mono text-slate-500">{formatTimestamp(g.timestamp)}</span>
+                {g.origin && (
+                  <span className="px-1.5 py-0.5 rounded bg-slate-100 text-slate-600 font-mono">via {g.origin}</span>
+                )}
+              </div>
+              {g.action === 'Updated' && (
+                <ul className="mt-1 text-sm text-slate-700 space-y-0.5">
+                  {g.rows.filter(r => r.fieldName).map(r => (
+                    <li key={r.id}>
+                      <span className="font-medium text-slate-600">{r.fieldName}</span>:{' '}
+                      <span className="font-mono text-slate-400 line-through">{display(r.oldValue)}</span>
+                      {' → '}
+                      <span className="font-mono text-slate-800">{display(r.newValue)}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {g.action === 'Created' && g.rows[0]?.newValue && (
+                <details className="mt-1 text-sm">
+                  <summary className="text-xs text-slate-500 cursor-pointer hover:underline">Initial values</summary>
+                  <pre className="mt-1 px-2 py-1 bg-slate-50 border border-slate-100 rounded text-[11px] font-mono overflow-x-auto whitespace-pre-wrap">{prettyJson(g.rows[0].newValue)}</pre>
+                </details>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+function group(entries: AuditEntry[]): Group[] {
+  // Server returns newest-first; keep that order.
+  const out: Group[] = [];
+  for (const e of entries) {
+    const last = out[out.length - 1];
+    if (last && last.timestamp === e.timestamp && last.action === e.action) {
+      last.rows.push(e);
+    } else {
+      out.push({ key: e.id, timestamp: e.timestamp, origin: e.origin, action: e.action, rows: [e] });
+    }
+  }
+  return out;
+}
+
+function display(v: string | null | undefined): string {
+  if (v === null || v === undefined || v === '') return '∅';
+  return v;
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}
+
+function prettyJson(raw: string): string {
+  try { return JSON.stringify(JSON.parse(raw), null, 2); } catch { return raw; }
+}
+
+function badgeClass(action: string): string {
+  switch (action) {
+    case 'Created': return 'bg-emerald-100 text-emerald-800';
+    case 'Updated': return 'bg-indigo-100 text-indigo-800';
+    case 'Deleted': return 'bg-rose-100 text-rose-800';
+    default:        return 'bg-slate-100 text-slate-700';
+  }
+}
+
+function dotClass(action: string): string {
+  switch (action) {
+    case 'Created': return 'bg-emerald-500';
+    case 'Updated': return 'bg-indigo-500';
+    case 'Deleted': return 'bg-rose-500';
+    default:        return 'bg-slate-400';
+  }
+}

--- a/samples/CrmErpDemo/Crm.Web/src/pages/AccountForm.tsx
+++ b/samples/CrmErpDemo/Crm.Web/src/pages/AccountForm.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Account, api } from '../api';
 import { randomCompany } from '../fakeData';
+import AuditLog from '../components/AuditLog';
 
 export default function AccountForm() {
   const { id } = useParams();
@@ -41,7 +42,8 @@ export default function AccountForm() {
   }
 
   return (
-    <form onSubmit={submit} className="max-w-xl bg-white rounded-lg shadow-sm border border-slate-200 p-6 space-y-4">
+    <div className="max-w-xl space-y-4">
+    <form onSubmit={submit} className="bg-white rounded-lg shadow-sm border border-slate-200 p-6 space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">{id ? 'Edit account' : 'New account'}</h1>
         {!id && (
@@ -69,6 +71,8 @@ export default function AccountForm() {
         )}
       </div>
     </form>
+    {id && <AuditLog entityType="Account" entityId={id} />}
+    </div>
   );
 }
 

--- a/samples/CrmErpDemo/Crm.Web/src/pages/ContactForm.tsx
+++ b/samples/CrmErpDemo/Crm.Web/src/pages/ContactForm.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Account, Contact, api } from '../api';
 import { randomPerson, randomPick } from '../fakeData';
+import AuditLog from '../components/AuditLog';
 
 export default function ContactForm() {
   const { id } = useParams();
@@ -41,7 +42,8 @@ export default function ContactForm() {
   }
 
   return (
-    <form onSubmit={submit} className="max-w-xl bg-white rounded-lg shadow-sm border border-slate-200 p-6 space-y-4">
+    <div className="max-w-xl space-y-4">
+    <form onSubmit={submit} className="bg-white rounded-lg shadow-sm border border-slate-200 p-6 space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">{id ? 'Edit contact' : 'New contact'}</h1>
         {!id && (
@@ -90,5 +92,7 @@ export default function ContactForm() {
         )}
       </div>
     </form>
+    {id && <AuditLog entityType="Contact" entityId={id} />}
+    </div>
   );
 }

--- a/samples/CrmErpDemo/CrmErpDemo.AppHost/Program.cs
+++ b/samples/CrmErpDemo/CrmErpDemo.AppHost/Program.cs
@@ -56,8 +56,7 @@ var provisioner = builder.AddProject<Projects.CrmErpDemo_Provisioner>("provision
 var resolver = builder.AddAzureFunctionsProject<Projects.NimBus_Resolver>("resolver")
     .WithReference(servicebus)
     .WithEnvironment("ResolverId", "Resolver")
-    .WithEnvironment("AzureWebJobsServiceBus", builder.Configuration["ConnectionStrings:servicebus"]!)
-    .WaitFor(provisioner);
+    .WithEnvironment("AzureWebJobsServiceBus", builder.Configuration["ConnectionStrings:servicebus"]!);
 
 // Point nimbus-ops at the CRM/ERP platform catalog instead of the default
 // Storefront/Billing/Warehouse one, so Endpoints/EventTypes show Crm & Erp.

--- a/samples/CrmErpDemo/CrmErpDemo.AppHost/Program.cs
+++ b/samples/CrmErpDemo/CrmErpDemo.AppHost/Program.cs
@@ -74,8 +74,7 @@ var nimbusOps = builder.AddProject<Projects.NimBus_WebApp>("nimbus-ops")
     .WithEnvironment("EnableLocalDevAuthentication", "true")
     .WithEndpoint("http", e => e.Port = 28376)
     .WithEndpoint("https", e => e.Port = 28375)
-    .WithExternalHttpEndpoints()
-    .WaitFor(provisioner);
+    .WithExternalHttpEndpoints();
 
 // Provider-specific wiring. The WebApp/Resolver pick their backend off NimBus__StorageProvider;
 // we set it explicitly so the AppHost CLI flag wins over the runtime auto-detect fallback.

--- a/samples/CrmErpDemo/Erp.Api/Endpoints/AuditEndpoints.cs
+++ b/samples/CrmErpDemo/Erp.Api/Endpoints/AuditEndpoints.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Erp.Api.Endpoints;
+
+public static class AuditEndpoints
+{
+    public static void MapAuditEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/audit");
+
+        // Latest audit rows first so the UI can render a top-down timeline
+        // without re-sorting. EntityType is "Customer" or "ErpContact" — see
+        // ErpDbContext.ResolveEntity for the canonical names.
+        group.MapGet("/{entityType}/{entityId:guid}", async (string entityType, Guid entityId, ErpDbContext db) =>
+        {
+            var rows = await db.Audits
+                .AsNoTracking()
+                .Where(a => a.EntityType == entityType && a.EntityId == entityId)
+                .OrderByDescending(a => a.Timestamp)
+                .ThenByDescending(a => a.Id)
+                .ToListAsync();
+            return Results.Ok(rows);
+        });
+    }
+}

--- a/samples/CrmErpDemo/Erp.Api/Entities/Audit.cs
+++ b/samples/CrmErpDemo/Erp.Api/Entities/Audit.cs
@@ -1,0 +1,18 @@
+namespace Erp.Api.Entities;
+
+// Per-record audit row. One row per changed field on Updated, plus a single
+// Created/Deleted summary row when the entity enters or leaves the system.
+// Populated automatically by ErpDbContext.SaveChangesAsync — every endpoint
+// and adapter-driven mutation produces audit rows for free.
+public class Audit
+{
+    public Guid Id { get; set; }
+    public string EntityType { get; set; } = string.Empty;
+    public Guid EntityId { get; set; }
+    public string Action { get; set; } = string.Empty;
+    public string? FieldName { get; set; }
+    public string? OldValue { get; set; }
+    public string? NewValue { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+    public string? Origin { get; set; }
+}

--- a/samples/CrmErpDemo/Erp.Api/ErpDbContext.cs
+++ b/samples/CrmErpDemo/Erp.Api/ErpDbContext.cs
@@ -1,5 +1,7 @@
 using Erp.Api.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Newtonsoft.Json;
 
 namespace Erp.Api;
 
@@ -7,6 +9,13 @@ public class ErpDbContext(DbContextOptions<ErpDbContext> options) : DbContext(op
 {
     public DbSet<Customer> Customers => Set<Customer>();
     public DbSet<ErpContact> Contacts => Set<ErpContact>();
+    public DbSet<Audit> Audits => Set<Audit>();
+
+    // Properties that are bookkeeping rather than user-visible state — never
+    // emit a field-diff audit row for these. IsDeleted flips become a single
+    // Deleted summary row instead (see ProjectAuditEntries).
+    private static readonly HashSet<string> IgnoredProperties =
+        new(StringComparer.Ordinal) { "Id", "CreatedAt", "UpdatedAt", "IsDeleted" };
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -30,5 +39,136 @@ public class ErpDbContext(DbContextOptions<ErpDbContext> options) : DbContext(op
             e.Property(x => x.Phone).HasMaxLength(40);
             e.HasIndex(x => x.CustomerId);
         });
+
+        modelBuilder.Entity<Audit>(e =>
+        {
+            e.HasKey(x => x.Id);
+            e.Property(x => x.EntityType).IsRequired().HasMaxLength(50);
+            e.Property(x => x.Action).IsRequired().HasMaxLength(20);
+            e.Property(x => x.FieldName).HasMaxLength(100);
+            e.Property(x => x.Origin).HasMaxLength(10);
+            e.HasIndex(x => new { x.EntityType, x.EntityId });
+        });
+    }
+
+    public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        ProjectAuditEntries();
+        return await base.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private void ProjectAuditEntries()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var rows = new List<Audit>();
+
+        foreach (var entry in ChangeTracker.Entries().ToList())
+        {
+            // Only audit the entity types the demo cares about; never audit
+            // Audit rows themselves (would loop and double-write on every save).
+            var (entityType, entityId, origin) = ResolveEntity(entry.Entity);
+            if (entityType is null) continue;
+
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                    rows.Add(new Audit
+                    {
+                        Id = Guid.NewGuid(),
+                        EntityType = entityType,
+                        EntityId = entityId,
+                        Action = "Created",
+                        NewValue = SnapshotJson(entry),
+                        Timestamp = now,
+                        Origin = origin,
+                    });
+                    break;
+
+                case EntityState.Modified:
+                    var deletedFlagChanged = false;
+                    foreach (var prop in entry.Properties)
+                    {
+                        var name = prop.Metadata.Name;
+                        if (name == "IsDeleted" && prop.IsModified
+                            && Equals(prop.OriginalValue, false) && Equals(prop.CurrentValue, true))
+                        {
+                            deletedFlagChanged = true;
+                            continue;
+                        }
+                        if (IgnoredProperties.Contains(name)) continue;
+                        if (!prop.IsModified) continue;
+                        if (Equals(prop.OriginalValue, prop.CurrentValue)) continue;
+
+                        rows.Add(new Audit
+                        {
+                            Id = Guid.NewGuid(),
+                            EntityType = entityType,
+                            EntityId = entityId,
+                            Action = "Updated",
+                            FieldName = name,
+                            OldValue = Format(prop.OriginalValue),
+                            NewValue = Format(prop.CurrentValue),
+                            Timestamp = now,
+                            Origin = origin,
+                        });
+                    }
+                    if (deletedFlagChanged)
+                    {
+                        rows.Add(new Audit
+                        {
+                            Id = Guid.NewGuid(),
+                            EntityType = entityType,
+                            EntityId = entityId,
+                            Action = "Deleted",
+                            Timestamp = now,
+                            Origin = origin,
+                        });
+                    }
+                    break;
+
+                case EntityState.Deleted:
+                    rows.Add(new Audit
+                    {
+                        Id = Guid.NewGuid(),
+                        EntityType = entityType,
+                        EntityId = entityId,
+                        Action = "Deleted",
+                        Timestamp = now,
+                        Origin = origin,
+                    });
+                    break;
+            }
+        }
+
+        if (rows.Count > 0) Audits.AddRange(rows);
+    }
+
+    private static (string? type, Guid id, string? origin) ResolveEntity(object entity) => entity switch
+    {
+        Customer c => ("Customer", c.Id, NullIfEmpty(c.Origin)),
+        ErpContact c => ("ErpContact", c.Id, NullIfEmpty(c.Origin)),
+        _ => (null, Guid.Empty, null),
+    };
+
+    private static string? NullIfEmpty(string s) => string.IsNullOrWhiteSpace(s) ? null : s;
+
+    private static string? Format(object? value) => value switch
+    {
+        null => null,
+        DateTimeOffset dto => dto.ToString("O"),
+        DateTime dt => dt.ToString("O"),
+        _ => value.ToString(),
+    };
+
+    private static string SnapshotJson(EntityEntry entry)
+    {
+        var bag = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var prop in entry.Properties)
+        {
+            var name = prop.Metadata.Name;
+            if (IgnoredProperties.Contains(name)) continue;
+            bag[name] = prop.CurrentValue;
+        }
+        return JsonConvert.SerializeObject(bag);
     }
 }

--- a/samples/CrmErpDemo/Erp.Api/Program.cs
+++ b/samples/CrmErpDemo/Erp.Api/Program.cs
@@ -101,7 +101,22 @@ for (var attempt = 1; attempt <= 10 && !initSucceeded; attempt++)
             IF COL_LENGTH('dbo.Customers', 'IsDeleted') IS NULL
                 ALTER TABLE dbo.Customers ADD IsDeleted BIT NOT NULL CONSTRAINT DF_Customers_IsDeleted DEFAULT 0;
             IF COL_LENGTH('dbo.Contacts', 'IsDeleted') IS NULL
-                ALTER TABLE dbo.Contacts ADD IsDeleted BIT NOT NULL CONSTRAINT DF_Contacts_IsDeleted DEFAULT 0;");
+                ALTER TABLE dbo.Contacts ADD IsDeleted BIT NOT NULL CONSTRAINT DF_Contacts_IsDeleted DEFAULT 0;
+            IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Audits' AND schema_id = SCHEMA_ID('dbo'))
+            BEGIN
+                CREATE TABLE dbo.Audits (
+                    Id UNIQUEIDENTIFIER NOT NULL CONSTRAINT PK_Audits PRIMARY KEY,
+                    EntityType NVARCHAR(50) NOT NULL,
+                    EntityId UNIQUEIDENTIFIER NOT NULL,
+                    Action NVARCHAR(20) NOT NULL,
+                    FieldName NVARCHAR(100) NULL,
+                    OldValue NVARCHAR(MAX) NULL,
+                    NewValue NVARCHAR(MAX) NULL,
+                    Timestamp DATETIMEOFFSET NOT NULL,
+                    Origin NVARCHAR(10) NULL
+                );
+                CREATE INDEX IX_Audits_Entity ON dbo.Audits (EntityType, EntityId, Timestamp DESC);
+            END");
 
         var outbox = (SqlServerOutbox)scope.ServiceProvider.GetRequiredService<NimBus.Core.Outbox.IOutbox>();
         await outbox.EnsureTableExistsAsync();
@@ -120,5 +135,6 @@ app.MapCustomerEndpoints();
 app.MapErpContactEndpoints();
 app.MapAdminEndpoints();
 app.MapHandoffEndpoints();
+app.MapAuditEndpoints();
 
 app.Run();

--- a/samples/CrmErpDemo/Erp.Web/src/api.ts
+++ b/samples/CrmErpDemo/Erp.Web/src/api.ts
@@ -11,6 +11,18 @@ export interface Customer {
   isDeleted?: boolean;
 }
 
+export interface AuditEntry {
+  id: string;
+  entityType: string;
+  entityId: string;
+  action: 'Created' | 'Updated' | 'Deleted' | string;
+  fieldName?: string | null;
+  oldValue?: string | null;
+  newValue?: string | null;
+  timestamp: string;
+  origin?: string | null;
+}
+
 export interface Contact {
   id: string;
   customerId?: string | null;
@@ -117,4 +129,7 @@ export const api = {
     }).then(json<Contact>),
   deleteContact: (id: string) =>
     fetch(`/api/contacts/${id}`, { method: 'DELETE' }).then(json<Contact>),
+
+  getAuditLog: (entityType: 'Customer' | 'ErpContact', entityId: string) =>
+    fetch(`/api/audit/${entityType}/${entityId}`).then(json<AuditEntry[]>),
 };

--- a/samples/CrmErpDemo/Erp.Web/src/components/AuditLog.tsx
+++ b/samples/CrmErpDemo/Erp.Web/src/components/AuditLog.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+import { AuditEntry, api } from '../api';
+
+interface Props {
+  entityType: 'Customer' | 'ErpContact';
+  entityId: string | undefined;
+}
+
+interface Group {
+  key: string;
+  timestamp: string;
+  origin?: string | null;
+  rows: AuditEntry[];
+  action: string;
+}
+
+// Reads /api/audit/{entityType}/{entityId} and renders the change history as
+// a vertical timeline. Updated rows are grouped by their (timestamp, action)
+// because a single SaveChanges may produce many field rows that share the
+// same instant — we want them under one "06/05/26 12:34:56 — Updated" header
+// rather than one bullet per field.
+export default function AuditLog({ entityType, entityId }: Props) {
+  const [entries, setEntries] = useState<AuditEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!entityId) return;
+    let cancelled = false;
+    setError(null);
+    api
+      .getAuditLog(entityType, entityId)
+      .then(rs => { if (!cancelled) setEntries(rs); })
+      .catch(err => { if (!cancelled) setError(err instanceof Error ? err.message : String(err)); });
+    return () => { cancelled = true; };
+  }, [entityType, entityId]);
+
+  if (!entityId) return null;
+
+  const groups = group(entries ?? []);
+
+  return (
+    <section className="bg-white rounded-lg shadow-sm border border-slate-200 p-6 space-y-3">
+      <h2 className="text-base font-semibold text-slate-700">Audit log</h2>
+      {error && <div className="text-sm text-red-700">Failed to load audit history: {error}</div>}
+      {entries === null && !error && <div className="text-sm text-slate-400">Loading…</div>}
+      {entries !== null && groups.length === 0 && (
+        <div className="text-sm text-slate-400">No history yet.</div>
+      )}
+      {groups.length > 0 && (
+        <ol className="relative pl-6 space-y-4 before:absolute before:left-2 before:top-1 before:bottom-1 before:w-px before:bg-slate-200">
+          {groups.map(g => (
+            <li key={g.key} className="relative">
+              <span className={`absolute left-[-22px] top-1.5 w-3 h-3 rounded-full border-2 border-white ${dotClass(g.action)}`} />
+              <div className="flex flex-wrap items-center gap-2 text-xs">
+                <span className={`px-1.5 py-0.5 rounded font-semibold uppercase tracking-wide ${badgeClass(g.action)}`}>{g.action}</span>
+                <span className="font-mono text-slate-500">{formatTimestamp(g.timestamp)}</span>
+                {g.origin && (
+                  <span className="px-1.5 py-0.5 rounded bg-slate-100 text-slate-600 font-mono">via {g.origin}</span>
+                )}
+              </div>
+              {g.action === 'Updated' && (
+                <ul className="mt-1 text-sm text-slate-700 space-y-0.5">
+                  {g.rows.filter(r => r.fieldName).map(r => (
+                    <li key={r.id}>
+                      <span className="font-medium text-slate-600">{r.fieldName}</span>:{' '}
+                      <span className="font-mono text-slate-400 line-through">{display(r.oldValue)}</span>
+                      {' → '}
+                      <span className="font-mono text-slate-800">{display(r.newValue)}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {g.action === 'Created' && g.rows[0]?.newValue && (
+                <details className="mt-1 text-sm">
+                  <summary className="text-xs text-slate-500 cursor-pointer hover:underline">Initial values</summary>
+                  <pre className="mt-1 px-2 py-1 bg-slate-50 border border-slate-100 rounded text-[11px] font-mono overflow-x-auto whitespace-pre-wrap">{prettyJson(g.rows[0].newValue)}</pre>
+                </details>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+function group(entries: AuditEntry[]): Group[] {
+  // Server returns newest-first; keep that order.
+  const out: Group[] = [];
+  for (const e of entries) {
+    const last = out[out.length - 1];
+    if (last && last.timestamp === e.timestamp && last.action === e.action) {
+      last.rows.push(e);
+    } else {
+      out.push({ key: e.id, timestamp: e.timestamp, origin: e.origin, action: e.action, rows: [e] });
+    }
+  }
+  return out;
+}
+
+function display(v: string | null | undefined): string {
+  if (v === null || v === undefined || v === '') return '∅';
+  return v;
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}
+
+function prettyJson(raw: string): string {
+  try { return JSON.stringify(JSON.parse(raw), null, 2); } catch { return raw; }
+}
+
+function badgeClass(action: string): string {
+  switch (action) {
+    case 'Created': return 'bg-emerald-100 text-emerald-800';
+    case 'Updated': return 'bg-indigo-100 text-indigo-800';
+    case 'Deleted': return 'bg-rose-100 text-rose-800';
+    default:        return 'bg-slate-100 text-slate-700';
+  }
+}
+
+function dotClass(action: string): string {
+  switch (action) {
+    case 'Created': return 'bg-emerald-500';
+    case 'Updated': return 'bg-indigo-500';
+    case 'Deleted': return 'bg-rose-500';
+    default:        return 'bg-slate-400';
+  }
+}

--- a/samples/CrmErpDemo/Erp.Web/src/components/admin/handoff-mode-panel.tsx
+++ b/samples/CrmErpDemo/Erp.Web/src/components/admin/handoff-mode-panel.tsx
@@ -65,16 +65,19 @@ export default function HandoffModePanel() {
             Erp.Api settles the message after the configured delay.
           </p>
         </div>
-        <label className="inline-flex items-center gap-2 cursor-pointer">
-          <span className="text-xs text-slate-600">{enabled ? 'ON' : 'OFF'}</span>
-          <input
-            type="checkbox"
-            checked={enabled}
-            onChange={(e) => setEnabled(e.target.checked)}
-            disabled={!loaded}
-            className="h-4 w-4 accent-indigo-600"
-          />
-        </label>
+        <button
+          type="button"
+          onClick={() => setEnabled((v) => !v)}
+          disabled={!loaded}
+          className={`px-3 py-1.5 rounded-md text-xs font-medium disabled:opacity-50 ${
+            enabled
+              ? 'bg-indigo-600 text-white hover:bg-indigo-700'
+              : 'bg-slate-200 text-slate-700 hover:bg-slate-300'
+          }`}
+          title="When ON, CrmAccountCreated returns PendingHandoff and Erp.Api settles the message after the configured delay."
+        >
+          {`Pending-handoff mode: ${enabled ? 'ON' : 'OFF'}`}
+        </button>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/samples/CrmErpDemo/Erp.Web/src/pages/ContactForm.tsx
+++ b/samples/CrmErpDemo/Erp.Web/src/pages/ContactForm.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Contact, Customer, api } from '../api';
 import { randomPerson, randomPick } from '../fakeData';
+import AuditLog from '../components/AuditLog';
 
 export default function ContactForm() {
   const { id } = useParams();
@@ -43,7 +44,8 @@ export default function ContactForm() {
   const lock = form.isDeleted ?? false;
 
   return (
-    <form onSubmit={submit} className="max-w-xl bg-white rounded-lg shadow-sm border border-slate-200 p-6 space-y-4">
+    <div className="max-w-xl space-y-4">
+    <form onSubmit={submit} className="bg-white rounded-lg shadow-sm border border-slate-200 p-6 space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">{id ? 'Edit contact' : 'New contact'}</h1>
         {!id && (
@@ -92,5 +94,7 @@ export default function ContactForm() {
         )}
       </div>
     </form>
+    {id && <AuditLog entityType="ErpContact" entityId={id} />}
+    </div>
   );
 }

--- a/samples/CrmErpDemo/Erp.Web/src/pages/CustomerForm.tsx
+++ b/samples/CrmErpDemo/Erp.Web/src/pages/CustomerForm.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Customer, api } from '../api';
 import { randomCompany } from '../fakeData';
+import AuditLog from '../components/AuditLog';
 
 export default function CustomerForm() {
   const { id } = useParams();
@@ -41,7 +42,8 @@ export default function CustomerForm() {
   }
 
   return (
-    <form onSubmit={submit} className="max-w-xl bg-white rounded-lg shadow-sm border border-slate-200 p-6 space-y-4">
+    <div className="max-w-xl space-y-4">
+    <form onSubmit={submit} className="bg-white rounded-lg shadow-sm border border-slate-200 p-6 space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">{id ? 'Edit customer' : 'New customer'}</h1>
         {!id && (
@@ -70,6 +72,8 @@ export default function CustomerForm() {
         )}
       </div>
     </form>
+    {id && <AuditLog entityType="Customer" entityId={id} />}
+    </div>
   );
 }
 

--- a/samples/CrmErpDemo/e2e/README.md
+++ b/samples/CrmErpDemo/e2e/README.md
@@ -11,10 +11,14 @@ NimBus management WebApp UI to resubmit, and asserts on cross-system state.
 | `01-happy-path.spec.ts` | CRM → ERP propagation, ERP → CRM propagation, both endpoints stay clean |
 | `02-error-mode-recovery.spec.ts` | Single message fails (ERP error mode) → resubmit via NimBus WebApp UI → success. Plus a service-mode silent-drop variant. |
 | `03-blocked-messages-recovery.spec.ts` | One create + N updates published while ERP is in error mode. Head fails, siblings defer behind the session lock. Resubmit head from the WebApp; verify the deferred backlog drains in order and all endpoints return to zero. |
+| `04-pending-handoff-success.spec.ts` | Handoff mode ON: create handed off, sibling updates defer behind the in-flight handoff, `HandoffJobBackgroundService` settles via `CompleteHandoff`, all rows reach Completed. |
+| `05-pending-handoff-failure.spec.ts` | Handoff mode at failureRate=1.0: `FailHandoff` carries DMF error text → audit row Failed → operator Skip via NimBus REST → Skipped. |
+| `06-pending-handoff-resubmit.spec.ts` | Same trigger as 05, but operator clicks Resubmit in the NimBus.WebApp UI (handoff mode disabled first); audit row leaves Failed and the ERP customer materialises. |
 
-The first two tests use REST APIs for setup/teardown and the WebApp browser
-only for the operator action being demonstrated. The third test also exercises
-the WebApp endpoints-list view (drilling in via UI click).
+Setup and teardown go through REST APIs; the WebApp browser is used for the
+operator action being demonstrated. Specs 02, 03 and 06 drive the WebApp
+endpoints-list view (drilling in via UI click and clicking Resubmit on a
+row); specs 04 and 05 are pure REST.
 
 ## Prerequisites
 

--- a/samples/CrmErpDemo/e2e/tests/06-pending-handoff-resubmit.spec.ts
+++ b/samples/CrmErpDemo/e2e/tests/06-pending-handoff-resubmit.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from "@playwright/test";
+import { CrmApiClient } from "../helpers/crm-api-client.js";
+import { ErpApiClient } from "../helpers/erp-api-client.js";
+import { NimBusApiClient, type NimBusEvent } from "../helpers/nimbus-api-client.js";
+import { Timeouts } from "../helpers/service-urls.js";
+import { waitFor } from "../helpers/wait-for.js";
+
+/**
+ * PendingHandoff failure → operator Resubmit via NimBus.WebApp UI.
+ *
+ * Companion to spec 05 (which exercises Skip via REST). Here the operator
+ * action is the same one used in 02-error-mode-recovery — driving the WebApp
+ * UI's Resubmit button on the row in the endpoint detail page. The handoff
+ * landing as Failed shares its operator-action surface with synchronous
+ * failures, so the recovery flow should look identical from the UI side.
+ */
+test.describe("PendingHandoff failure: handoff fails → operator Resubmit via WebApp UI → succeeds", () => {
+  let crm: CrmApiClient;
+  let erp: ErpApiClient;
+  let nimbus: NimBusApiClient;
+
+  test.beforeAll(async () => {
+    crm = await CrmApiClient.create();
+    erp = await ErpApiClient.create();
+    nimbus = await NimBusApiClient.create();
+    await erp.resetFailureModes();
+    await erp.resetHandoffMode();
+  });
+
+  test.afterEach(async () => {
+    await erp.resetHandoffMode();
+  });
+
+  test.afterAll(async () => {
+    await erp.resetFailureModes();
+    await erp.resetHandoffMode();
+    await crm.dispose();
+    await erp.dispose();
+    await nimbus.dispose();
+  });
+
+  test("create + handoff fails → Failed row → Resubmit in WebApp → Completed + ERP customer materialises", async ({ page }) => {
+    // ── 1. Force every handoff settlement to fail with a DMF-style error.
+    await erp.setHandoffMode({ enabled: true, durationSeconds: 3, failureRate: 1.0 });
+
+    // ── 2. Create one CRM account. Single-message scenario: no siblings.
+    const legalName = `Handoff-Resubmit-${Date.now()}`;
+    const account = await crm.createAccount({ legalName, countryCode: "FR" });
+
+    // ── 3. Wait for the audit row to reach Failed with the DMF errorText.
+    //       ~3s deadline + 1s BackgroundService tick + slack.
+    const failedEvent: NimBusEvent = await waitFor(
+      async () => {
+        const events = await nimbus.searchEvents("ErpEndpoint", {
+          sessionId: account.id,
+          eventTypeId: ["CrmAccountCreated"],
+          resolutionStatus: ["Failed"],
+        });
+        return events[0] ?? null;
+      },
+      {
+        timeoutMs: Timeouts.failedMessageMs,
+        description: `Failed CrmAccountCreated audit row for session ${account.id}`,
+      },
+    );
+    expect(failedEvent.eventId, "eventId").toBeTruthy();
+    expect(failedEvent.lastMessageId, "lastMessageId").toBeTruthy();
+    const errorText = failedEvent.messageContent?.errorContent?.errorText ?? "";
+    expect(errorText, "messageContent.errorContent.errorText").toMatch(/^DMF rejected:/);
+
+    // Sanity: ERP customer was NOT created (FailHandoff path skips the upsert).
+    expect(await erp.findCustomerByCrmAccountId(account.id)).toBeNull();
+
+    // ── 4. Disable handoff mode BEFORE clicking Resubmit. Otherwise the
+    //       redelivery would just hand off + fail again and the test would
+    //       race. Mirrors the setErrorMode(false) step in spec 02.
+    await erp.setHandoffMode({ enabled: false, durationSeconds: 3, failureRate: 0 });
+
+    // ── 5. Operator opens the NimBus WebApp, navigates to ErpEndpoint detail,
+    //       confirms the failed handoff row is visible, and clicks "Resubmit".
+    await page.goto(`/Endpoints/Details/ErpEndpoint`);
+    const failedRow = page.locator("table tbody tr").filter({ hasText: failedEvent.eventId.substring(0, 8) });
+    await expect(failedRow).toBeVisible();
+    await expect(failedRow).toContainText("Failed");
+    await failedRow.locator("button", { hasText: "Resubmit" }).click();
+
+    // ── 6. With handoff mode off, the resubmitted message hits the synchronous
+    //       upsert path in the ERP adapter, so the customer should now exist.
+    const erpCustomer = await waitFor(
+      async () => await erp.findCustomerByCrmAccountId(account.id),
+      { timeoutMs: Timeouts.propagationMs, description: `ERP customer created after handoff Resubmit (${account.id})` },
+    );
+    expect(erpCustomer.legalName).toBe(legalName);
+
+    // ── 7. The original eventId should leave the Failed bucket (Resolver
+    //       MERGE-overwrites Failed → Completed for the same id).
+    await waitFor(
+      async () => {
+        const events = await nimbus.searchEvents("ErpEndpoint", { resolutionStatus: ["Failed"] });
+        const stillFailed = events.find((e) => e.eventId === failedEvent.eventId);
+        return stillFailed ? null : true;
+      },
+      { timeoutMs: Timeouts.failedMessageMs, description: `Failed event ${failedEvent.eventId} cleared after Resubmit` },
+    );
+  });
+});

--- a/src/NimBus.MessageStore.SqlServer/SqlServerSchemaInitializer.cs
+++ b/src/NimBus.MessageStore.SqlServer/SqlServerSchemaInitializer.cs
@@ -79,28 +79,47 @@ internal sealed class SqlServerSchemaInitializer : IHostedService
         // don't race on `CREATE SCHEMA` or on the IF-OBJECT_ID/CREATE TABLE pair.
         // The second runner waits, finds the schema already created and the
         // journal populated, and exits without applying anything.
-        await using (var lockConn = new SqlConnection(_options.ConnectionString))
+        //
+        // Disable connection pooling for the lock connection: the @LockOwner=Session
+        // applock is released only when the SQL session ends, and a pooled
+        // SqlConnection.Dispose() returns the physical session to the pool instead
+        // of closing it. Without `Pooling=False`, the lock stays held for as long
+        // as the pool keeps the session alive — which can far exceed the second
+        // runner's 60 s wait — and they all time out. We also explicitly call
+        // sp_releaseapplock as belt-and-braces before disposing.
+        var lockConnString = new SqlConnectionStringBuilder(_options.ConnectionString)
+        {
+            Pooling = false,
+        }.ConnectionString;
+        await using (var lockConn = new SqlConnection(lockConnString))
         {
             await lockConn.OpenAsync(cancellationToken).ConfigureAwait(false);
             await AcquireSchemaUpgradeLock(lockConn, cancellationToken).ConfigureAwait(false);
 
-            // DbUp's journal table lives in the configured schema, and journal setup
-            // runs before any DbUp script. Bootstrap the schema directly so journal
-            // creation has somewhere to land; 0001_Schema.sql remains idempotent.
-            await EnsureSchemaExists(cancellationToken).ConfigureAwait(false);
-
-            var assembly = typeof(SqlServerSchemaInitializer).Assembly;
-            var upgrader = BuildUpgrader(assembly);
-
-            var result = upgrader.PerformUpgrade();
-            if (!result.Successful)
+            try
             {
-                throw new InvalidOperationException(
-                    $"DbUp failed to apply NimBus message-store schema: {result.Error?.Message}", result.Error);
-            }
+                // DbUp's journal table lives in the configured schema, and journal setup
+                // runs before any DbUp script. Bootstrap the schema directly so journal
+                // creation has somewhere to land; 0001_Schema.sql remains idempotent.
+                await EnsureSchemaExists(cancellationToken).ConfigureAwait(false);
 
-            _logger.LogInformation("SQL Server message-store schema upgrade applied {Count} script(s).",
-                result.Scripts.Count());
+                var assembly = typeof(SqlServerSchemaInitializer).Assembly;
+                var upgrader = BuildUpgrader(assembly);
+
+                var result = upgrader.PerformUpgrade();
+                if (!result.Successful)
+                {
+                    throw new InvalidOperationException(
+                        $"DbUp failed to apply NimBus message-store schema: {result.Error?.Message}", result.Error);
+                }
+
+                _logger.LogInformation("SQL Server message-store schema upgrade applied {Count} script(s).",
+                    result.Scripts.Count());
+            }
+            finally
+            {
+                await ReleaseSchemaUpgradeLock(lockConn, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 
@@ -138,6 +157,24 @@ internal sealed class SqlServerSchemaInitializer : IHostedService
             throw new InvalidOperationException(
                 $"Could not acquire schema-upgrade lock for '{resource}' on the SQL Server (sp_getapplock returned {status}). " +
                 "Another NimBus instance may be holding the lock; retry once it finishes, or extend the lockTimeout.");
+        }
+    }
+
+    private async Task ReleaseSchemaUpgradeLock(SqlConnection conn, CancellationToken cancellationToken)
+    {
+        var resource = $"NimBus.Schema.{_options.Schema}";
+        try
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "EXEC sp_releaseapplock @Resource = @res, @LockOwner = N'Session'";
+            cmd.Parameters.AddWithValue("@res", resource);
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Don't let release failures mask the real error from DbUp; we already
+            // disable pooling on this connection so the session ends on Dispose.
+            _logger.LogWarning(ex, "Failed to release schema-upgrade lock '{Resource}'; relying on session close.", resource);
         }
     }
 

--- a/src/NimBus.WebApp/ClientApp/public/nimbus_ascii_logo.svg
+++ b/src/NimBus.WebApp/ClientApp/public/nimbus_ascii_logo.svg
@@ -1,8 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 116" role="img" aria-labelledby="title desc">
   <title id="title">NimBus</title>
   <desc id="desc">ASCII art logo for NimBus.</desc>
-  <rect width="520" height="116" rx="16" fill="#f8fafc" stroke="#cbd5e1" />
-  <text font-family="'Courier New', Courier, monospace" font-size="15" fill="#0f172a" xml:space="preserve">
+  <text font-family="'Courier New', Courier, monospace" font-size="15" fill="currentColor" xml:space="preserve">
     <tspan x="18" y="30"> _   _ _           ____             </tspan>
     <tspan x="18" dy="20">| \ | (_)_ __ ___ | __ ) _   _ ___  </tspan>
     <tspan x="18" dy="20">|  \| | | '_ ` _ \|  _ \| | | / __| </tspan>

--- a/src/NimBus.WebApp/ClientApp/src/components/endpoint-details/events-panel.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/endpoint-details/events-panel.tsx
@@ -37,7 +37,7 @@ const ACTIONABLE_STATUSES = [
 ];
 
 // URL sentinel meaning "user explicitly wants no status filter". We need this
-// because an absent `status` param falls back to defaults (Failed/DeadLettered/Unsupported) — so without
+// because an absent `status` param falls back to defaults (Failed/DeadLettered/Unsupported/Pending) — so without
 // the sentinel, "show all statuses" would silently revert to the default after
 // any navigation. Pressing "All statuses" or removing the last chip writes
 // `?status=*`; buildEventFilterFromParams translates it back to no filter
@@ -51,9 +51,11 @@ function isAllStatusesSentinel(status: string[]): boolean {
 // URL-driven filter shape. Only the most-visible fields are persisted; advanced
 // filters (payload, enqueued, updated) live in the FilterContext as draft state
 // only and are picked up at Search-time. The default `status` set of
-// "Failed + DeadLettered + Unsupported" matches the operator UX where the page
-// opens pre-filtered to the most common failed-message states (also the Reset
-// target). Declared as a closed `type` so it
+// "Failed + DeadLettered + Unsupported + Pending" matches the operator UX where
+// the page opens pre-filtered to messages that need attention (failed states)
+// plus in-flight Pending entries — most importantly Pending+Handoff rows, which
+// stay Pending until an external system settles them and are exactly what
+// operators want to see at a glance. Declared as a closed `type` so it
 // satisfies the index-signature constraint of `useUrlFilters<T>`.
 type EndpointFilterParams = {
   status: string[];
@@ -69,6 +71,7 @@ const DEFAULT_ENDPOINT_FILTER_PARAMS: EndpointFilterParams = {
     api.ResolutionStatus.Failed,
     api.ResolutionStatus.DeadLettered,
     api.ResolutionStatus.Unsupported,
+    api.ResolutionStatus.Pending,
   ],
   eventTypeId: [],
   eventId: "",

--- a/src/NimBus.WebApp/ClientApp/src/components/header.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/header.tsx
@@ -9,6 +9,32 @@ const MenuItem: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <span className="block mr-6 p-1.5 md:mt-0 mt-4">{children}</span>
 );
 
+// Inline so the ASCII glyphs inherit `currentColor` from the wrapping <a>'s
+// text-foreground — that's what makes the logo invert on dark mode without
+// shipping a second asset. Keep this in sync with public/nimbus_ascii_logo.svg.
+const NimBusLogo: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 520 116"
+    role="img"
+    aria-label="NimBus"
+    className={className}
+  >
+    <text
+      fontFamily="'Courier New', Courier, monospace"
+      fontSize="15"
+      fill="currentColor"
+      xmlSpace="preserve"
+    >
+      <tspan x="18" y="30">{` _   _ _           ____             `}</tspan>
+      <tspan x="18" dy="20">{`| \\ | (_)_ __ ___ | __ ) _   _ ___  `}</tspan>
+      <tspan x="18" dy="20">{`|  \\| | | '_ \` _ \\|  _ \\| | | / __| `}</tspan>
+      <tspan x="18" dy="20">{`| |\\  | | | | | | | |_) | |_| \\__ \\ `}</tspan>
+      <tspan x="18" dy="20">{`|_| \\_|_|_| |_| |_|____/ \\__,_|___/ `}</tspan>
+    </text>
+  </svg>
+);
+
 interface HeaderProps {
   links: Navigation;
   className?: string;
@@ -29,12 +55,8 @@ const Header = (props: HeaderProps) => {
     >
       <div className="flex flex-nowrap items-center self-center justify-between w-full">
         <div className="flex items-center mr-5">
-          <a href="/Endpoints" className="text-xl hover:no-underline">
-            <img
-              src="/nimbus_ascii_logo.png"
-              className="h-12 w-auto max-w-none"
-              alt="NimBus"
-            />
+          <a href="/Endpoints" className="text-xl hover:no-underline text-foreground">
+            <NimBusLogo className="h-12 w-auto" />
           </a>
           <span className="hidden lg:inline ml-3 text-sm text-muted-foreground italic">
             A nimbus for your Azure cloud.


### PR DESCRIPTION
## Summary

A grab-bag of CrmErpDemo polish and a handful of small NimBus fixes that came up while improving the demo. The schema-lock fix is also being shipped on its own in #36 — once one merges, the other becomes a clean no-op.

### Commits

- **fix(sqlserver): release applock and disable pooling on lock connection** — same fix as #36; included here so the demo branch builds standalone.
- **feat(samples): per-record audit log for CRM/ERP customers and contacts** — clicking on an Account/Contact (CRM) or Customer/ErpContact (ERP) now shows what changed, the previous and new values, and the timestamp. Both REST edits and inbound NimBus events produce audit rows; the Origin column captures provenance. Implemented as a `DbContext.SaveChangesAsync` override + new `Audits` table (idempotent migration extends the existing block) + `GET /api/audit/{entityType}/{entityId}` + an `<AuditLog>` panel in each `*Form.tsx`.
- **chore(samples): resolver no longer waits on provisioner** — Resolver only needs the Service Bus connection at startup; the topology can land in parallel and the processor reconnects when the subscription appears. Drops 24 s off cold-boot Resolver gating.
- **fix(webapp): make NimBus logo theme-aware** — the header rendered `nimbus_ascii_logo.png` (dark glyphs on a baked-in light card) which disappeared in dark mode. Inlined as a React component with `fill=\"currentColor\"` so it inherits `text-foreground` from the wrapping `<a>`.
- **chore(webapp): include Pending in endpoint-details default status filter** — operators landing on an endpoint detail page now see Pending entries (most importantly Pending+Handoff rows that wait for an external system) alongside the failed states.

Older commits already on this branch from the prior session (provisioner-wait removal, handoff toggle button, UI-driven handoff resubmit e2e) carry over.

## Test plan

- [ ] CrmErpDemo end-to-end via `aspire run` from `samples/CrmErpDemo/CrmErpDemo.AppHost`:
  - Resolver and nimbus-ops both come up healthy without lock-timeout.
  - Resolver no longer shows a 24 s wait gate behind the provisioner.
  - Create/edit/delete a CRM Account → CRM audit log shows Created (with JSON snapshot) → linked Updates from `ErpCustomerCreated` → field-diff Updates from the explicit edit → Deleted summary row. Mirrored ERP Customer audit shows the field updates with `origin=Crm`.
  - Repeat for a CRM Contact and ERP Customer + ERP ErpContact.
  - Toggle dark mode in nimbus-ops — logo remains visible.
  - Open an endpoint with a `Pending+Handoff` row: it appears in the default view without manually adding the chip.
- [ ] `dotnet build src/NimBus.sln` clean.
- [ ] `dotnet test tests/NimBus.Resolver.Tests/NimBus.Resolver.Tests.csproj` and `tests/NimBus.EndToEnd.Tests` (filter `AsyncCompletion`) still green.