### PR TITLE
fix(resolver): wall-clock processing time for async-handoff events

### DIFF
--- a/src/NimBus.Resolver/Services/ResolverService.cs
+++ b/src/NimBus.Resolver/Services/ResolverService.cs
@@ -5,6 +5,7 @@ using NimBus.MessageStore;
 using NimBus.MessageStore.Abstractions;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -212,7 +213,7 @@ namespace NimBus.Broker.Services
             return (endpointId, endpointRole);
         }
 
-        private UnresolvedEvent CreateUnresolvedEvent(MessageEntity message)
+        private UnresolvedEvent CreateUnresolvedEvent(MessageEntity message, long? processingTimeMsOverride = null)
         {
             return new UnresolvedEvent
             {
@@ -243,7 +244,11 @@ namespace NimBus.Broker.Services
                 From = message.From,
                 MessageContent = message.MessageContent,
                 QueueTimeMs = message.QueueTimeMs,
-                ProcessingTimeMs = message.ProcessingTimeMs,
+                // For terminal settlement of an event that went through async
+                // handoff, override the per-hop handler duration with the
+                // wall-clock span from the original EventRequest. The raw value
+                // remains on the per-message MessageEntity row for auditing.
+                ProcessingTimeMs = processingTimeMsOverride ?? message.ProcessingTimeMs,
                 // PendingHandoff metadata: copy through from the projected
                 // MessageEntity so the UnresolvedEvent (i.e. the audit row
                 // surfaced by the WebApp) carries them too.
@@ -254,10 +259,38 @@ namespace NimBus.Broker.Services
             };
         }
 
