### PR TITLE
feat(samples): run CrmErpDemo against the Azure Service Bus emulator

### DIFF
--- a/samples/CrmErpDemo/CrmErpDemo.AppHost/CrmErpDemo.AppHost.csproj
+++ b/samples/CrmErpDemo/CrmErpDemo.AppHost/CrmErpDemo.AppHost.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.2.4" />
     <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.2.4" />
     <PackageReference Include="Aspire.Hosting.Azure.Functions" Version="13.2.4" />
+    <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.2.4" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.DbGate" Version="9.7.0" />
   </ItemGroup>
 

--- a/samples/CrmErpDemo/CrmErpDemo.AppHost/EmulatorTopologyConfigBuilder.cs
+++ b/samples/CrmErpDemo/CrmErpDemo.AppHost/EmulatorTopologyConfigBuilder.cs
@@ -1,0 +1,267 @@
+using System.Text.Json;
+using NimBus.Core;
+using NimBus.Core.Endpoints;
+using NimBus.Core.Messages;
+
+namespace CrmErpDemo.AppHost;
+
+// Generates the Service Bus emulator's UserConfig JSON from an IPlatform.
+//
+// We use this instead of NimBus.CommandLine.ServiceBusTopologyProvisioner when
+// running under the emulator: the provisioner relies on
+// ServiceBusAdministrationClient (HTTPS REST) which the 2.0.0 emulator doesn't
+// expose on a port the SDK's connection-string-driven URL synthesis can find.
+// The emulator does, however, accept a static UserConfig at startup describing
+// every topic / subscription / rule. So we build that config from the same
+// IPlatform the runtime provisioner consults, write it next to the AppHost
+// binary, and hand it to RunAsEmulator(...).WithConfigurationFile(...).
+//
+// The shape mirrors EnsureEndpointTopologyAsync in
+// src/NimBus.CommandLine/ServiceBusTopologyProvisioner.cs — the production
+// provisioner stays the source of truth for real Azure.
+internal static class EmulatorTopologyConfigBuilder
+{
+    public static string Build(IPlatform platform)
+    {
+        var endpoints = platform.Endpoints
+            .OrderBy(e => e.Id, StringComparer.Ordinal)
+            .ToList();
+
+        var topics = new List<object>
+        {
+            BuildResolverTopic(),
+        };
+
+        foreach (var endpoint in endpoints)
+        {
+            topics.Add(BuildEndpointTopic(platform, endpoint));
+        }
+
+        var root = new
+        {
+            UserConfig = new
+            {
+                Namespaces = new[]
+                {
+                    new
+                    {
+                        Name = "sbemulatorns",
+                        Topics = topics,
+                        Queues = Array.Empty<object>(),
+                    },
+                },
+                Logging = new { Type = "File" },
+            },
+        };
+
+        return JsonSerializer.Serialize(root, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never,
+        });
+    }
+
+    private static object BuildResolverTopic() => new
+    {
+        Name = Constants.ResolverId,
+        Properties = TopicProperties(),
+        Subscriptions = new[]
+        {
+            new
+            {
+                Name = Constants.ResolverId,
+                Properties = SessionSubscriptionProperties(forwardTo: null),
+                // Resolver subscription keeps the default catch-all rule so every
+                // forwarded response message lands here regardless of user.* hints.
+                Rules = new[] { DefaultRule() },
+            },
+        },
+    };
+
+    private static object BuildEndpointTopic(IPlatform platform, IEndpoint endpoint)
+    {
+        var subscriptions = new List<object>
+        {
+            // Self-subscription — endpoint receives its own routed traffic plus
+            // continuation / retry control envelopes addressed to this endpoint.
+            new
+            {
+                Name = endpoint.Id,
+                Properties = SessionSubscriptionProperties(forwardTo: null),
+                Rules = new object[]
+                {
+                    Rule($"to-{endpoint.Id}", $"user.To = '{endpoint.Id}'", action: null),
+                    Rule("continuation", $"user.To = '{Constants.ContinuationId}'", $"SET user.To = '{endpoint.Id}'; SET user.From = '{Constants.ContinuationId}'"),
+                    Rule("retry", $"user.To = '{Constants.RetryId}'", $"SET user.To = '{endpoint.Id}'; SET user.From = '{Constants.RetryId}'"),
+                },
+            },
+            // Forwarding to the centralised Resolver — every audit message
+            // produced by this endpoint flows through here.
+            new
+            {
+                Name = Constants.ResolverId,
+                Properties = ForwardSubscriptionProperties(Constants.ResolverId),
+                Rules = new object[]
+                {
+                    Rule($"from-{endpoint.Id}", $"user.To = '{Constants.ResolverId}'", $"SET user.From = '{endpoint.Id}'"),
+                    Rule($"to-{endpoint.Id}", $"user.To = '{endpoint.Id}'", action: null),
+                },
+            },
+            // Deferred parking lot for sibling messages while a session is
+            // blocked. Session-required so we can replay in FIFO; TTL is
+            // clamped to 1 hour for the emulator (real Azure uses 14 days).
+            new
+            {
+                Name = "Deferred",
+                Properties = DeferredSubscriptionProperties(),
+                Rules = new object[]
+                {
+                    Rule("DeferredFilter", "user.To = 'Deferred' AND user.OriginalSessionId IS NOT NULL", action: null),
+                },
+            },
+            // DeferredProcessor: non-session control queue used by the worker
+            // host to drive the deferred replay loop.
+            new
+            {
+                Name = "DeferredProcessor",
+                Properties = NonSessionSubscriptionProperties(),
+                Rules = new object[]
+                {
+                    Rule("DeferredProcessorFilter", "user.To = 'DeferredProcessor'", action: null),
+                },
+            },
+        };
+
+        // Cross-endpoint forwarding — for every event-type this endpoint
+        // produces, fan out to each consuming endpoint via a forward
+        // subscription with one rule per event-type.
+        foreach (var consumer in platform.Endpoints
+            .Where(c => !string.Equals(c.Id, endpoint.Id, StringComparison.Ordinal))
+            .DistinctBy(c => c.Id)
+            .OrderBy(c => c.Id, StringComparer.Ordinal))
+        {
+            var rules = new List<object>();
+            foreach (var eventType in endpoint.EventTypesProduced
+                .Where(et => platform.GetConsumers(et).Any(c => c.Id == consumer.Id))
+                .OrderBy(et => et.Id, StringComparer.Ordinal))
+            {
+                // The "From IS NULL" guard prevents a forwarding loop when an
+                // event type is produced AND consumed by both endpoints — see
+                // the matching note in ServiceBusTopologyProvisioner.cs.
+                rules.Add(Rule(
+                    eventType.Id,
+                    $"user.EventTypeId = '{eventType.Id}' AND user.From IS NULL",
+                    $"SET user.From = '{endpoint.Id}'; SET user.EventId = newid(); SET user.To = '{consumer.Id}';"));
+            }
+
+            if (rules.Count == 0) continue;
+
+            subscriptions.Add(new
+            {
+                Name = consumer.Id,
+                Properties = ForwardSubscriptionProperties(consumer.Id),
+                Rules = rules.ToArray(),
+            });
+        }
+
+        return new
+        {
+            Name = endpoint.Id,
+            Properties = TopicProperties(),
+            Subscriptions = subscriptions.ToArray(),
+        };
+    }
+
+    private static object TopicProperties() => new
+    {
+        // Emulator caps topic size at 100 MB and the duplicate-detection
+        // window at 5 minutes; production uses 10 minutes. We're not relying
+        // on duplicate detection in the demo, but the field is required.
+        DuplicateDetectionHistoryTimeWindow = "PT5M",
+        RequiresDuplicateDetection = false,
+        DefaultMessageTimeToLive = "PT1H",
+    };
+
+    private static object SessionSubscriptionProperties(string? forwardTo) => new
+    {
+        DeadLetteringOnMessageExpiration = false,
+        DefaultMessageTimeToLive = "PT1H",
+        LockDuration = "PT30S",
+        MaxDeliveryCount = 10,
+        ForwardTo = forwardTo ?? string.Empty,
+        ForwardDeadLetteredMessagesTo = string.Empty,
+        RequiresSession = true,
+    };
+
+    private static object DeferredSubscriptionProperties() => new
+    {
+        DeadLetteringOnMessageExpiration = false,
+        DefaultMessageTimeToLive = "PT1H",
+        LockDuration = "PT30S",
+        MaxDeliveryCount = 10,
+        ForwardTo = string.Empty,
+        ForwardDeadLetteredMessagesTo = string.Empty,
+        RequiresSession = true,
+    };
+
+    private static object NonSessionSubscriptionProperties() => new
+    {
+        DeadLetteringOnMessageExpiration = false,
+        DefaultMessageTimeToLive = "PT1H",
+        LockDuration = "PT30S",
+        MaxDeliveryCount = 10,
+        ForwardTo = string.Empty,
+        ForwardDeadLetteredMessagesTo = string.Empty,
+        RequiresSession = false,
+    };
+
+    private static object ForwardSubscriptionProperties(string forwardTo) => new
+    {
+        DeadLetteringOnMessageExpiration = false,
+        DefaultMessageTimeToLive = "PT1H",
+        LockDuration = "PT30S",
+        MaxDeliveryCount = 10,
+        ForwardTo = forwardTo,
+        ForwardDeadLetteredMessagesTo = string.Empty,
+        RequiresSession = false,
+    };
+
+    private static object Rule(string name, string sqlFilter, string? action)
+    {
+        // The emulator rejects empty SqlExpression on Action — we have to omit
+        // the Action property entirely when the rule has no transformation.
+        if (string.IsNullOrEmpty(action))
+        {
+            return new
+            {
+                Name = name,
+                Properties = new
+                {
+                    FilterType = "Sql",
+                    SqlFilter = new { SqlExpression = sqlFilter },
+                },
+            };
+        }
+
+        return new
+        {
+            Name = name,
+            Properties = new
+            {
+                FilterType = "Sql",
+                SqlFilter = new { SqlExpression = sqlFilter },
+                Action = new { SqlExpression = action },
+            },
+        };
+    }
+
+    private static object DefaultRule() => new
+    {
+        Name = "$Default",
+        Properties = new
+        {
+            FilterType = "Sql",
+            SqlFilter = new { SqlExpression = "1=1" },
+        },
+    };
+}

