### PR TITLE
feat(webapp): PR 2 — Event Types catalog redesign

### DIFF
--- a/src/NimBus.WebApp/ClientApp/src/components/event-types/event-type-card.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/event-types/event-type-card.tsx
@@ -1,51 +1,86 @@
 import { Link } from "react-router-dom";
-import { Badge } from "components/ui/badge";
 import { Tooltip } from "components/ui/tooltip";
+import { cn } from "lib/utils";
 import * as api from "api-client";
 
 interface IEventTypeCardProps {
   eventType: api.EventType;
   producerCount?: number;
   consumerCount?: number;
+  /** Optional "Last published" timestamp display string (e.g. "4 s ago"). */
+  lastPublishedDisplay?: string;
 }
 
+/**
+ * Event-type catalog card. Design rec §09: make the grid scan like an API
+ * catalog — surface a producer → consumer flow chip in place of opaque P:N/C:N
+ * counts, so the operator's actual question ("is this contract alive and who
+ * owns it?") is answered pre-attentively.
+ *
+ * The current `EventType` API exposes only producer/consumer *counts*, so the
+ * flow chip uses pluralised count labels rather than real endpoint names —
+ * upgrading to real names requires a backend change and can land later
+ * without touching this component's contract.
+ */
 const EventTypeCard: React.FC<IEventTypeCardProps> = ({
   eventType,
   producerCount = 0,
   consumerCount = 0,
+  lastPublishedDisplay,
 }) => {
   const name = eventType.name || "Unknown";
   const description = eventType.description || "No description available";
-  const truncatedDescription =
-    description.length > 100
-      ? `${description.substring(0, 100)}...`
-      : description;
+  const pluralize = (n: number, w: string) => `${n} ${w}${n === 1 ? "" : "s"}`;
 
   return (
-    <Link to={`/EventTypes/Details/${eventType.id}`} className="no-underline">
-      <div className="p-4 border rounded-md border-border bg-card text-card-foreground cursor-pointer min-h-[140px] flex flex-col transition-all duration-200 hover:border-blue-400 hover:shadow-md hover:-translate-y-0.5">
-        <div className="flex flex-col items-start gap-2 flex-1">
-          <Tooltip content={name} position="top">
-            <p className="font-bold text-blue-600 text-base truncate w-full">
-              {name}
-            </p>
-          </Tooltip>
-          <p className="text-sm text-muted-foreground line-clamp-2 flex-1">
-            {truncatedDescription}
-          </p>
-        </div>
-        <div className="flex gap-2 mt-2">
-          <Tooltip content="Producers">
-            <Badge variant="success" className="bg-green-100 text-green-800">
-              P: {producerCount}
-            </Badge>
-          </Tooltip>
-          <Tooltip content="Consumers">
-            <Badge variant="info" className="bg-blue-100 text-blue-800">
-              C: {consumerCount}
-            </Badge>
-          </Tooltip>
-        </div>
+    <Link
+      to={`/EventTypes/Details/${eventType.id}`}
+      className={cn(
+        "no-underline group block",
+        "bg-card border border-border rounded-nb-md",
+        "px-4 py-3.5 min-h-[140px] flex flex-col gap-2",
+        "transition-colors duration-100",
+        "hover:border-primary hover:shadow-nb-sm",
+      )}
+    >
+      <Tooltip content={name} position="top">
+        <h4
+          className={cn(
+            "m-0 font-bold text-[14px] truncate",
+            "text-status-info dark:text-blue-300",
+          )}
+        >
+          {name}
+        </h4>
+      </Tooltip>
+      <p
+        className={cn(
+          "m-0 text-[12.5px] text-muted-foreground leading-snug",
+          "line-clamp-2 flex-1",
+        )}
+      >
+        {description}
+      </p>
+      <div className="flex items-center gap-2 mt-auto pt-1 flex-wrap font-mono text-[10.5px]">
+        <span
+          className={cn(
+            "inline-flex items-center gap-1.5",
+            "bg-background border border-border rounded-nb-sm px-2 py-0.5",
+          )}
+        >
+          <span className="text-status-success font-semibold">
+            {pluralize(producerCount, "producer")}
+          </span>
+          <span className="text-muted-foreground">→</span>
+          <span className="text-status-info font-semibold">
+            {pluralize(consumerCount, "consumer")}
+          </span>
+        </span>
+        {lastPublishedDisplay && (
+          <span className="ml-auto italic text-muted-foreground">
+            {lastPublishedDisplay}
+          </span>
+        )}
       </div>
     </Link>
   );

--- a/src/NimBus.WebApp/ClientApp/src/components/event-types/event-type-namespace-group.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/event-types/event-type-namespace-group.tsx
@@ -1,11 +1,12 @@
 import * as api from "api-client";
-import { Badge } from "components/ui/badge";
 import {
   Accordion,
   AccordionItem,
   AccordionTrigger,
   AccordionContent,
 } from "components/ui/accordion";
+import { NamespacePill } from "components/ui/namespace-pill";
+import { cn } from "lib/utils";
 import EventTypeCard from "./event-type-card";
 
 interface EventTypeWithCounts {
@@ -24,6 +25,10 @@ interface IEventTypeNamespaceGroupProps {
   defaultExpandedNamespaces?: string[];
 }
 
+/**
+ * Renders event-type cards grouped by namespace. Each group sits inside a
+ * surface-2 panel with a NamespacePill heading + count chip — design system §08.
+ */
 const EventTypeNamespaceGroup: React.FC<IEventTypeNamespaceGroupProps> = ({
   groups,
   defaultExpandedNamespaces,
@@ -40,28 +45,34 @@ const EventTypeNamespaceGroup: React.FC<IEventTypeNamespaceGroupProps> = ({
         <AccordionItem
           key={group.namespace}
           id={group.namespace}
-          className="mb-2"
+          className="mb-3"
         >
           <AccordionTrigger
             itemId={group.namespace}
-            className="bg-muted rounded-md data-[expanded]:rounded-b-none"
+            className={cn(
+              "bg-muted rounded-nb-md data-[expanded]:rounded-b-none",
+              "px-4 py-3 hover:bg-muted",
+            )}
           >
-            <span className="flex-1 text-left font-semibold">
-              {group.namespace}
-              <Badge
-                variant="primary"
-                size="sm"
-                className="ml-2 bg-purple-100 text-purple-800"
+            <span className="flex-1 text-left flex items-center gap-2.5">
+              <NamespacePill>{group.namespace}</NamespacePill>
+              <span
+                className={cn(
+                  "inline-flex items-center justify-center font-mono",
+                  "text-[11px] font-bold px-2 py-0.5 rounded-full",
+                  "bg-nimbus-purple-50 text-nimbus-purple",
+                  "dark:bg-purple-950/40 dark:text-purple-300",
+                )}
               >
                 {group.eventTypes.length}
-              </Badge>
+              </span>
             </span>
           </AccordionTrigger>
           <AccordionContent
             itemId={group.namespace}
-            className="bg-muted rounded-b-md"
+            className="bg-muted rounded-b-nb-md px-4 pb-4 pt-1"
           >
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
               {group.eventTypes.map((item) => (
                 <EventTypeCard
                   key={item.eventType.id}

--- a/src/NimBus.WebApp/ClientApp/src/components/event-types/event-type-search-toolbar.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/event-types/event-type-search-toolbar.tsx
@@ -1,38 +1,18 @@
-import { Button } from "components/ui/button";
-import { Input } from "components/ui/input";
 import { Select } from "components/ui/select";
-import { Tooltip } from "components/ui/tooltip";
+import { FilterToolbar, FilterSearch } from "components/ui/filter-toolbar";
+import { cn } from "lib/utils";
 
 export type ViewMode = "cards" | "table";
 
-// Grid view icon
 const GridViewIcon = () => (
-  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
     <path d="M3 3h8v8H3V3zm0 10h8v8H3v-8zm10-10h8v8h-8V3zm0 10h8v8h-8v-8z" />
   </svg>
 );
 
-// Table view icon
 const TableRowsIcon = () => (
-  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
     <path d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z" />
-  </svg>
-);
-
-// Search icon
-const SearchIcon = () => (
-  <svg
-    className="w-4 h-4"
-    fill="none"
-    stroke="currentColor"
-    viewBox="0 0 24 24"
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth={2}
-      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-    />
   </svg>
 );
 
@@ -46,6 +26,15 @@ interface IEventTypeSearchToolbarProps {
   onViewModeChange: (mode: ViewMode) => void;
 }
 
+const segBtn = (active: boolean) =>
+  cn(
+    "px-2.5 py-1.5 rounded-md text-xs font-semibold transition-colors",
+    "inline-flex items-center gap-1.5",
+    active
+      ? "bg-primary text-white"
+      : "text-muted-foreground hover:text-foreground",
+  );
+
 const EventTypeSearchToolbar: React.FC<IEventTypeSearchToolbarProps> = ({
   searchTerm,
   onSearchChange,
@@ -56,55 +45,55 @@ const EventTypeSearchToolbar: React.FC<IEventTypeSearchToolbarProps> = ({
   onViewModeChange,
 }) => {
   return (
-    <div className="flex flex-wrap gap-4 mb-4 items-center">
-      <div className="max-w-[400px] flex-1">
-        <Input
-          type="text"
-          placeholder="Search event types..."
+    <FilterToolbar
+      className="mb-4"
+      search={
+        <FilterSearch
           value={searchTerm}
-          onChange={(e) => onSearchChange(e.target.value)}
-          leftElement={<SearchIcon />}
+          onChange={onSearchChange}
+          placeholder="Search event types…"
         />
-      </div>
-
-      <Select
-        value={selectedNamespace}
-        onChange={(e) => onNamespaceChange(e.target.value)}
-        className="max-w-[300px]"
-      >
-        <option value="">All Namespaces</option>
-        {namespaces.map((ns) => (
-          <option key={ns} value={ns}>
-            {ns}
-          </option>
-        ))}
-      </Select>
-
-      <div className="flex ml-auto border border-input rounded-md">
-        <Tooltip content="Card View">
-          <Button
-            variant={viewMode === "cards" ? "solid" : "ghost"}
-            colorScheme={viewMode === "cards" ? "blue" : "gray"}
+      }
+      actions={
+        <Select
+          value={selectedNamespace}
+          onChange={(e) => onNamespaceChange(e.target.value)}
+          className="min-w-[200px] max-w-[300px]"
+        >
+          <option value="">All Namespaces</option>
+          {namespaces.map((ns) => (
+            <option key={ns} value={ns}>
+              {ns}
+            </option>
+          ))}
+        </Select>
+      }
+      trailing={
+        <div
+          className={cn(
+            "inline-flex items-center bg-card border border-border",
+            "rounded-nb-md p-[3px] gap-[2px]",
+          )}
+        >
+          <button
+            type="button"
             onClick={() => onViewModeChange("cards")}
+            className={segBtn(viewMode === "cards")}
             aria-label="Card view"
-            className="rounded-r-none"
           >
-            <GridViewIcon />
-          </Button>
-        </Tooltip>
-        <Tooltip content="Table View">
-          <Button
-            variant={viewMode === "table" ? "solid" : "ghost"}
-            colorScheme={viewMode === "table" ? "blue" : "gray"}
+            <GridViewIcon /> Grid
+          </button>
+          <button
+            type="button"
             onClick={() => onViewModeChange("table")}
+            className={segBtn(viewMode === "table")}
             aria-label="Table view"
-            className="rounded-l-none"
           >
-            <TableRowsIcon />
-          </Button>
-        </Tooltip>
-      </div>
-    </div>
+            <TableRowsIcon /> Table
+          </button>
+        </div>
+      }
+    />
   );
 };
 

--- a/src/NimBus.WebApp/ClientApp/src/components/ui/namespace-pill.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/ui/namespace-pill.tsx
@@ -1,0 +1,31 @@
+import { type ReactNode } from "react";
+import { cn } from "lib/utils";
+
+export interface NamespacePillProps {
+  children: ReactNode;
+  className?: string;
+  size?: "sm" | "md";
+}
+
+/**
+ * Mono-font pill identifying a contract namespace (e.g. CrmErpDemo.Contracts.Events).
+ * Purple is reserved for namespace/type metadata — distinct from primary (action)
+ * and status hues so a glance instantly classifies the chrome.
+ */
+export const NamespacePill = ({
+  children,
+  className,
+  size = "md",
+}: NamespacePillProps) => (
+  <span
+    className={cn(
+      "inline-flex items-center font-mono font-semibold tracking-wide",
+      "bg-nimbus-purple-50 text-nimbus-purple rounded-full",
+      "dark:bg-purple-950/40 dark:text-purple-300",
+      size === "sm" ? "text-[10.5px] px-2 py-0.5" : "text-[12px] px-2.5 py-1",
+      className,
+    )}
+  >
+    {children}
+  </span>
+);

--- a/src/NimBus.WebApp/ClientApp/src/pages/event-types-list.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/pages/event-types-list.tsx
@@ -3,6 +3,8 @@ import * as api from "api-client";
 import Page from "components/page";
 import { Spinner } from "components/ui/spinner";
 import { Badge } from "components/ui/badge";
+import { NamespacePill } from "components/ui/namespace-pill";
+import { EmptyState } from "components/ui/empty-state";
 import DataTable, { ITableRow, ITableHeadCell } from "components/data-table";
 import EventTypeSearchToolbar, {
   ViewMode,
@@ -133,7 +135,11 @@ const EventTypesList: React.FC = () => {
         [
           TableColumns.name,
           {
-            value: <span className="text-blue-600 font-bold">{et.name}</span>,
+            value: (
+              <span className="text-status-info dark:text-blue-300 font-bold">
+                {et.name}
+              </span>
+            ),
             searchValue: et.name || "",
           },
         ],
@@ -141,12 +147,9 @@ const EventTypesList: React.FC = () => {
           TableColumns.namespace,
           {
             value: (
-              <Badge
-                variant={et.namespace ? "primary" : "default"}
-                className={et.namespace ? "bg-purple-100 text-purple-800" : ""}
-              >
+              <NamespacePill size="sm">
                 {et.namespace || UNCATEGORIZED}
-              </Badge>
+              </NamespacePill>
             ),
             searchValue: et.namespace || UNCATEGORIZED,
           },
@@ -188,9 +191,15 @@ const EventTypesList: React.FC = () => {
     { id: TableColumns.consumers, label: "Consumers", numeric: true },
   ];
 
+  const eventTypeCount = eventTypes.length;
+  const namespaceCount = namespaces.length;
+
   if (loading) {
     return (
-      <Page title="Event Types">
+      <Page
+        title="Event Types"
+        subtitle="Contracts published across the bus"
+      >
         <div className="flex items-center justify-center w-full h-[200px]">
           <Spinner size="xl" color="primary" />
         </div>
@@ -209,8 +218,11 @@ const EventTypesList: React.FC = () => {
   const setViewMode = (next: ViewMode) =>
     setFiltersWithoutHistory({ ...applied, viewMode: next });
 
+  const hasActiveFilters = searchTerm.length > 0 || selectedNamespace.length > 0;
+  const subtitle = `${eventTypeCount} contract${eventTypeCount === 1 ? "" : "s"} across ${namespaceCount} namespace${namespaceCount === 1 ? "" : "s"}`;
+
   return (
-    <Page title="Event Types">
+    <Page title="Event Types" subtitle={subtitle}>
       <div className="w-full">
         <EventTypeSearchToolbar
           searchTerm={searchTerm}
@@ -223,11 +235,33 @@ const EventTypesList: React.FC = () => {
         />
 
         {filteredEventTypes.length === 0 ? (
-          <div className="flex items-center justify-center h-[200px]">
-            <p className="text-muted-foreground">
-              No event types found matching your criteria.
-            </p>
-          </div>
+          <EmptyState
+            icon="◌"
+            title={
+              hasActiveFilters
+                ? "No event types match your filters"
+                : "No event types registered yet"
+            }
+            description={
+              hasActiveFilters
+                ? "Try a different search term or clear the namespace filter."
+                : "Event types will appear here once endpoints declare their published and consumed contracts."
+            }
+            action={
+              hasActiveFilters && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSearchTerm("");
+                    setSelectedNamespace("");
+                  }}
+                  className="text-primary-600 hover:text-primary text-[13px] font-semibold underline-offset-2 hover:underline"
+                >
+                  Clear all filters
+                </button>
+              )
+            }
+          />
         ) : viewMode === "cards" ? (
           <EventTypeNamespaceGroup groups={groupedEventTypes} />
         ) : (


### PR DESCRIPTION
## Summary
Second page-level adoption of the design system. Stacks on #44.

### New primitive
- \`NamespacePill\` — mono purple pill identifying a contract namespace. Used on cards, group headers, and table cells; same look every time the namespace appears.

### Event Types catalog
- \`EventTypeCard\` rebuilt: producer → consumer **flow chip** replaces the opaque \`P:N / C:N\` pair (design rec §09). Producer is success-green, consumer is info-blue — so a glance answers "who publishes / who consumes" pre-attentively.
- Cards expose an optional \`lastPublishedDisplay\` prop (renders italic, right-aligned) — wires up once the API exposes it; renders nothing meanwhile.
- Namespace groups: surface-2 panel wrapper, \`NamespacePill\` heading, mono count chip, tighter card grid.
- Search toolbar uses \`FilterToolbar\`/\`FilterSearch\` from PR 1 + a segmented Grid/Table switch.
- Zero-match state uses \`EmptyState\` with \"Clear all filters\".
- Page header: \"Event Types\" + subtitle \"N contracts across M namespaces\".

## Test plan
- [x] \`npm run build\` succeeds (650 modules)
- [ ] Open \`/EventTypes\` and confirm: cream surface-2 group panels with purple namespace pills + count, cards show \"1 producer → 1 consumer\" flow chip, hover lifts the card with a coral border
- [ ] Toggle to Table view — namespace column renders as \`NamespacePill\`, not a Badge
- [ ] Search for nonsense — \`EmptyState\` with \"Clear all filters\" appears
- [ ] Dark mode: purple pill stays legible on the warm-black palette