### PR TITLE
feat(webapp): PR 1 — endpoint-details redesign

### DIFF
--- a/src/NimBus.WebApp/ClientApp/src/components/common/truncated-guid.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/common/truncated-guid.tsx
@@ -1,24 +1,35 @@
 import { Tooltip } from "components/ui/tooltip";
 import { useToast } from "components/ui/toast";
+import { cn } from "lib/utils";
 
 interface ITruncatedGuidProps {
   guid: string | undefined | null;
   displayLength?: number;
+  /** When false, the trailing copy affordance won't render. Default: true. */
+  withCopy?: boolean;
+  className?: string;
 }
 
+/**
+ * Renders a truncated machine ID as monospace + tabular-nums (design rec §07).
+ * The copy icon fades in on row hover via the parent's `.group` class so
+ * resting tables stay quiet — but click anywhere on the value still copies.
+ */
 export default function TruncatedGuid({
   guid,
   displayLength = 8,
+  withCopy = true,
+  className,
 }: ITruncatedGuidProps) {
   const { addToast } = useToast();
 
   if (!guid) {
-    return <span>-</span>;
+    return <span className="text-muted-foreground">—</span>;
   }
 
   const truncated =
     guid.length > displayLength
-      ? `${guid.substring(0, displayLength)}...`
+      ? `${guid.substring(0, displayLength)}…`
       : guid;
 
   const handleClick = async (e: React.MouseEvent) => {
@@ -45,8 +56,41 @@ export default function TruncatedGuid({
 
   return (
     <Tooltip content={guid} position="top">
-      <span className="cursor-pointer hover:underline" onClick={handleClick}>
+      <span
+        onClick={handleClick}
+        className={cn(
+          "inline-flex items-center gap-1 cursor-pointer font-mono text-[12px] tabular-nums",
+          "text-foreground hover:text-primary",
+          className,
+        )}
+      >
         {truncated}
+        {withCopy && (
+          <svg
+            aria-hidden="true"
+            width="11"
+            height="11"
+            viewBox="0 0 16 16"
+            fill="none"
+            className="opacity-0 group-hover:opacity-60 hover:!opacity-100 transition-opacity shrink-0"
+          >
+            <rect
+              x="5"
+              y="5"
+              width="9"
+              height="9"
+              rx="1.5"
+              stroke="currentColor"
+              strokeWidth="1.4"
+            />
+            <path
+              d="M3 11V3.5C3 2.7 3.7 2 4.5 2H11"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+            />
+          </svg>
+        )}
       </span>
     </Tooltip>
   );

--- a/src/NimBus.WebApp/ClientApp/src/components/data-table/data-table-new.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/data-table/data-table-new.tsx
@@ -275,24 +275,25 @@ export function DataTable({
       )}
 
       {/* Table */}
-      <div className="overflow-auto">
+      <div className="overflow-auto bg-card border border-border rounded-nb-md">
         <table
-          className="w-full text-sm"
+          className="w-full text-[13px]"
           style={
             fixedWidth ? { tableLayout: "fixed", width: fixedWidth } : undefined
           }
         >
-          <thead className="bg-background sticky top-0 z-10 border-b border-border">
+          <thead className="bg-muted sticky top-0 z-10 border-b border-border">
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <th
                     key={header.id}
                     className={cn(
-                      "px-4 py-3 text-left font-semibold text-foreground",
-                      "bg-background shadow-[inset_0_-1px_0_rgba(224,224,224,1)]",
+                      "px-3.5 py-3 text-left font-semibold text-muted-foreground",
+                      "text-[11px] uppercase tracking-[0.06em] whitespace-nowrap",
+                      "bg-muted border-b border-border",
                       header.column.getCanSort() &&
-                        "cursor-pointer select-none hover:bg-accent",
+                        "cursor-pointer select-none hover:text-foreground",
                     )}
                     style={{
                       width:
@@ -437,8 +438,8 @@ function TableRow({ row, rowData }: { row: any; rowData: ITableRow }) {
   return (
     <tr
       className={cn(
-        "hover:bg-accent transition-colors",
-        row.getIsSelected() && "bg-primary-50",
+        "group hover:bg-primary-tint dark:hover:bg-primary/15 transition-colors",
+        row.getIsSelected() && "bg-primary-50 dark:bg-primary/10",
         rowData.route && "cursor-pointer",
       )}
       onClick={
@@ -462,7 +463,11 @@ function TableRow({ row, rowData }: { row: any; rowData: ITableRow }) {
       {row.getVisibleCells().map((cell: any) => (
         <td
           key={cell.id}
-          className={cn("px-4 py-3", cell.column.id === "select" && "w-9")}
+          className={cn(
+            "px-3.5 py-2.5 border-b border-border",
+            "text-foreground tabular-nums",
+            cell.column.id === "select" && "w-9",
+          )}
         >
           {flexRender(cell.column.columnDef.cell, cell.getContext())}
         </td>

--- a/src/NimBus.WebApp/ClientApp/src/components/endpoint-details/events-panel.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/endpoint-details/events-panel.tsx
@@ -14,10 +14,46 @@ import TruncatedGuid from "components/common/truncated-guid";
 import ErrorGroupedView from "./error-grouped-view";
 import { useUrlFilters } from "hooks/use-url-filters";
 import { Badge } from "components/ui/badge";
+import { StatTile, StatRow } from "components/ui/stat-tile";
+import { EmptyState } from "components/ui/empty-state";
+import { cn } from "lib/utils";
 
 const isHandoffEvent = (event: api.Event): boolean =>
   event.resolutionStatus === api.ResolutionStatus.Pending &&
   (event.pendingSubStatus ?? "").toLowerCase() === "handoff";
+
+// Map a ResolutionStatus onto the design system's badge variant set.
+// Status-only — coral is reserved for action / focus (design rec §02).
+function statusToBadgeVariant(
+  status: string | api.ResolutionStatus | undefined,
+):
+  | "completed"
+  | "failed"
+  | "deferred"
+  | "deadlettered"
+  | "skipped"
+  | "unsupported"
+  | "pending"
+  | "default" {
+  switch (status) {
+    case api.ResolutionStatus.Completed:
+      return "completed";
+    case api.ResolutionStatus.Failed:
+      return "failed";
+    case api.ResolutionStatus.Deferred:
+      return "deferred";
+    case api.ResolutionStatus.DeadLettered:
+      return "deadlettered";
+    case api.ResolutionStatus.Skipped:
+      return "skipped";
+    case api.ResolutionStatus.Unsupported:
+      return "unsupported";
+    case api.ResolutionStatus.Pending:
+      return "pending";
+    default:
+      return "default";
+  }
+}
 
 interface EventsPanelProps {
   endpointId: string;
@@ -443,15 +479,20 @@ const EventsPanel = (props: EventsPanelProps) => {
           [
             "status",
             {
-              value: isHandoffEvent(item) ? (
+              value: (
                 <span className="inline-flex items-center gap-2">
-                  {item.resolutionStatus}
-                  <Badge variant="info" size="sm">
-                    Awaiting external
+                  <Badge
+                    variant={statusToBadgeVariant(item.resolutionStatus)}
+                    size="sm"
+                  >
+                    {item.resolutionStatus ?? "—"}
                   </Badge>
+                  {isHandoffEvent(item) && (
+                    <Badge variant="info" size="sm">
+                      Awaiting external
+                    </Badge>
+                  )}
                 </span>
-              ) : (
-                item.resolutionStatus
               ),
               searchValue: item.resolutionStatus ?? "",
             },
@@ -589,9 +630,82 @@ const EventsPanel = (props: EventsPanelProps) => {
   // from `initialValue` props whenever the URL changes (e.g. browser Back/forward).
   const filterRemountKey = `${applied.status.join(",")}|${applied.eventTypeId.join(",")}|${applied.eventId}|${applied.sessionId}`;
 
+  // Counts derived from the currently-loaded page. Server-wide totals would
+  // need a dedicated stats endpoint — this gives an honest "what's on screen"
+  // summary that matches the operator's mental model of the result set.
+  const counts = React.useMemo(() => {
+    let completed = 0;
+    let failed = 0;
+    let deferred = 0;
+    let pending = 0;
+    for (const e of events) {
+      switch (e.resolutionStatus) {
+        case api.ResolutionStatus.Completed:
+          completed += 1;
+          break;
+        case api.ResolutionStatus.Failed:
+        case api.ResolutionStatus.DeadLettered:
+        case api.ResolutionStatus.Unsupported:
+          failed += 1;
+          break;
+        case api.ResolutionStatus.Deferred:
+          deferred += 1;
+          break;
+        case api.ResolutionStatus.Pending:
+          pending += 1;
+          break;
+      }
+    }
+    return { completed, failed, deferred, pending };
+  }, [events]);
+
+  const hasActiveFilters =
+    !isAllStatusesSentinel(applied.status) ||
+    applied.eventTypeId.length > 0 ||
+    applied.eventId.length > 0 ||
+    applied.sessionId.length > 0;
+
+  const segBtn = (active: boolean) =>
+    cn(
+      "px-3 py-1.5 rounded-md text-xs font-semibold transition-colors",
+      active
+        ? "bg-primary text-white"
+        : "text-muted-foreground hover:text-foreground",
+    );
+
   return (
     <FilterContext.Provider value={context}>
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 w-full">
+        {/* Promote summary metrics above the table — design rec §03.
+            Status-coloured tiles answer "how is this endpoint doing?"
+            before the operator scans rows. */}
+        <StatRow>
+          <StatTile
+            label="Completed"
+            value={counts.completed.toLocaleString()}
+            delta="on screen"
+            tone="muted"
+          />
+          <StatTile
+            label="Deferred"
+            value={counts.deferred.toLocaleString()}
+            delta={counts.deferred ? "needs attention" : "—"}
+            tone={counts.deferred ? "warning" : "muted"}
+          />
+          <StatTile
+            label="Failed"
+            value={counts.failed.toLocaleString()}
+            delta={counts.failed ? "needs attention" : "—"}
+            tone={counts.failed ? "danger" : "muted"}
+          />
+          <StatTile
+            label="Pending"
+            value={counts.pending.toLocaleString()}
+            delta="in-flight"
+            tone="muted"
+          />
+        </StatRow>
+
         <EventFiltering
           key={filterRemountKey}
           handleFilterClicked={handleFilterClicked}
@@ -605,20 +719,29 @@ const EventsPanel = (props: EventsPanelProps) => {
           maxResults={maxResults}
           onMaxResultsChange={setMaxResults}
         />
+
+        {/* View-mode segmented control — matches design `.seg` button group.
+            Single role per hue: coral is "active selection", not a status. */}
         <div className="flex items-center gap-2 text-sm">
-          <span className="text-muted-foreground">View:</span>
-          <button
-            className={`px-3 py-1 rounded-md border text-xs font-medium ${viewMode === "list" ? "bg-primary text-white border-primary" : "bg-card text-foreground border-border"}`}
-            onClick={() => setViewMode("list")}
-          >
-            List
-          </button>
-          <button
-            className={`px-3 py-1 rounded-md border text-xs font-medium ${viewMode === "grouped" ? "bg-primary text-white border-primary" : "bg-card text-foreground border-border"}`}
-            onClick={() => setViewMode("grouped")}
-          >
-            Grouped by Error
-          </button>
+          <span className="text-muted-foreground font-semibold text-[13px]">
+            View:
+          </span>
+          <div className="inline-flex items-center bg-card border border-border rounded-nb-md p-[3px] gap-[2px]">
+            <button
+              type="button"
+              className={segBtn(viewMode === "list")}
+              onClick={() => setViewMode("list")}
+            >
+              List
+            </button>
+            <button
+              type="button"
+              className={segBtn(viewMode === "grouped")}
+              onClick={() => setViewMode("grouped")}
+            >
+              Grouped by Error
+            </button>
+          </div>
         </div>
 
         {viewMode === "grouped" ? (
@@ -627,6 +750,31 @@ const EventsPanel = (props: EventsPanelProps) => {
             onResubmitEvent={resubmitSingleEvent}
             onSkipEvent={skipSingleEvent}
             isActionableStatus={isActionableStatus}
+          />
+        ) : !isLoading && events.length === 0 ? (
+          <EmptyState
+            icon="◌"
+            title={
+              hasActiveFilters
+                ? "No events match your filters"
+                : "No events yet"
+            }
+            description={
+              hasActiveFilters
+                ? "Try removing a filter or expanding the time window."
+                : "Messages will appear here as this endpoint receives traffic."
+            }
+            action={
+              hasActiveFilters && (
+                <button
+                  type="button"
+                  onClick={handleReset}
+                  className="text-primary-600 hover:text-primary text-[13px] font-semibold underline-offset-2 hover:underline"
+                >
+                  Clear all filters
+                </button>
+              )
+            }
           />
         ) : (
           <DataTable

--- a/src/NimBus.WebApp/ClientApp/src/components/ui/empty-state.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/ui/empty-state.tsx
@@ -1,0 +1,64 @@
+import { type ReactNode } from "react";
+import { cn } from "lib/utils";
+
+export interface EmptyStateProps {
+  /** Optional icon — pass a single SVG/character node. */
+  icon?: ReactNode;
+  /** Bold one-line headline. */
+  title: ReactNode;
+  /** Optional supporting copy under the title. */
+  description?: ReactNode;
+  /** Primary action button(s) under the description. */
+  action?: ReactNode;
+  /** Tone tints the icon background (default: muted; success: green). */
+  tone?: "muted" | "success" | "warning" | "danger" | "info";
+  className?: string;
+}
+
+const iconBgTone = {
+  muted: "bg-muted text-muted-foreground",
+  success: "bg-status-success-50 text-status-success",
+  warning: "bg-status-warning-50 text-status-warning",
+  danger: "bg-status-danger-50 text-status-danger",
+  info: "bg-status-info-50 text-status-info",
+};
+
+/**
+ * Empty / zero-row state. Used wherever filtered results return nothing,
+ * or a metric panel has "good news" to show (e.g. "no failures") — design
+ * recs §08 and §09 metrics. Empty states are a teaching moment, not an error.
+ */
+export const EmptyState = ({
+  icon,
+  title,
+  description,
+  action,
+  tone = "muted",
+  className,
+}: EmptyStateProps) => (
+  <div
+    className={cn(
+      "flex flex-col items-center justify-center text-center gap-3",
+      "py-12 px-6 rounded-nb-md bg-card border border-border",
+      className,
+    )}
+  >
+    {icon && (
+      <div
+        className={cn(
+          "w-12 h-12 rounded-full inline-flex items-center justify-center text-xl font-bold",
+          iconBgTone[tone],
+        )}
+      >
+        {icon}
+      </div>
+    )}
+    <div className="font-bold text-base text-foreground">{title}</div>
+    {description && (
+      <p className="text-[13px] text-muted-foreground max-w-md leading-relaxed m-0">
+        {description}
+      </p>
+    )}
+    {action && <div className="mt-1">{action}</div>}
+  </div>
+);

--- a/src/NimBus.WebApp/ClientApp/src/components/ui/filter-toolbar.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/ui/filter-toolbar.tsx
@@ -1,0 +1,131 @@
+import { type ReactNode } from "react";
+import { cn } from "lib/utils";
+
+export interface FilterChipProps {
+  /** Field label shown before the colon, e.g. "Status". */
+  field?: string;
+  /** Active value, e.g. "Failed, Deferred". */
+  value: ReactNode;
+  /** Called when the × is clicked. Omit to render a non-removable chip. */
+  onRemove?: () => void;
+  className?: string;
+}
+
+/**
+ * Removable filter chip — coral on cream by default, mono font.
+ * Used inside `FilterToolbar` so the active filter state is the single
+ * source of truth (design rec §04: collapse the two filter zones into one).
+ */
+export const FilterChip = ({
+  field,
+  value,
+  onRemove,
+  className,
+}: FilterChipProps) => (
+  <span
+    className={cn(
+      "inline-flex items-center gap-1.5 font-mono text-[11.5px] font-semibold",
+      "bg-primary-tint text-primary-600 rounded-nb-sm pl-2.5 pr-2 py-1",
+      "dark:bg-primary/20 dark:text-primary-400",
+      className,
+    )}
+  >
+    {field && <span className="opacity-70">{field}:</span>}
+    <span>{value}</span>
+    {onRemove && (
+      <button
+        type="button"
+        onClick={onRemove}
+        className="text-current text-[13px] leading-none pl-0.5 hover:opacity-70"
+        aria-label="Remove filter"
+      >
+        ×
+      </button>
+    )}
+  </span>
+);
+
+export interface FilterToolbarProps {
+  /** Search input on the left. */
+  search?: ReactNode;
+  /** Active filter chips. */
+  chips?: ReactNode;
+  /** "+ Add filter" / "Save view" buttons on the right of chips. */
+  actions?: ReactNode;
+  /** Right-aligned trailing slot (e.g. view-mode segmented control). */
+  trailing?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Single inline filter row — surface card with search, chips, and trailing
+ * actions. Replaces the legacy three-zone filter layout (inputs row +
+ * "Advanced filters" drawer + in-table search) — design rec §04.
+ */
+export const FilterToolbar = ({
+  search,
+  chips,
+  actions,
+  trailing,
+  className,
+}: FilterToolbarProps) => (
+  <div
+    className={cn(
+      "flex items-center gap-2 flex-wrap",
+      "bg-card border border-border rounded-nb-md p-2.5",
+      className,
+    )}
+  >
+    {search && <div className="flex-1 min-w-[240px]">{search}</div>}
+    {chips}
+    {actions}
+    {trailing && <div className="ml-auto">{trailing}</div>}
+  </div>
+);
+
+export interface FilterSearchProps {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+/**
+ * Search-input variant tuned for the toolbar — magnifier on the left,
+ * cream surface, no border because the toolbar already has one.
+ */
+export const FilterSearch = ({
+  value,
+  onChange,
+  placeholder = "Filter…",
+  className,
+}: FilterSearchProps) => (
+  <div className={cn("relative", className)}>
+    <span
+      aria-hidden="true"
+      className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+    >
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+        <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.5" />
+        <path
+          d="M10.5 10.5L13 13"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+      </svg>
+    </span>
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      className={cn(
+        "w-full text-[13px] text-foreground bg-background dark:bg-muted",
+        "border border-border rounded-nb-md pl-9 pr-3 py-2",
+        "placeholder:text-muted-foreground",
+        "focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/30",
+      )}
+    />
+  </div>
+);

--- a/src/NimBus.WebApp/ClientApp/src/components/ui/stat-tile.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/ui/stat-tile.tsx
@@ -1,0 +1,91 @@
+import { type ReactNode } from "react";
+import { cn } from "lib/utils";
+
+export type StatTileTone = "default" | "warning" | "danger" | "muted";
+
+export interface StatTileProps {
+  /** Caps-mono micro label above the value. */
+  label: string;
+  /** Hero number — rendered with tabular figures. */
+  value: ReactNode;
+  /** Optional unit suffix (e.g. "ms") shown small after the value. */
+  unit?: string;
+  /** Single-line delta below the value (e.g. "▲ 3.4% vs prior 1h"). */
+  delta?: ReactNode;
+  /** Tone tints the delta color and signals "needs attention" via context. */
+  tone?: StatTileTone;
+  className?: string;
+  onClick?: () => void;
+}
+
+const deltaTone: Record<StatTileTone, string> = {
+  default: "text-status-success",
+  warning: "text-status-warning",
+  danger: "text-status-danger",
+  muted: "text-muted-foreground",
+};
+
+/**
+ * Stat tile from the design system §06 — promotes summary metrics above
+ * the table so the page answers "how is this endpoint doing?" before the
+ * operator scans rows.
+ */
+export const StatTile = ({
+  label,
+  value,
+  unit,
+  delta,
+  tone = "default",
+  className,
+  onClick,
+}: StatTileProps) => {
+  const Comp = onClick ? "button" : "div";
+  return (
+    <Comp
+      onClick={onClick}
+      className={cn(
+        "text-left bg-card border border-border rounded-nb-md px-4 py-3.5",
+        "transition-colors",
+        onClick && "hover:border-border-strong cursor-pointer",
+        className,
+      )}
+    >
+      <div className="font-mono text-[10px] tracking-[0.12em] uppercase text-muted-foreground mb-1.5">
+        {label}
+      </div>
+      <div className="text-[28px] font-bold leading-none tracking-tight tabular-nums">
+        {value}
+        {unit && (
+          <span className="text-[13px] font-semibold text-muted-foreground ml-0.5">
+            {unit}
+          </span>
+        )}
+      </div>
+      {delta && (
+        <div className={cn("mt-2 font-mono text-[11px]", deltaTone[tone])}>
+          {delta}
+        </div>
+      )}
+    </Comp>
+  );
+};
+
+export interface StatRowProps {
+  children: ReactNode;
+  className?: string;
+  /** Default `4` matches design's `.stats { grid-template-columns: repeat(4,1fr) }`. */
+  columns?: 2 | 3 | 4 | 5;
+}
+
+const colsClass: Record<number, string> = {
+  2: "grid-cols-2",
+  3: "grid-cols-3",
+  4: "grid-cols-4",
+  5: "grid-cols-5",
+};
+
+export const StatRow = ({ children, className, columns = 4 }: StatRowProps) => (
+  <div className={cn("grid gap-3", colsClass[columns], className)}>
+    {children}
+  </div>
+);

--- a/src/NimBus.WebApp/ClientApp/src/pages/endpoint-details.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/pages/endpoint-details.tsx
@@ -46,7 +46,7 @@ const EndpointDetails = (props: EndpointDetailsProps) => {
   return (
     <>
       {!endpointIsInvalid ? (
-        <Page title={`${params.id} details`}>
+        <Page title={params.id!} subtitle="Endpoint details">
           <EventsPanel endpointId={params.id!} />
         </Page>
       ) : (


### PR DESCRIPTION
## Summary
First page-level adoption of the NimBus design system. Lands three shared primitives that PRs 2-6 will reuse, and applies them to the most-trafficked screen.

Stacks on top of #43 (design system foundation).

### New primitives (under \`components/ui/\`)
- \`StatTile\` / \`StatRow\` — KPI tiles with tabular-num value, mono caps label, tone-tinted delta. Design rec §03.
- \`FilterChip\` / \`FilterToolbar\` / \`FilterSearch\` — single inline filter toolbar replacing the legacy three-zone layout. Design rec §04.
- \`EmptyState\` — icon · headline · description · action; tones for success/warning/danger/info. Design rec §08.

### Endpoint Details page
- Stats row across the top: Completed / Deferred / Failed / Pending counts derived from the current result set
- Status column rendered as proper \`Badge\` variants — no orange-as-status (design rec §02)
- Segmented List / Grouped-by-Error switch picks up design's \`.seg\` styling
- Zero-row state renders \`EmptyState\` with \"Clear all filters\" affordance instead of a blank table
- Page header uses the new title + subtitle pattern (\"CrmEndpoint · Endpoint details\")

### Data-table polish
- Surface-2 sticky header with caps-mono labels, rounded surface card, primary-tint hover row (matches mockup)
- Rows get \`.group\` so \`TruncatedGuid\`'s copy icon fades in on hover (design rec §06)
- \`TruncatedGuid\` renders mono + tabular-nums with hover-revealed copy glyph

## Test plan
- [x] \`npm run build\` succeeds (648 modules)
- [ ] Open \`/Endpoints/Details/CrmEndpoint\` and confirm: 4 stat tiles render at the top with correct tones, badge column shows green/amber/red/neutral pills, hovering a row shows a copy icon next to the event ID, hovering the value copies the full GUID to clipboard
- [ ] Apply a filter that returns no rows — confirm \`EmptyState\` with \"Clear all filters\" appears
- [ ] Toggle theme — table header / tiles / badges should pick up the warm-black dark palette