--- a/samples/CrmErpDemo/CrmErpDemo.AppHost/Program.cs
+++ b/samples/CrmErpDemo/CrmErpDemo.AppHost/Program.cs
@@ -16,8 +16,47 @@ if (storageProvider is not ("sqlserver" or "cosmos"))
         $"Unknown StorageProvider '{storageProvider}'. Use 'sqlserver' (default) or 'cosmos'.");
 }
 
-// External resources — Service Bus is the only always-non-local dependency.
-var servicebus = builder.AddConnectionString("servicebus");
+// Service Bus source. Default is a real Azure namespace via AddConnectionString
+// (connection string supplied by the AppHost's user-secrets). Setting
+// `UseEmulator=true` (CLI flag) or `NIMBUS_SB_EMULATOR=true` (env var) instead
+// spins up Microsoft's official emulator container under Aspire — no Azure
+// dependency required for local/CI demos.
+//
+// Emulator mode also pre-declares topology via a generated config.json (see
+// EmulatorTopologyConfigBuilder), because the SDK's ServiceBusAdministrationClient
+// can't reach the emulator's REST admin endpoint over the connection string
+// alone — the emulator exposes admin on container port 5300, which the SDK's
+// connection-string-driven URL synthesis doesn't know about. Pre-declaring
+// the topology at boot makes the runtime provisioner unnecessary in this
+// mode; production keeps using ServiceBusTopologyProvisioner unchanged.
+var useEmulator = string.Equals(
+    builder.Configuration["UseEmulator"]
+        ?? Environment.GetEnvironmentVariable("NIMBUS_SB_EMULATOR")
+        ?? "false",
+    "true",
+    StringComparison.OrdinalIgnoreCase);
+
+IResourceBuilder<IResourceWithConnectionString> servicebus;
+if (useEmulator)
+{
+    var emulatorConfigPath = Path.Combine(
+        AppContext.BaseDirectory,
+        "servicebus-emulator-config.generated.json");
+    File.WriteAllText(
+        emulatorConfigPath,
+        CrmErpDemo.AppHost.EmulatorTopologyConfigBuilder.Build(
+            new CrmErpDemo.Contracts.CrmErpPlatformConfiguration()));
+
+    servicebus = builder
+        .AddAzureServiceBus("servicebus")
+        .RunAsEmulator(emulator => emulator
+            .WithImageTag("2.0.0")
+            .WithConfigurationFile(emulatorConfigPath));
+}
+else
+{
+    servicebus = builder.AddConnectionString("servicebus");
+}
 
 // SQL Server — Aspire spins up a container; CRM and ERP always get their own databases.
 // NimBus's message store also lives on this server when sqlserver is selected.