+        // Returns the wall-clock duration since the original EventRequest's
+        // EnqueuedTimeUtc when settling a terminal response (Resolution/Error)
+        // for an event that previously emitted a PendingHandoffResponse.
+        // Returns null otherwise so the regular per-hop ProcessingTimeMs wins.
+        private async Task<long?> ComputeHandoffWallClockMsIfTerminal(MessageEntity message)
+        {
+            if (message.MessageType != MessageType.ResolutionResponse &&
+                message.MessageType != MessageType.ErrorResponse)
+            {
+                return null;
+            }
+
+            var history = (await _store.GetEventHistory(message.EventId)).ToList();
+            if (!history.Any(m => m.MessageType == MessageType.PendingHandoffResponse))
+            {
+                return null;
+            }
+
+            var eventRequest = history.FirstOrDefault(m => m.MessageType == MessageType.EventRequest);
+            if (eventRequest is null)
+            {
+                return null;
+            }
+
+            return (long)Math.Max(0, (DateTime.UtcNow - eventRequest.EnqueuedTimeUtc).TotalMilliseconds);
+        }
+
         private async Task<ResolutionStatus> UpdateState(MessageEntity message)
         {
             ResolutionStatus status = GetResultingStatus(message);
-            UnresolvedEvent unresolvedEvent = CreateUnresolvedEvent(message);
+            long? wallClockMs = await ComputeHandoffWallClockMsIfTerminal(message);
+            UnresolvedEvent unresolvedEvent = CreateUnresolvedEvent(message, wallClockMs);
 
             var statusHandlers = new Dictionary<ResolutionStatus, Func<Task>>
             {

--- a/tests/NimBus.Resolver.Tests/ResolverServiceTests.cs
+++ b/tests/NimBus.Resolver.Tests/ResolverServiceTests.cs
@@ -109,6 +109,127 @@ public class ResolverServiceTests
     }
 
     [TestMethod]
+    public async Task Handle_TerminalAfterHandoff_OverridesProcessingTimeWithWallClock()
+    {
+        // Simulates the lifecycle of a handoff event:
+        //   T0       — EventRequest enqueued (the wall-clock anchor)
+        //   T0+200ms — PendingHandoffResponse audit row arrives
+        //   ...long external job runs...
+        //   now()    — Final ResolutionResponse settles the event
+        // The aggregate UnresolvedEvent's ProcessingTimeMs must reflect the
+        // full wall-clock span (now − EventRequest.EnqueuedTimeUtc), not the
+        // 250ms handler duration of the final hop.
+        var cosmos = new FakeCosmosDbClient();
+        var eventRequestEnqueued = DateTime.UtcNow.AddSeconds(-30);
+
+        cosmos.StoredMessages.Add(new MessageEntity
+        {
+            EventId = "event-1",
+            MessageId = "msg-event-request",
+            MessageType = MessageType.EventRequest,
+            EnqueuedTimeUtc = eventRequestEnqueued,
+            EndpointId = "BillingEndpoint",
+        });
+        cosmos.StoredMessages.Add(new MessageEntity
+        {
+            EventId = "event-1",
+            MessageId = "msg-pending-handoff",
+            MessageType = MessageType.PendingHandoffResponse,
+            EnqueuedTimeUtc = eventRequestEnqueued.AddMilliseconds(200),
+            EndpointId = "BillingEndpoint",
+            PendingSubStatus = "Handoff",
+        });
+
+        var resolutionResponse = CreateMessageContext(
+            messageType: MessageType.ResolutionResponse,
+            to: "Resolver",
+            from: "BillingEndpoint");
+        resolutionResponse.ProcessingTimeMs = 250; // raw last-hop handler duration
+
+        var service = CreateService(cosmos);
+        await service.Handle(resolutionResponse);
+
+        Assert.AreEqual(1, cosmos.CompletedUploads.Count, "Terminal upload should have run.");
+        var completed = cosmos.CompletedUploads[0].Content;
+        Assert.IsNotNull(completed.ProcessingTimeMs, "Wall-clock value must be populated.");
+        Assert.IsTrue(completed.ProcessingTimeMs >= 30_000,
+            $"Expected wall-clock ≥ 30s; got {completed.ProcessingTimeMs}ms.");
+        Assert.IsTrue(completed.ProcessingTimeMs < 60_000,
+            $"Wall-clock should be the EventRequest→now span, not far longer; got {completed.ProcessingTimeMs}ms.");
+
+        // Per-message audit row preserves the raw last-hop duration.
+        var resolutionRow = cosmos.StoredMessages.Single(m => m.MessageType == MessageType.ResolutionResponse);
+        Assert.AreEqual(250, resolutionRow.ProcessingTimeMs);
+    }
+
+    [TestMethod]
+    public async Task Handle_TerminalWithoutHandoff_KeepsHandlerProcessingTime()
+    {
+        // Non-handoff event: history has only the EventRequest. The override
+        // must not trigger; the response's local handler duration (75ms) wins.
+        var cosmos = new FakeCosmosDbClient();
+        cosmos.StoredMessages.Add(new MessageEntity
+        {
+            EventId = "event-1",
+            MessageId = "msg-event-request",
+            MessageType = MessageType.EventRequest,
+            EnqueuedTimeUtc = DateTime.UtcNow.AddSeconds(-30),
+            EndpointId = "BillingEndpoint",
+        });
+
+        var resolutionResponse = CreateMessageContext(
+            messageType: MessageType.ResolutionResponse,
+            to: "Resolver",
+            from: "BillingEndpoint");
+        resolutionResponse.ProcessingTimeMs = 75;
+
+        var service = CreateService(cosmos);
+        await service.Handle(resolutionResponse);
+
+        Assert.AreEqual(1, cosmos.CompletedUploads.Count);
+        Assert.AreEqual(75, cosmos.CompletedUploads[0].Content.ProcessingTimeMs);
+    }
+
+    [TestMethod]
+    public async Task Handle_HandoffFailure_OverridesProcessingTimeOnErrorResponse()
+    {
+        // HandoffFailedRequest path: the terminal ErrorResponse must also use
+        // the wall-clock span. Symmetric with the success path above.
+        var cosmos = new FakeCosmosDbClient();
+        var eventRequestEnqueued = DateTime.UtcNow.AddSeconds(-30);
+
+        cosmos.StoredMessages.Add(new MessageEntity
+        {
+            EventId = "event-1",
+            MessageId = "msg-event-request",
+            MessageType = MessageType.EventRequest,
+            EnqueuedTimeUtc = eventRequestEnqueued,
+            EndpointId = "BillingEndpoint",
+        });
+        cosmos.StoredMessages.Add(new MessageEntity
+        {
+            EventId = "event-1",
+            MessageId = "msg-pending-handoff",
+            MessageType = MessageType.PendingHandoffResponse,
+            EnqueuedTimeUtc = eventRequestEnqueued.AddMilliseconds(200),
+            EndpointId = "BillingEndpoint",
+            PendingSubStatus = "Handoff",
+        });
+
+        var errorResponse = CreateMessageContext(
+            messageType: MessageType.ErrorResponse,
+            to: "Resolver",
+            from: "BillingEndpoint");
+        errorResponse.ProcessingTimeMs = 50;
+
+        var service = CreateService(cosmos);
+        await service.Handle(errorResponse);
+
+        Assert.AreEqual(1, cosmos.FailedUploads.Count);
+        Assert.IsTrue(cosmos.FailedUploads[0].Content.ProcessingTimeMs >= 30_000);
+    }
+
+    [TestMethod]
     public async Task Handle_UnexpectedException_DeadLettersMessage()
     {
         var cosmos = new FakeCosmosDbClient
@@ -334,7 +455,8 @@ public class ResolverServiceTests
         public Task<bool> SetHeartbeat(Heartbeat heartbeat, string endpointId) => throw new NotSupportedException();
         public Task<MessageSearchResult> SearchMessages(MessageFilter filter, string? continuationToken, int maxItemCount) => throw new NotSupportedException();
         public Task<MessageEntity> GetMessage(string eventId, string messageId) => throw new NotSupportedException();
-        public Task<IEnumerable<MessageEntity>> GetEventHistory(string eventId) => throw new NotSupportedException();
+        public Task<IEnumerable<MessageEntity>> GetEventHistory(string eventId) =>
+            Task.FromResult<IEnumerable<MessageEntity>>(StoredMessages.Where(m => m.EventId == eventId).ToList());
         public Task<MessageEntity> GetFailedMessage(string eventId, string endpointId) => throw new NotSupportedException();
         public Task<MessageEntity> GetDeadletteredMessage(string eventId, string endpointId) => throw new NotSupportedException();
         public Task RemoveStoredMessage(string eventId, string messageId) => throw new NotSupportedException();


### PR DESCRIPTION
## Summary

For an event that goes through async handoff (e.g. `CrmAccountCreated` → adapter signals `MarkPendingHandoff` → external system later calls back via `HandoffCompletedRequest` → final `ResolutionResponse`), the WebApp Event Details page currently shows **Processing Time = ~150 ms**, but the user expects it to be the **wall-clock duration from when the EventRequest started being processed until the event reached its terminal status** — typically tens of seconds when an external job is involved.

What's actually shown is the local handler duration of the *final* hop (the subscriber processing the `HandoffCompletedRequest` → `ResolutionResponse`). Each `UpsertStatus` MERGE UPDATE overwrites `ProcessingTimeMs` with whatever timing the most-recent message carried, so by the time the row reaches `Completed`, the original EventRequest timing is gone and the displayed value reflects only the last hop.

## Approach

Compute the wall-clock value on the Resolver side, at the final terminal upsert of a handoff event, by looking up the original EventRequest from the per-message history (`IMessageTrackingStore.GetEventHistory`).

When **all** of:

1. The incoming message is `ResolutionResponse` or `ErrorResponse`.
2. Event history contains a `PendingHandoffResponse` row.
3. An `EventRequest` row exists in history.

…then `ProcessingTimeMs` on the projected `UnresolvedEvent` is overridden to `now − EventRequest.EnqueuedTimeUtc`. The per-message `MessageEntity` row keeps its raw last-hop duration for accurate auditing — only the aggregate row gets the wall-clock value.

For *non-handoff* events the override does not trigger; behavior is unchanged.

## Test plan

- [x] `dotnet test tests/NimBus.Resolver.Tests/NimBus.Resolver.Tests.csproj` — 10/10 pass (3 new):
  - `Handle_TerminalAfterHandoff_OverridesProcessingTimeWithWallClock` — ResolutionResponse override.
  - `Handle_HandoffFailure_OverridesProcessingTimeOnErrorResponse` — symmetric ErrorResponse path.
  - `Handle_TerminalWithoutHandoff_KeepsHandlerProcessingTime` — non-handoff no-op.
- [x] `dotnet test tests/NimBus.EndToEnd.Tests/NimBus.EndToEnd.Tests.csproj --filter AsyncCompletion` — 2/2 pass (no regression).
- [ ] Manual via CrmErpDemo: trigger a handoff success, confirm Event Details shows Processing Time ≈ wall-clock seconds (e.g. ~19 s for a 18 s external delay), not ~150 ms.

## Files

- `src/NimBus.Resolver/Services/ResolverService.cs` — adds `ComputeHandoffWallClockMsIfTerminal` helper; `CreateUnresolvedEvent` now accepts an optional override; `UpdateState` calls the helper before projecting.
- `tests/NimBus.Resolver.Tests/ResolverServiceTests.cs` — three new test methods + wires `FakeCosmosDbClient.GetEventHistory` to the in-memory list.