@@ -43,9 +82,13 @@ builder.AddDbGate("dbgate")
         ctx.EnvironmentVariables["PASSWORD_sql"] = sql.Resource.PasswordParameter;
     });
 
-// Provision topics/subscriptions for CrmEndpoint + ErpEndpoint.
-var provisioner = builder.AddProject<Projects.CrmErpDemo_Provisioner>("provisioner")
-    .WithReference(servicebus);
+// Provision topics/subscriptions for CrmEndpoint + ErpEndpoint at runtime
+// against a real Azure namespace. Skipped in emulator mode — topology is
+// pre-declared via the emulator's UserConfig (see EmulatorTopologyConfigBuilder).
+IResourceBuilder<ProjectResource>? provisioner = useEmulator
+    ? null
+    : builder.AddProject<Projects.CrmErpDemo_Provisioner>("provisioner")
+        .WithReference(servicebus);
 
 // Reused operator surface — the same Resolver + WebApp used in the main NimBus.AppHost.
 //
@@ -56,7 +99,11 @@ var provisioner = builder.AddProject<Projects.CrmErpDemo_Provisioner>("provision
 var resolver = builder.AddAzureFunctionsProject<Projects.NimBus_Resolver>("resolver")
     .WithReference(servicebus)
     .WithEnvironment("ResolverId", "Resolver")
-    .WithEnvironment("AzureWebJobsServiceBus", builder.Configuration["ConnectionStrings:servicebus"]!);
+    // Functions uses AzureWebJobsServiceBus, not ConnectionStrings:servicebus.
+    // Bind from the resource's runtime expression so both AddConnectionString
+    // (string in user-secrets) and RunAsEmulator (string materialised by the
+    // container at start) flow through the same path.
+    .WithEnvironment("AzureWebJobsServiceBus", servicebus.Resource.ConnectionStringExpression);
 
 // Point nimbus-ops at the CRM/ERP platform catalog instead of the default
 // Storefront/Billing/Warehouse one, so Endpoints/EventTypes show Crm & Erp.
@@ -106,15 +153,15 @@ var crmApi = builder.AddProject<Projects.Crm_Api>("crm-api")
     .WithReference(crmDb)
     .WithEndpoint("http", e => e.Port = 5080)
     .WithExternalHttpEndpoints()
-    .WaitFor(crmDb)
-    .WaitFor(provisioner);
+    .WaitFor(crmDb);
+if (provisioner is not null) crmApi = crmApi.WaitFor(provisioner);
 
-builder.AddProject<Projects.Crm_Adapter>("crm-adapter")
+var crmAdapter = builder.AddProject<Projects.Crm_Adapter>("crm-adapter")
     .WithReference(servicebus)
     .WithReference(crmDb)
     .WithReference(crmApi)
-    .WaitFor(crmApi)
-    .WaitFor(provisioner);
+    .WaitFor(crmApi);
+if (provisioner is not null) crmAdapter.WaitFor(provisioner);
 
 builder.AddViteApp("crm-web", "../Crm.Web")
     .WithReference(crmApi)
@@ -127,17 +174,17 @@ var erpApi = builder.AddProject<Projects.Erp_Api>("erp-api")
     .WithReference(erpDb)
     .WithEndpoint("http", e => e.Port = 5090)
     .WithExternalHttpEndpoints()
-    .WaitFor(erpDb)
-    .WaitFor(provisioner);
+    .WaitFor(erpDb);
+if (provisioner is not null) erpApi = erpApi.WaitFor(provisioner);
 
-builder.AddAzureFunctionsProject<Projects.Erp_Adapter_Functions>("erp-adapter")
+var erpAdapter = builder.AddAzureFunctionsProject<Projects.Erp_Adapter_Functions>("erp-adapter")
     .WithReference(servicebus)
     .WithReference(erpApi)
-    .WithEnvironment("AzureWebJobsServiceBus", builder.Configuration["ConnectionStrings:servicebus"]!)
+    .WithEnvironment("AzureWebJobsServiceBus", servicebus.Resource.ConnectionStringExpression)
     .WithEnvironment("TopicName", "ErpEndpoint")
     .WithEnvironment("SubscriptionName", "ErpEndpoint")
-    .WaitFor(erpApi)
-    .WaitFor(provisioner);
+    .WaitFor(erpApi);
+if (provisioner is not null) erpAdapter.WaitFor(provisioner);
 
 builder.AddViteApp("erp-web", "../Erp.Web")
     .WithReference(erpApi)

--- a/src/NimBus.CommandLine/ServiceBusTopologyProvisioner.cs
+++ b/src/NimBus.CommandLine/ServiceBusTopologyProvisioner.cs
@@ -20,6 +20,18 @@ public sealed class ServiceBusTopologyProvisioner
         _platformFactory = platformFactory ?? throw new ArgumentNullException(nameof(platformFactory));
     }
 
+    // The official Azure Service Bus emulator advertises itself in the
+    // connection string via UseDevelopmentEmulator=true. NimBus's defaults
+    // (5 GB topic size, 14-day deferred-subscription TTL) exceed the
+    // emulator's hard caps (100 MB topics, conservative TTL upper bound),
+    // so when we detect the emulator we drop those down to values the
+    // emulator accepts. Production / real-Azure paths are untouched.
+    private static bool IsEmulator(string? connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString)) return false;
+        return connectionString.IndexOf("UseDevelopmentEmulator=true", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
     internal ServiceBusTopologyProvisioner(AzureCliRunner az)
         : this(
             az,
@@ -49,7 +61,7 @@ public sealed class ServiceBusTopologyProvisioner
         var platform = _platformFactory();
         var client = _clientFactory(_connectionString);
 
-        await ApplyCoreAsync(client, platform, cancellationToken).ConfigureAwait(false);
+        await ApplyCoreAsync(client, platform, IsEmulator(_connectionString), cancellationToken).ConfigureAwait(false);
     }
 
     internal async Task ApplyAsync(TopologyOptions options, CancellationToken cancellationToken)
@@ -62,23 +74,23 @@ public sealed class ServiceBusTopologyProvisioner
         var platform = _platformFactory();
         var client = _clientFactory(connectionString);
 
-        await ApplyCoreAsync(client, platform, cancellationToken).ConfigureAwait(false);
+        await ApplyCoreAsync(client, platform, IsEmulator(connectionString), cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task ApplyCoreAsync(ServiceBusAdministrationClient client, IPlatform platform, CancellationToken cancellationToken)
+    private static async Task ApplyCoreAsync(ServiceBusAdministrationClient client, IPlatform platform, bool isEmulator, CancellationToken cancellationToken)
     {
-        await EnsureTopicAsync(client, Constants.ResolverId, cancellationToken).ConfigureAwait(false);
+        await EnsureTopicAsync(client, Constants.ResolverId, isEmulator, cancellationToken).ConfigureAwait(false);
 
         foreach (var endpoint in platform.Endpoints.OrderBy(endpoint => endpoint.Id, StringComparer.Ordinal))
         {
-            await EnsureTopicAsync(client, endpoint.Id, cancellationToken).ConfigureAwait(false);
+            await EnsureTopicAsync(client, endpoint.Id, isEmulator, cancellationToken).ConfigureAwait(false);
         }
 
         await EnsureSessionSubscriptionAsync(client, Constants.ResolverId, Constants.ResolverId, forwardTo: null, keepDefaultRule: true, cancellationToken).ConfigureAwait(false);
 
         foreach (var endpoint in platform.Endpoints.OrderBy(endpoint => endpoint.Id, StringComparer.Ordinal))
         {
-            await EnsureEndpointTopologyAsync(client, platform, endpoint, cancellationToken).ConfigureAwait(false);
+            await EnsureEndpointTopologyAsync(client, platform, endpoint, isEmulator, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -86,6 +98,7 @@ public sealed class ServiceBusTopologyProvisioner
         ServiceBusAdministrationClient client,
         IPlatform platform,
         IEndpoint endpoint,
+        bool isEmulator,
         CancellationToken cancellationToken)
     {
         await EnsureSessionSubscriptionAsync(client, endpoint.Id, endpoint.Id, forwardTo: null, keepDefaultRule: false, cancellationToken).ConfigureAwait(false);
@@ -98,7 +111,7 @@ public sealed class ServiceBusTopologyProvisioner
         await EnsureRuleAsync(client, endpoint.Id, endpoint.Id, "continuation", $"user.To = '{Constants.ContinuationId}'", $"SET user.To = '{endpoint.Id}'; SET user.From = '{Constants.ContinuationId}'", cancellationToken).ConfigureAwait(false);
         await EnsureRuleAsync(client, endpoint.Id, endpoint.Id, "retry", $"user.To = '{Constants.RetryId}'", $"SET user.To = '{endpoint.Id}'; SET user.From = '{Constants.RetryId}'", cancellationToken).ConfigureAwait(false);
 
-        await EnsureDeferredSubscriptionAsync(client, endpoint.Id, cancellationToken).ConfigureAwait(false);
+        await EnsureDeferredSubscriptionAsync(client, endpoint.Id, isEmulator, cancellationToken).ConfigureAwait(false);
         await EnsureDeferredProcessorSubscriptionAsync(client, endpoint.Id, cancellationToken).ConfigureAwait(false);
 
         foreach (var eventType in endpoint.EventTypesProduced.OrderBy(eventType => eventType.Id, StringComparer.Ordinal))
@@ -154,7 +167,7 @@ public sealed class ServiceBusTopologyProvisioner
             $"Failed to read the Service Bus connection string for '{names.ServiceBusNamespace}'.").ConfigureAwait(false);
     }
 
-    private static async Task EnsureTopicAsync(ServiceBusAdministrationClient client, string topicName, CancellationToken cancellationToken)
+    private static async Task EnsureTopicAsync(ServiceBusAdministrationClient client, string topicName, bool isEmulator, CancellationToken cancellationToken)
     {
         if (await client.TopicExistsAsync(topicName, cancellationToken).ConfigureAwait(false))
         {
@@ -166,8 +179,16 @@ public sealed class ServiceBusTopologyProvisioner
             SupportOrdering = true,
             DuplicateDetectionHistoryTimeWindow = TimeSpan.FromMinutes(10),
             EnableBatchedOperations = true,
-            MaxSizeInMegabytes = 5120,
         };
+
+        // Real Azure namespaces accept up to 5 GB per topic; the emulator caps
+        // at 100 MB and rejects anything larger. Setting the cap explicitly on
+        // production matches the historical default; omitting it on the emulator
+        // lets the server pick its own (100 MB) ceiling without a 400 response.
+        if (!isEmulator)
+        {
+            options.MaxSizeInMegabytes = 5120;
+        }
 
         await client.CreateTopicAsync(options, cancellationToken).ConfigureAwait(false);
         CliOutput.WriteLine($"Created topic '{topicName}'.");
@@ -255,7 +276,7 @@ public sealed class ServiceBusTopologyProvisioner
         return lastSlash < 0 ? path : path.Substring(lastSlash + 1);
     }
 
-    private static async Task EnsureDeferredSubscriptionAsync(ServiceBusAdministrationClient client, string topicName, CancellationToken cancellationToken)
+    private static async Task EnsureDeferredSubscriptionAsync(ServiceBusAdministrationClient client, string topicName, bool isEmulator, CancellationToken cancellationToken)
     {
         const string subscriptionName = "Deferred";
         var existing = await TryGetSubscriptionAsync(client, topicName, subscriptionName, cancellationToken).ConfigureAwait(false);
@@ -269,7 +290,12 @@ public sealed class ServiceBusTopologyProvisioner
             }
 
             var options = CreateSubscriptionOptions(topicName, subscriptionName, requiresSession: true, forwardTo: null);
-            options.DefaultMessageTimeToLive = TimeSpan.FromDays(14);
+            // 14 days matches what real Azure accepts and what operator workflows
+            // assume for parking deferred messages. The emulator's documented TTL
+            // upper bound is conservative and not pinned in the public docs, so
+            // for emulator runs we drop to 1 hour — long enough for sample/CI
+            // smoke runs, well inside any plausible upper limit.
+            options.DefaultMessageTimeToLive = isEmulator ? TimeSpan.FromHours(1) : TimeSpan.FromDays(14);
             await client.CreateSubscriptionAsync(options, cancellationToken).ConfigureAwait(false);
             CliOutput.WriteLine($"Ensured deferred subscription '{subscriptionName}' on topic '{topicName}'.");
         }

--- a/src/NimBus.WebApp/Controllers/ApiContract/EndpointImplementation.cs
+++ b/src/NimBus.WebApp/Controllers/ApiContract/EndpointImplementation.cs
@@ -678,8 +678,24 @@ public class EndpointImplementation : IEndpointApiController
 
     private async Task SetSubscriptionStatusMetadata(EndpointMetadata metadata)
     {
-        var endpointManagement = new EndpointManagement(serviceBusManagement);
-        var subscriptionState = await endpointManagement.GetEndpointSubscriptionState(metadata.EndpointId);
+        // Querying the Service Bus admin REST endpoint can fail in two known
+        // scenarios: (1) running against the emulator, whose admin REST port
+        // (5300) isn't reachable through the standard connection string the
+        // SDK uses, and (2) transient real-Azure outages during page loads.
+        // Either way, a single subscription-status probe failing should not
+        // 500 the entire endpoints list — leave SubscriptionStatus null
+        // ("unknown") and let the page still render.
+        SubscriptionState? subscriptionState = null;
+        try
+        {
+            var endpointManagement = new EndpointManagement(serviceBusManagement);
+            subscriptionState = await endpointManagement.GetEndpointSubscriptionState(metadata.EndpointId);
+        }
+        catch (Exception)
+        {
+            // Swallow — SubscriptionStatus stays null, surfaced in UI as "unknown".
+        }
+
         metadata.SubscriptionStatus = subscriptionState switch
         {
             SubscriptionState.Active => true,


### PR DESCRIPTION
## Summary

Adds an opt-in `--UseEmulator true` (or `NIMBUS_SB_EMULATOR=true`) flag to the CrmErpDemo AppHost that swaps the real Azure Service Bus namespace for Microsoft's official emulator container (`mcr.microsoft.com/azure-messaging/servicebus-emulator:2.0.0`). Production path is unchanged — the default still reads the connection string from user-secrets.

### Why this isn't trivial

The SDK's `ServiceBusAdministrationClient` can't reach the 2.0.0 emulator's REST admin endpoint (port 5300) over the connection string alone — it derives admin URLs from the AMQP endpoint at standard HTTPS ports, which the emulator doesn't serve. The runtime topology provisioner therefore can't create entities against the emulator. Two-part fix:

1. **Skip the `provisioner` resource in emulator mode and pre-declare the full topology via the emulator's UserConfig at boot.** New `EmulatorTopologyConfigBuilder` generates the JSON from `CrmErpPlatformConfiguration` — same source the runtime provisioner consults — so the topologies stay in sync. Fed via `RunAsEmulator(e => e.WithConfigurationFile(...))`.
2. **`ServiceBusTopologyProvisioner` gains an emulator detector** that triggers on `UseDevelopmentEmulator=true` in the connection string and clamps two defaults the emulator rejects (5 GB topic size → omit, 14-day deferred TTL → 1 hour). Useful for any future SDK/emulator combo where the admin path opens up; harmless until then.

The same admin-REST gap also broke the WebApp's `/api/metadatashort` endpoint (used by the Endpoints page to enrich metadata with subscription state). Fixed in the second commit by wrapping the admin probe in try/catch — `SubscriptionStatus` falls back to `null` ("unknown") on failure instead of 500-ing the whole list.

### Emulator quirks discovered + worked around

- `DuplicateDetectionHistoryTimeWindow` must be ≤ 5 minutes (production uses 10).
- Rule `Action` must be **omitted** entirely when there's no SQL transformation — empty string is rejected with a parser error in FluentAssertions.

## Commits

- `a19f2c1` — feat(samples): run CrmErpDemo against the official Azure Service Bus emulator
- `0858e14` — fix(webapp): don't 500 the endpoints list when admin REST is unreachable

## Test plan

Verified end-to-end with `aspire run -- --UseEmulator true`:

- [x] Emulator + SQL Edge sidecar come up; emulator reports "Successfully Up" with the topology pre-declared.
- [x] CRM `POST /api/accounts` → ERP customer materialises ~3 s later via the `CrmAccountCreated` forward subscription.
- [x] ERP's `ErpCustomerCreated` flows back, populating `erpCustomerId` / `erpCustomerNumber` on the CRM account.
- [x] CRM `PUT /api/accounts/{id}` → 3 field-diff audit rows on CRM at T+0; 3 mirrored field-diff rows on the ERP customer at T+1s with `origin=Crm` preserved through the cross-side adapter.
- [x] All four child resources (`crm-api`, `crm-adapter`, `erp-api`, `erp-adapter`) plus `nimbus-ops` and `resolver` come up green; no `provisioner` resource exists in this mode.
- [x] WebApp Endpoints page renders without 500 when admin REST is unreachable.

Production mode (no flag) is byte-identical to today: provisioner runs, real Azure path unchanged.

## Caveats from the original feasibility study still apply

- Container state wipes on AppHost restart (queues, scheduled, deferred, session state). Fine for demos, hostile for long-running local dev.
- Session-state semantics not documented for the emulator. The Resolver flow worked in this smoke test but production-grade scenarios may surface gaps.
- 256 KB hard message-size cap (no large-message tier).