### PR TITLE
feat(webapp): Topology page — live publish/subscribe graph

### DIFF
--- a/src/NimBus.WebApp/ClientApp/src/app.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/app.tsx
@@ -9,6 +9,7 @@ import EventTypeDetails from "pages/event-type-details";
 import MessagesList from "pages/messages-list";
 import Admin from "pages/admin";
 import Metrics from "pages/metrics";
+import Topology from "pages/topology";
 import Insights from "pages/insights";
 import AuditsList from "pages/audits-list";
 import Footer from "components/footer";
@@ -64,6 +65,12 @@ const navigation: Navigation = [
     path: "/Metrics",
     header: true,
     render: () => <Metrics />,
+  },
+  {
+    name: "Topology",
+    path: "/Topology",
+    header: true,
+    render: () => <Topology />,
   },
   {
     name: "Insights",

--- a/src/NimBus.WebApp/ClientApp/src/app.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/app.tsx
@@ -15,6 +15,7 @@ import AuditsList from "pages/audits-list";
 import Footer from "components/footer";
 import { Navigation } from "models/navigation";
 import { ToastProvider } from "components/ui/toast";
+import { CommandPaletteProvider } from "components/command-palette";
 import { ThemeProvider } from "hooks/use-theme";
 
 const navigation: Navigation = [
@@ -102,26 +103,28 @@ function App() {
   return (
     <ThemeProvider>
       <ToastProvider>
-        <div className="flex min-h-screen bg-background">
-          <Sidebar />
-          <div className="flex flex-col flex-1 min-w-0">
-            <Topbar />
-            <main className="flex-1 flex flex-col min-w-0">
-              <Routes>
-                {navigation
-                  .filter((x) => x.render)
-                  .map((route) => (
-                    <Route
-                      key={route.path}
-                      path={route.path}
-                      element={route.render!()}
-                    />
-                  ))}
-              </Routes>
-            </main>
-            <Footer />
+        <CommandPaletteProvider>
+          <div className="flex min-h-screen bg-background">
+            <Sidebar />
+            <div className="flex flex-col flex-1 min-w-0">
+              <Topbar />
+              <main className="flex-1 flex flex-col min-w-0">
+                <Routes>
+                  {navigation
+                    .filter((x) => x.render)
+                    .map((route) => (
+                      <Route
+                        key={route.path}
+                        path={route.path}
+                        element={route.render!()}
+                      />
+                    ))}
+                </Routes>
+              </main>
+              <Footer />
+            </div>
           </div>
-        </div>
+        </CommandPaletteProvider>
       </ToastProvider>
     </ThemeProvider>
   );

--- a/src/NimBus.WebApp/ClientApp/src/components/command-palette/command-palette-context.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/command-palette/command-palette-context.tsx
@@ -1,0 +1,16 @@
+import { createContext } from "react";
+
+export interface CommandPaletteContextValue {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+/**
+ * Internal context — consumers use the `useCommandPalette` hook instead of
+ * touching this directly so the provider stays the single source of truth
+ * for open/close state.
+ */
+export const CommandPaletteContext =
+  createContext<CommandPaletteContextValue | null>(null);

--- a/src/NimBus.WebApp/ClientApp/src/components/command-palette/command-palette-provider.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/command-palette/command-palette-provider.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { CommandPaletteContext } from "./command-palette-context";
+import { CommandPalette } from "./command-palette";
+
+interface CommandPaletteProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Owns the palette's open/close state and the global Cmd+K / Ctrl+K listener.
+ *
+ * The shortcut still fires when focus is in an `<input>` (operators paste GUIDs
+ * mid-typing), but we opt out for `<textarea>` and `contenteditable` regions
+ * where Ctrl/Cmd+K is more likely to mean "edit hyperlink".
+ *
+ * The palette itself is rendered once here so child trees only need to consume
+ * the hook to open it — same pattern as `ToastProvider`.
+ */
+export const CommandPaletteProvider: React.FC<CommandPaletteProviderProps> = ({
+  children,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((v) => !v), []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      // Letter "k" only; ignore Shift+K and other modifiers.
+      if (e.key !== "k" && e.key !== "K") return;
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.shiftKey || e.altKey) return;
+
+      // Don't shadow textarea / rich-text editing shortcuts.
+      const target = e.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (tag === "TEXTAREA") return;
+        if (target.isContentEditable) return;
+      }
+
+      e.preventDefault();
+      toggle();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [toggle]);
+
+  const value = useMemo(
+    () => ({ isOpen, open, close, toggle }),
+    [isOpen, open, close, toggle],
+  );
+
+  return (
+    <CommandPaletteContext.Provider value={value}>
+      {children}
+      <CommandPalette isOpen={isOpen} onClose={close} />
+    </CommandPaletteContext.Provider>
+  );
+};

--- a/src/NimBus.WebApp/ClientApp/src/components/command-palette/command-palette.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/command-palette/command-palette.tsx
@@ -1,0 +1,351 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import { createPortal } from "react-dom";
+import { useNavigate } from "react-router-dom";
+import { cn } from "lib/utils";
+import { Spinner } from "components/ui/spinner";
+import { usePaletteSearch, type PaletteResult } from "./use-palette-search";
+
+interface CommandPaletteProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const SECTION_LABELS: Record<PaletteResult["kind"], string> = {
+  endpoint: "Endpoints",
+  eventType: "Event Types",
+  event: "Events",
+  session: "Sessions",
+};
+
+const SECTION_ORDER: Array<PaletteResult["kind"]> = [
+  "endpoint",
+  "eventType",
+  "event",
+  "session",
+];
+
+const KIND_ICON: Record<PaletteResult["kind"], React.ReactNode> = {
+  endpoint: (
+    <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <rect x="2" y="3" width="12" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M2 6h12" stroke="currentColor" strokeWidth="1.4" />
+    </svg>
+  ),
+  eventType: (
+    <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path d="M2 4h6M2 8h12M2 12h9" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  ),
+  event: (
+    <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path d="M2 4h12v8H2z" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
+      <path d="M2 4l6 5 6-5" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
+    </svg>
+  ),
+  session: (
+    <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M8 5v3l2 2" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  ),
+};
+
+/**
+ * The ⌘K / Ctrl+K command palette. Centred near the top of the viewport,
+ * portalled to body, ESC + outside-click close. Local + remote search lives
+ * in `usePaletteSearch`; this component is concerned only with input,
+ * keyboard navigation, rendering, and routing on selection.
+ */
+export const CommandPalette: React.FC<CommandPaletteProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const [query, setQuery] = useState("");
+  const [highlighted, setHighlighted] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  const { results, catalogLoading, remoteSearching, remoteError } =
+    usePaletteSearch(query, isOpen);
+
+  // Reset when the palette opens so the previous gesture's state isn't sticky.
+  useEffect(() => {
+    if (isOpen) {
+      setQuery("");
+      setHighlighted(0);
+      // Defer focus until after the portal mounts.
+      const id = window.setTimeout(() => inputRef.current?.focus(), 0);
+      return () => window.clearTimeout(id);
+    }
+  }, [isOpen]);
+
+  // Keep the highlight in-range as results change.
+  useEffect(() => {
+    if (highlighted >= results.length) {
+      setHighlighted(results.length === 0 ? 0 : results.length - 1);
+    }
+  }, [results.length, highlighted]);
+
+  // Scroll the highlighted row into view when navigating with the keyboard.
+  useEffect(() => {
+    const node = listRef.current?.querySelector<HTMLElement>(
+      `[data-row-index='${highlighted}']`,
+    );
+    node?.scrollIntoView({ block: "nearest" });
+  }, [highlighted]);
+
+  // Lock body scroll while open. Mirrors what the Modal primitive does so the
+  // page underneath doesn't shift when the palette opens.
+  useEffect(() => {
+    if (!isOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [isOpen]);
+
+  const grouped = useMemo(() => {
+    const map: Record<PaletteResult["kind"], PaletteResult[]> = {
+      endpoint: [],
+      eventType: [],
+      event: [],
+      session: [],
+    };
+    for (const r of results) {
+      map[r.kind].push(r);
+    }
+    return map;
+  }, [results]);
+
+  const handleSelect = (r: PaletteResult) => {
+    onClose();
+    // Defer the navigate until after the close transition starts so the
+    // route doesn't render under a stale overlay.
+    window.requestAnimationFrame(() => navigate(r.route));
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlighted((i) => Math.min(i + 1, Math.max(results.length - 1, 0)));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlighted((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const r = results[highlighted];
+      if (r) handleSelect(r);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const trimmed = query.trim();
+  const showEmptyHint = trimmed.length === 0;
+  const noResults =
+    !showEmptyHint &&
+    results.length === 0 &&
+    !catalogLoading &&
+    !remoteSearching;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 bg-black/50 flex items-start justify-center pt-[10vh] px-4"
+      onMouseDown={(e) => {
+        // Only close if the user clicked the overlay itself, not a descendant.
+        if (e.target === e.currentTarget) onClose();
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+    >
+      <div
+        className={cn(
+          "w-full max-w-xl bg-card text-card-foreground",
+          "rounded-nb-lg border border-border shadow-nb-lg overflow-hidden",
+          "flex flex-col max-h-[70vh]",
+          "animate-zoom-in",
+        )}
+      >
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+          <svg
+            className="w-4 h-4 text-muted-foreground shrink-0"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden
+          >
+            <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M10.5 10.5L13 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+          <input
+            ref={inputRef}
+            type="text"
+            autoComplete="off"
+            spellCheck={false}
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setHighlighted(0);
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder="Jump to endpoint, event, or session…"
+            className={cn(
+              "flex-1 bg-transparent outline-none border-0 text-foreground",
+              "placeholder:text-muted-foreground text-[14px]",
+            )}
+            aria-label="Search"
+            aria-autocomplete="list"
+            aria-controls="cmd-palette-results"
+            aria-activedescendant={
+              results[highlighted]?.key
+                ? `cmd-palette-row-${results[highlighted]!.key}`
+                : undefined
+            }
+          />
+          {(catalogLoading || remoteSearching) && (
+            <Spinner size="sm" color="primary" />
+          )}
+          <kbd
+            className={cn(
+              "font-mono text-[10.5px] bg-muted border border-border",
+              "px-1.5 py-px rounded text-muted-foreground",
+            )}
+          >
+            esc
+          </kbd>
+        </div>
+
+        <div
+          ref={listRef}
+          id="cmd-palette-results"
+          role="listbox"
+          className="flex-1 overflow-y-auto py-1"
+        >
+          {showEmptyHint && (
+            <EmptyHint catalogLoading={catalogLoading} />
+          )}
+          {noResults && <NoResults query={trimmed} />}
+          {remoteError && !remoteSearching && (
+            <div className="px-4 py-3 text-[12.5px] text-status-warning-ink font-mono">
+              ID lookup failed — backend unavailable.
+            </div>
+          )}
+          {SECTION_ORDER.map((kind) => {
+            const items = grouped[kind];
+            if (items.length === 0) return null;
+            return (
+              <section key={kind}>
+                <div
+                  className={cn(
+                    "px-4 pt-3 pb-1 font-mono text-[10.5px] uppercase",
+                    "tracking-[0.12em] text-muted-foreground",
+                  )}
+                >
+                  {SECTION_LABELS[kind]}
+                </div>
+                <ul className="m-0 p-0 list-none">
+                  {items.map((r) => {
+                    const flatIndex = results.indexOf(r);
+                    const isActive = flatIndex === highlighted;
+                    return (
+                      <li
+                        key={r.key}
+                        id={`cmd-palette-row-${r.key}`}
+                        role="option"
+                        aria-selected={isActive}
+                        data-row-index={flatIndex}
+                        onMouseEnter={() => setHighlighted(flatIndex)}
+                        onMouseDown={(e) => {
+                          // mousedown not click — beats the overlay's
+                          // onMouseDown that would otherwise close us first.
+                          e.preventDefault();
+                          handleSelect(r);
+                        }}
+                        className={cn(
+                          "px-4 py-2 flex items-center gap-3 cursor-pointer",
+                          "text-[13px]",
+                          isActive
+                            ? "bg-primary-tint text-primary-600"
+                            : "text-foreground",
+                        )}
+                      >
+                        <span
+                          className={cn(
+                            "shrink-0",
+                            isActive
+                              ? "text-primary-600"
+                              : "text-muted-foreground",
+                          )}
+                        >
+                          {KIND_ICON[r.kind]}
+                        </span>
+                        <span className="flex-1 min-w-0">
+                          <span className="font-semibold truncate block">
+                            {r.title}
+                          </span>
+                          {r.subtitle && (
+                            <span
+                              className={cn(
+                                "font-mono text-[11px] truncate block",
+                                isActive
+                                  ? "text-primary-600/80"
+                                  : "text-muted-foreground",
+                              )}
+                            >
+                              {r.subtitle}
+                            </span>
+                          )}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            );
+          })}
+        </div>
+
+        <div
+          className={cn(
+            "px-4 py-2 border-t border-border bg-muted",
+            "font-mono text-[10.5px] text-muted-foreground",
+            "flex items-center gap-4",
+          )}
+        >
+          <span>↑↓ navigate</span>
+          <span>↵ open</span>
+          <span>esc close</span>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+const EmptyHint: React.FC<{ catalogLoading: boolean }> = ({
+  catalogLoading,
+}) => (
+  <div className="px-4 py-6 text-[12.5px] text-muted-foreground">
+    {catalogLoading
+      ? "Loading catalog…"
+      : "Type to search endpoints, event types, or paste an event ID or session ID. Use ↑↓ Enter to navigate."}
+  </div>
+);
+
+const NoResults: React.FC<{ query: string }> = ({ query }) => (
+  <div className="px-4 py-6 text-[12.5px] text-muted-foreground">
+    No matches for <span className="font-mono text-foreground">{query}</span>.
+    Try a different name or paste a full event / session ID.
+  </div>
+);

--- a/src/NimBus.WebApp/ClientApp/src/components/command-palette/index.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/command-palette/index.ts
@@ -1,0 +1,2 @@
+export { CommandPaletteProvider } from "./command-palette-provider";
+export { useCommandPalette } from "./use-command-palette";

--- a/src/NimBus.WebApp/ClientApp/src/components/command-palette/use-command-palette.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/command-palette/use-command-palette.ts
@@ -1,0 +1,19 @@
+import { useContext } from "react";
+import {
+  CommandPaletteContext,
+  type CommandPaletteContextValue,
+} from "./command-palette-context";
+
+/**
+ * Read the command-palette state from anywhere in the tree.
+ * Throws if used outside `CommandPaletteProvider` so missing wiring fails loudly.
+ */
+export function useCommandPalette(): CommandPaletteContextValue {
+  const ctx = useContext(CommandPaletteContext);
+  if (!ctx) {
+    throw new Error(
+      "useCommandPalette must be used inside <CommandPaletteProvider>",
+    );
+  }
+  return ctx;
+}

--- a/src/NimBus.WebApp/ClientApp/src/components/command-palette/use-palette-search.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/command-palette/use-palette-search.ts
@@ -1,0 +1,240 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import * as api from "api-client";
+
+// 8-4-4-4-12 hex layout OR 32 contiguous hex chars (Service Bus session keys).
+const GUID_DASHED = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const HEX_32 = /^[0-9a-fA-F]{32}$/;
+const REMOTE_DEBOUNCE_MS = 250;
+const MAX_LOCAL_RESULTS = 8;
+const MAX_REMOTE_RESULTS = 25;
+
+export interface PaletteResult {
+  /** Stable key for React reconciliation. */
+  key: string;
+  kind: "endpoint" | "eventType" | "event" | "session";
+  title: string;
+  /** Mono secondary line; usually a namespace or "Session …" descriptor. */
+  subtitle?: string;
+  /** Route to navigate to on selection. */
+  route: string;
+}
+
+export interface PaletteSearchState {
+  /** Whether catalog (endpoints + event types) is still loading. */
+  catalogLoading: boolean;
+  /** Whether a GUID lookup is in flight. */
+  remoteSearching: boolean;
+  /** Soft error from the GUID lookup; UI shows a hint, doesn't crash. */
+  remoteError?: string;
+  results: PaletteResult[];
+}
+
+function looksLikeId(input: string): boolean {
+  return GUID_DASHED.test(input) || HEX_32.test(input);
+}
+
+/**
+ * Aggregates command-palette results from two sources:
+ *
+ * 1. **Catalog (local)** — endpoint names + event types fetched once when the
+ *    palette opens and substring-filtered against the input.
+ * 2. **GUID lookup (remote)** — when the input looks like an ID we hit the
+ *    `/api/messages/search` endpoint twice in parallel (by eventId, by sessionId)
+ *    and surface the hits as `event` / `session` rows.
+ *
+ * Catalog requests run once per page load (the catalog rarely changes during
+ * an operator's session). Remote lookups debounce 250 ms so paste-then-type
+ * doesn't fire 5 round-trips.
+ */
+export function usePaletteSearch(
+  query: string,
+  enabled: boolean,
+): PaletteSearchState {
+  const [endpoints, setEndpoints] = useState<string[] | undefined>(undefined);
+  const [eventTypes, setEventTypes] = useState<api.EventType[] | undefined>(
+    undefined,
+  );
+  const [catalogLoading, setCatalogLoading] = useState(false);
+
+  const [remoteEvents, setRemoteEvents] = useState<api.Message[]>([]);
+  const [remoteSessions, setRemoteSessions] = useState<api.Message[]>([]);
+  const [remoteSearching, setRemoteSearching] = useState(false);
+  const [remoteError, setRemoteError] = useState<string | undefined>(undefined);
+  // Increments every time we kick off a new remote search; only the latest
+  // ticket's response is applied so out-of-order returns can't clobber state.
+  const remoteTicket = useRef(0);
+
+  // 1. Catalog fetch — once, lazily when the palette first opens.
+  useEffect(() => {
+    if (!enabled) return;
+    if (endpoints !== undefined && eventTypes !== undefined) return;
+    let cancelled = false;
+    setCatalogLoading(true);
+    const client = new api.Client(api.CookieAuth());
+    Promise.all([
+      client.getEndpointsAll().catch((): string[] => []),
+      client.getEventTypes().catch((): api.EventType[] => []),
+    ])
+      .then(([eps, types]) => {
+        if (cancelled) return;
+        setEndpoints(eps);
+        setEventTypes(types);
+      })
+      .finally(() => {
+        if (!cancelled) setCatalogLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, endpoints, eventTypes]);
+
+  // 2. Remote GUID lookup — debounced.
+  useEffect(() => {
+    if (!enabled) {
+      setRemoteEvents([]);
+      setRemoteSessions([]);
+      setRemoteError(undefined);
+      return;
+    }
+    const trimmed = query.trim();
+    if (!trimmed || !looksLikeId(trimmed)) {
+      setRemoteEvents([]);
+      setRemoteSessions([]);
+      setRemoteError(undefined);
+      return;
+    }
+
+    const ticket = ++remoteTicket.current;
+    const timer = window.setTimeout(async () => {
+      const client = new api.Client(api.CookieAuth());
+      setRemoteSearching(true);
+      setRemoteError(undefined);
+      try {
+        const byEvent = new api.MessageSearchRequest();
+        byEvent.filter = api.MessageSearchFilter.fromJS({ eventId: trimmed });
+        byEvent.maxItemCount = MAX_REMOTE_RESULTS;
+
+        const bySession = new api.MessageSearchRequest();
+        bySession.filter = api.MessageSearchFilter.fromJS({
+          sessionId: trimmed,
+        });
+        bySession.maxItemCount = MAX_REMOTE_RESULTS;
+
+        const [evRes, seRes] = await Promise.all([
+          client.postMessagesSearch(byEvent).catch(() => undefined),
+          client.postMessagesSearch(bySession).catch(() => undefined),
+        ]);
+
+        if (ticket !== remoteTicket.current) return;
+        setRemoteEvents(evRes?.messages ?? []);
+        setRemoteSessions(seRes?.messages ?? []);
+      } catch (err) {
+        if (ticket !== remoteTicket.current) return;
+        setRemoteError(
+          err instanceof Error ? err.message : "Lookup failed",
+        );
+        setRemoteEvents([]);
+        setRemoteSessions([]);
+      } finally {
+        if (ticket === remoteTicket.current) {
+          setRemoteSearching(false);
+        }
+      }
+    }, REMOTE_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [enabled, query]);
+
+  // 3. Compose results
+  return useMemo<PaletteSearchState>(() => {
+    const trimmed = query.trim();
+    const lower = trimmed.toLowerCase();
+    const results: PaletteResult[] = [];
+
+    // Local matches — only when there's actual input (empty input shows hint).
+    if (trimmed) {
+      const epMatches = (endpoints ?? [])
+        .filter((name) => name.toLowerCase().includes(lower))
+        .slice(0, MAX_LOCAL_RESULTS);
+      for (const name of epMatches) {
+        results.push({
+          key: `endpoint::${name}`,
+          kind: "endpoint",
+          title: name,
+          subtitle: "Endpoint",
+          route: `/Endpoints/Details/${encodeURIComponent(name)}`,
+        });
+      }
+
+      const typeMatches = (eventTypes ?? [])
+        .filter((et) => {
+          const name = (et.name || et.id || "").toLowerCase();
+          const ns = (et.namespace || "").toLowerCase();
+          return name.includes(lower) || ns.includes(lower);
+        })
+        .slice(0, MAX_LOCAL_RESULTS);
+      for (const et of typeMatches) {
+        results.push({
+          key: `eventType::${et.id}`,
+          kind: "eventType",
+          title: et.name || et.id,
+          subtitle: et.namespace || "Event type",
+          route: `/EventTypes/Details/${encodeURIComponent(et.id)}`,
+        });
+      }
+    }
+
+    // Remote — only meaningful when query is GUID-shaped.
+    if (trimmed && looksLikeId(trimmed)) {
+      for (const m of remoteEvents) {
+        if (!m.eventId || !m.endpointId) continue;
+        const ep = m.endpointId;
+        const evId = m.eventId;
+        const short = evId.length > 12 ? `${evId.slice(0, 8)}…` : evId;
+        results.push({
+          key: `event::${ep}::${evId}`,
+          kind: "event",
+          title: `Event ${short}`,
+          subtitle: `${m.eventTypeId ?? "(unknown type)"} · ${ep}`,
+          route: `/Message/Index/${encodeURIComponent(ep)}/${encodeURIComponent(evId)}/0`,
+        });
+      }
+
+      // Sessions can match many messages — collapse to one row per unique session.
+      const sessionSeen = new Set<string>();
+      for (const m of remoteSessions) {
+        if (!m.sessionId) continue;
+        if (sessionSeen.has(m.sessionId)) continue;
+        sessionSeen.add(m.sessionId);
+        const short =
+          m.sessionId.length > 12
+            ? `${m.sessionId.slice(0, 8)}…`
+            : m.sessionId;
+        const ep = m.endpointId ?? m.to ?? "—";
+        results.push({
+          key: `session::${m.sessionId}`,
+          kind: "session",
+          title: `Session ${short}`,
+          subtitle: `Endpoint ${ep}`,
+          route: `/Messages?sessionId=${encodeURIComponent(m.sessionId)}`,
+        });
+      }
+    }
+
+    return {
+      catalogLoading,
+      remoteSearching,
+      remoteError,
+      results,
+    };
+  }, [
+    query,
+    endpoints,
+    eventTypes,
+    remoteEvents,
+    remoteSessions,
+    remoteSearching,
+    remoteError,
+    catalogLoading,
+  ]);
+}

--- a/src/NimBus.WebApp/ClientApp/src/components/sidebar.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/sidebar.tsx
@@ -8,6 +8,8 @@ interface NavItem {
   /** Match path prefixes so /Endpoints/Details/X keeps Endpoints highlighted. */
   matchPrefix?: string;
   icon: React.ReactNode;
+  /** Optional trailing badge (e.g. "new") — rendered in the muted pill slot. */
+  badge?: string;
 }
 
 interface NavGroup {
@@ -105,6 +107,19 @@ const Icon = {
       />
     </svg>
   ),
+  topology: (
+    <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none">
+      <circle cx="4" cy="4" r="2" stroke="currentColor" strokeWidth="1.4" />
+      <circle cx="12" cy="4" r="2" stroke="currentColor" strokeWidth="1.4" />
+      <circle cx="8" cy="12" r="2" stroke="currentColor" strokeWidth="1.4" />
+      <path
+        d="M5.6 5.4l1.5 5M10.4 5.4L8.9 10.4M6 4h4"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+      />
+    </svg>
+  ),
 };
 
 const NAV: NavGroup[] = [
@@ -130,6 +145,12 @@ const NAV: NavGroup[] = [
         icon: Icon.messages,
       },
       { name: "Metrics", path: "/Metrics", icon: Icon.metrics },
+      {
+        name: "Topology",
+        path: "/Topology",
+        icon: Icon.topology,
+        badge: "new",
+      },
     ],
   },
   {
@@ -218,7 +239,17 @@ const Sidebar = () => {
                 }}
               >
                 <span className="opacity-90 shrink-0">{item.icon}</span>
-                {item.name}
+                <span className="flex-1 truncate">{item.name}</span>
+                {item.badge && (
+                  <span
+                    className={cn(
+                      "ml-auto font-mono text-[10px] uppercase tracking-wider px-1.5 py-px rounded-full font-bold",
+                      "bg-primary/[0.22] text-primary",
+                    )}
+                  >
+                    {item.badge}
+                  </span>
+                )}
               </NavLink>
             ))}
           </div>

--- a/src/NimBus.WebApp/ClientApp/src/components/topbar.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/topbar.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation, useParams } from "react-router-dom";
 import { useTheme } from "hooks/use-theme";
+import { useCommandPalette } from "components/command-palette";
 import { cn } from "lib/utils";
 
 interface Crumb {
@@ -66,9 +67,15 @@ function useBreadcrumbs(): Crumb[] {
 const Topbar = () => {
   const crumbs = useBreadcrumbs();
   const { resolvedTheme, setTheme } = useTheme();
+  const { open: openCommandPalette } = useCommandPalette();
 
   const toggleTheme = () =>
     setTheme(resolvedTheme === "dark" ? "light" : "dark");
+
+  const isMac =
+    typeof navigator !== "undefined" &&
+    /Mac|iPhone|iPad/.test(navigator.platform);
+  const shortcutLabel = isMac ? "⌘K" : "Ctrl K";
 
   return (
     <header
@@ -105,18 +112,23 @@ const Topbar = () => {
 
       <div className="flex-1" />
 
-      {/* ⌘K command-palette placeholder (recommendation §10). Not wired —
-          renders as a static search affordance for now. */}
-      <div
+      {/* ⌘K command-palette trigger — recommendation §10 from the design
+          handoff. Keyboard users invoke via Cmd+K / Ctrl+K from anywhere
+          (wired in CommandPaletteProvider); this button is the same gesture
+          for mouse-first users. */}
+      <button
+        type="button"
+        onClick={openCommandPalette}
         className={cn(
           "hidden md:flex items-center gap-2",
           "bg-card border border-border rounded-nb-md",
           "px-3 py-1.5 min-w-[280px] text-muted-foreground text-[13px]",
-          "cursor-not-allowed opacity-75",
+          "hover:border-border-strong hover:text-foreground transition-colors",
+          "cursor-pointer",
         )}
-        title="Command palette (not yet wired)"
+        title={`Open command palette (${shortcutLabel})`}
       >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden>
           <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.5" />
           <path
             d="M10.5 10.5L13 13"
@@ -127,9 +139,9 @@ const Topbar = () => {
         </svg>
         <span>Jump to endpoint, event, or session…</span>
         <kbd className="ml-auto font-mono text-[10.5px] bg-muted border border-border px-1.5 py-px rounded text-muted-foreground">
-          ⌘K
+          {shortcutLabel}
         </kbd>
-      </div>
+      </button>
 
       <button
         onClick={toggleTheme}

--- a/src/NimBus.WebApp/ClientApp/src/components/topbar.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/topbar.tsx
@@ -50,6 +50,8 @@ function useBreadcrumbs(): Crumb[] {
       return [{ label: "Messages" }];
     case "Metrics":
       return [{ label: "Metrics" }];
+    case "Topology":
+      return [{ label: "Topology" }];
     case "Insights":
       return [{ label: "Insights" }];
     case "Audits":

--- a/src/NimBus.WebApp/ClientApp/src/components/topology/topology-graph.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/topology/topology-graph.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "lib/utils";
 import type { EventPill, TopologyEdge, TopologyNode } from "./types";
 
@@ -10,6 +10,14 @@ const HUB_W = 120;
 const HUB_H = 60;
 const HUB_CX = VIEWBOX_W / 2;
 const HUB_CY = VIEWBOX_H / 2;
+
+const MIN_ZOOM = 0.4;
+const MAX_ZOOM = 4;
+const WHEEL_ZOOM_FACTOR = 1.15;
+const BUTTON_ZOOM_FACTOR = 1.25;
+// Drag threshold (screen pixels) below which we treat a release as a click,
+// so panning the canvas doesn't swallow card selection.
+const DRAG_CLICK_THRESHOLD = 4;
 
 interface TopologyGraphProps {
   nodes: TopologyNode[];
@@ -36,7 +44,28 @@ export const TopologyGraph: React.FC<TopologyGraphProps> = ({
   className,
 }) => {
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
   const tagRef = useRef<HTMLSpanElement | null>(null);
+
+  // Pan/zoom state. `pan` is the top-left corner of the visible viewBox in
+  // base coordinates; `zoom` shrinks the visible viewBox (zoom > 1 = closer).
+  // Together they drive the SVG `viewBox` attribute — text and strokes stay
+  // crisp at any zoom level because we never CSS-transform the SVG.
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  // Tracks an in-progress drag so a release with negligible movement still
+  // counts as a click (otherwise panning would steal card selection).
+  const dragRef = useRef<{
+    startX: number;
+    startY: number;
+    panX: number;
+    panY: number;
+    moved: number;
+  } | null>(null);
+
+  const viewBoxW = VIEWBOX_W / zoom;
+  const viewBoxH = VIEWBOX_H / zoom;
+  const viewBoxStr = `${pan.x} ${pan.y} ${viewBoxW} ${viewBoxH}`;
 
   // Radial layout — angle each endpoint around the hub. Radius shrinks
   // slightly as N grows so cards stay inside the viewbox; clamped so the
@@ -120,6 +149,12 @@ export const TopologyGraph: React.FC<TopologyGraphProps> = ({
     if (!wrap || !tag) return;
 
     const handleMove = (e: MouseEvent) => {
+      // While the user is actively dragging the canvas, suppress tooltips —
+      // they distract from the pan and follow the cursor jitterily.
+      if (dragRef.current) {
+        tag.classList.remove("show");
+        return;
+      }
       const target = (e.target as HTMLElement | null)?.closest?.("[data-tag]");
       if (!target) {
         tag.classList.remove("show");
@@ -141,6 +176,129 @@ export const TopologyGraph: React.FC<TopologyGraphProps> = ({
       wrap.removeEventListener("mouseleave", handleLeave);
     };
   }, []);
+
+  // Wheel-to-zoom. React's onWheel is passive by default in recent versions,
+  // so preventDefault() inside the JSX handler doesn't stop the page from
+  // scrolling. Wire it imperatively with `{ passive: false }` so the zoom
+  // wholly consumes wheel events over the canvas.
+  useEffect(() => {
+    const svg = svgRef.current;
+    const wrap = wrapRef.current;
+    if (!svg || !wrap) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const r = wrap.getBoundingClientRect();
+      const cx = e.clientX - r.left;
+      const cy = e.clientY - r.top;
+      // Cursor position in current viewBox coordinates — we keep this stable
+      // across the zoom so the operator can drill into a node naturally.
+      const vx = pan.x + (cx / r.width) * viewBoxW;
+      const vy = pan.y + (cy / r.height) * viewBoxH;
+      const factor = e.deltaY < 0 ? WHEEL_ZOOM_FACTOR : 1 / WHEEL_ZOOM_FACTOR;
+      const nextZoom = clamp(zoom * factor, MIN_ZOOM, MAX_ZOOM);
+      if (nextZoom === zoom) return;
+      const newW = VIEWBOX_W / nextZoom;
+      const newH = VIEWBOX_H / nextZoom;
+      setZoom(nextZoom);
+      setPan({
+        x: vx - (cx / r.width) * newW,
+        y: vy - (cy / r.height) * newH,
+      });
+    };
+
+    svg.addEventListener("wheel", handleWheel, { passive: false });
+    return () => svg.removeEventListener("wheel", handleWheel);
+  }, [pan.x, pan.y, viewBoxW, viewBoxH, zoom]);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      // Don't start a pan on interactive elements — let click handlers run.
+      const target = e.target as Element | null;
+      if (target && target.closest("[data-tag]")) return;
+      if (e.button !== 0) return; // left-button only
+      dragRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        panX: pan.x,
+        panY: pan.y,
+        moved: 0,
+      };
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        // Some browsers throw if the element is detaching — safe to ignore.
+      }
+    },
+    [pan.x, pan.y],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      const drag = dragRef.current;
+      const wrap = wrapRef.current;
+      if (!drag || !wrap) return;
+      const r = wrap.getBoundingClientRect();
+      const dxScreen = e.clientX - drag.startX;
+      const dyScreen = e.clientY - drag.startY;
+      drag.moved = Math.max(drag.moved, Math.hypot(dxScreen, dyScreen));
+      setPan({
+        x: drag.panX - dxScreen * (viewBoxW / r.width),
+        y: drag.panY - dyScreen * (viewBoxH / r.height),
+      });
+    },
+    [viewBoxW, viewBoxH],
+  );
+
+  // Last gesture's total movement (screen px). Read by EndpointCard's onClick
+  // wrapper so a click that happened at the end of a pan is suppressed —
+  // otherwise releasing a drag over a card would silently switch selection.
+  const lastMovedRef = useRef(0);
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      const drag = dragRef.current;
+      lastMovedRef.current = drag?.moved ?? 0;
+      dragRef.current = null;
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // Pointer-capture release is best-effort.
+      }
+    },
+    [],
+  );
+
+  // Returns true if the immediately preceding pointer gesture counts as a drag,
+  // i.e. moved beyond the click threshold. Cards use this to swallow clicks
+  // synthesised at the end of a pan.
+  const wasDragging = () => lastMovedRef.current > DRAG_CLICK_THRESHOLD;
+
+  const zoomBy = (factor: number) => {
+    const wrap = wrapRef.current;
+    if (!wrap) return;
+    // Zoom around the geometric center of the visible viewBox so the
+    // graph stays balanced.
+    const r = wrap.getBoundingClientRect();
+    const cx = r.width / 2;
+    const cy = r.height / 2;
+    const vx = pan.x + (cx / r.width) * viewBoxW;
+    const vy = pan.y + (cy / r.height) * viewBoxH;
+    const nextZoom = clamp(zoom * factor, MIN_ZOOM, MAX_ZOOM);
+    if (nextZoom === zoom) return;
+    const newW = VIEWBOX_W / nextZoom;
+    const newH = VIEWBOX_H / nextZoom;
+    setZoom(nextZoom);
+    setPan({
+      x: vx - (cx / r.width) * newW,
+      y: vy - (cy / r.height) * newH,
+    });
+  };
+
+  const resetView = () => {
+    setZoom(1);
+    setPan({ x: 0, y: 0 });
+  };
 
   return (
     <div
@@ -165,9 +323,20 @@ export const TopologyGraph: React.FC<TopologyGraphProps> = ({
         )}
       />
       <svg
-        viewBox={`0 0 ${VIEWBOX_W} ${VIEWBOX_H}`}
+        ref={svgRef}
+        viewBox={viewBoxStr}
         preserveAspectRatio="xMidYMid meet"
-        className="block w-full h-auto"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        // touch-none kills the browser's pinch/scroll defaults so our gestures win.
+        // The cursor swap signals "draggable" when the operator is over background.
+        style={{ touchAction: "none" }}
+        className={cn(
+          "block w-full h-auto select-none",
+          dragRef.current ? "cursor-grabbing" : "cursor-grab",
+        )}
       >
         <defs>
           <ArrowMarker id="nb-arrow-green" color="var(--nb-success, #2E8F5E)" />
@@ -202,9 +371,10 @@ export const TopologyGraph: React.FC<TopologyGraphProps> = ({
               x={pos.x}
               y={pos.y}
               selected={selectedNodeId === node.id}
-              onClick={() =>
-                onSelectNode(selectedNodeId === node.id ? undefined : node.id)
-              }
+              onClick={() => {
+                if (wasDragging()) return;
+                onSelectNode(selectedNodeId === node.id ? undefined : node.id);
+              }}
             />
           );
         })}
@@ -236,9 +406,79 @@ export const TopologyGraph: React.FC<TopologyGraphProps> = ({
           </text>
         </g>
       </svg>
+
+      {/* Zoom controls overlay — bottom-right. Trackpad users (or anyone
+          without a wheel) need a non-gesture way to navigate. The percentage
+          chip mirrors the design system's caps-mono micro-label style. */}
+      <div
+        className={cn(
+          "absolute bottom-3 right-3 z-10",
+          "flex flex-col items-stretch gap-1",
+          "bg-card border border-border rounded-nb-md shadow-nb-sm",
+          "p-1",
+        )}
+        // Keep clicks here from starting a pan.
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <ZoomButton
+          label="+"
+          onClick={() => zoomBy(BUTTON_ZOOM_FACTOR)}
+          disabled={zoom >= MAX_ZOOM}
+          title="Zoom in"
+        />
+        <div className="text-center font-mono text-[10px] text-muted-foreground tabular-nums py-0.5">
+          {Math.round(zoom * 100)}%
+        </div>
+        <ZoomButton
+          label="−"
+          onClick={() => zoomBy(1 / BUTTON_ZOOM_FACTOR)}
+          disabled={zoom <= MIN_ZOOM}
+          title="Zoom out"
+        />
+        <ZoomButton
+          label="⤧"
+          onClick={resetView}
+          disabled={zoom === 1 && pan.x === 0 && pan.y === 0}
+          title="Reset view"
+        />
+      </div>
     </div>
   );
 };
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+interface ZoomButtonProps {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  title: string;
+}
+
+const ZoomButton: React.FC<ZoomButtonProps> = ({
+  label,
+  onClick,
+  disabled,
+  title,
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    title={title}
+    aria-label={title}
+    className={cn(
+      "w-7 h-7 inline-flex items-center justify-center rounded-md",
+      "text-[14px] font-semibold leading-none select-none",
+      "text-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed",
+      "transition-colors",
+    )}
+  >
+    {label}
+  </button>
+);
 
 const ArrowMarker: React.FC<{ id: string; color: string }> = ({ id, color }) => (
   <marker

--- a/src/NimBus.WebApp/ClientApp/src/components/topology/topology-graph.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/topology/topology-graph.tsx
@@ -1,0 +1,469 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "lib/utils";
+import type { EventPill, TopologyEdge, TopologyNode } from "./types";
+
+const VIEWBOX_W = 880;
+const VIEWBOX_H = 580;
+const CARD_W = 160;
+const CARD_H = 80;
+const HUB_W = 120;
+const HUB_H = 60;
+const HUB_CX = VIEWBOX_W / 2;
+const HUB_CY = VIEWBOX_H / 2;
+
+interface TopologyGraphProps {
+  nodes: TopologyNode[];
+  edges: TopologyEdge[];
+  pills: EventPill[];
+  selectedNodeId?: string;
+  onSelectNode: (id: string | undefined) => void;
+  className?: string;
+}
+
+/**
+ * SVG topology graph — bus hub at the centre, endpoint cards arranged on a
+ * circle around it, curved edges flowing outward (publish, green) or inward
+ * (subscribe, blue). Failing edges go red, idle ones dashed-muted. Hover
+ * any edge / pill / card to surface a tooltip; click a card to select it
+ * (selection state lives in the parent so the inspector can re-render).
+ */
+export const TopologyGraph: React.FC<TopologyGraphProps> = ({
+  nodes,
+  edges,
+  pills,
+  selectedNodeId,
+  onSelectNode,
+  className,
+}) => {
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const tagRef = useRef<HTMLSpanElement | null>(null);
+
+  // Radial layout — angle each endpoint around the hub. Radius shrinks
+  // slightly as N grows so cards stay inside the viewbox; clamped so the
+  // graph doesn't visually compress at small N.
+  const layout = useMemo(() => {
+    const n = Math.max(nodes.length, 1);
+    const radius = Math.min(220, Math.max(160, 60 + n * 18));
+    const positions: Record<string, { x: number; y: number; angle: number }> = {};
+    nodes.forEach((node, i) => {
+      // Start from -π/2 (top) and walk clockwise so the first node lands
+      // straight above the hub.
+      const angle = -Math.PI / 2 + (i / n) * Math.PI * 2;
+      positions[node.id] = {
+        x: HUB_CX + radius * Math.cos(angle) - CARD_W / 2,
+        y: HUB_CY + radius * Math.sin(angle) - CARD_H / 2,
+        angle,
+      };
+    });
+    return positions;
+  }, [nodes]);
+
+  // Curve from a card's edge to the hub's edge. We pick the side of the card
+  // closest to the hub and the side of the hub closest to the card so the
+  // line never visually crosses node bodies.
+  const drawCurve = (endpointId: string, kind: "publish" | "subscribe") => {
+    const pos = layout[endpointId];
+    if (!pos) return "";
+    // Card center
+    const cx = pos.x + CARD_W / 2;
+    const cy = pos.y + CARD_H / 2;
+    // Pick exit point on the card facing the hub
+    const dx = HUB_CX - cx;
+    const dy = HUB_CY - cy;
+    const len = Math.hypot(dx, dy) || 1;
+    const ux = dx / len;
+    const uy = dy / len;
+    const startX = cx + ux * (CARD_W / 2 - 6);
+    const startY = cy + uy * (CARD_H / 2 - 6);
+    const endX = HUB_CX - ux * (HUB_W / 2 - 6);
+    const endY = HUB_CY - uy * (HUB_H / 2 - 6);
+    // Control points bend the curve outward so two opposite edges between
+    // the same pair don't visually overlap. We offset perpendicular to the
+    // straight line by ~40px, flipped for publish vs subscribe.
+    const perpX = -uy;
+    const perpY = ux;
+    const sign = kind === "publish" ? 1 : -1;
+    const c1x = startX + ux * 50 + perpX * 36 * sign;
+    const c1y = startY + uy * 50 + perpY * 36 * sign;
+    const c2x = endX - ux * 50 + perpX * 36 * sign;
+    const c2y = endY - uy * 50 + perpY * 36 * sign;
+    return `M ${startX} ${startY} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${endX} ${endY}`;
+  };
+
+  // Compute pill anchor positions — sit them on the midpoint of the parent
+  // edge. We approximate the midpoint of a cubic curve by sampling t=0.5.
+  const pillPositions = useMemo(() => {
+    return pills.map((pill) => {
+      const pos = layout[pill.anchorEndpointId];
+      if (!pos) return { pill, x: HUB_CX, y: HUB_CY };
+      const cx = pos.x + CARD_W / 2;
+      const cy = pos.y + CARD_H / 2;
+      const dx = HUB_CX - cx;
+      const dy = HUB_CY - cy;
+      const sign = pill.kind === "publish" ? 1 : -1;
+      // Approximate midpoint with a small perpendicular bias matching the
+      // curve's control offset, so labels track the curve's apex.
+      const midX = cx + dx * 0.5;
+      const midY = cy + dy * 0.5;
+      const len = Math.hypot(dx, dy) || 1;
+      const perpX = (-dy / len) * 22 * sign;
+      const perpY = (dx / len) * 22 * sign;
+      return { pill, x: midX + perpX, y: midY + perpY };
+    });
+  }, [pills, layout]);
+
+  // Tooltip plumbing — one floating <span> outside the SVG. Any node/pill/edge
+  // emits `data-tag` and we render that text on mousemove.
+  useEffect(() => {
+    const wrap = wrapRef.current;
+    const tag = tagRef.current;
+    if (!wrap || !tag) return;
+
+    const handleMove = (e: MouseEvent) => {
+      const target = (e.target as HTMLElement | null)?.closest?.("[data-tag]");
+      if (!target) {
+        tag.classList.remove("show");
+        return;
+      }
+      const text = target.getAttribute("data-tag") ?? "";
+      tag.textContent = text;
+      const r = wrap.getBoundingClientRect();
+      tag.style.left = `${e.clientX - r.left}px`;
+      tag.style.top = `${e.clientY - r.top}px`;
+      tag.classList.add("show");
+    };
+    const handleLeave = () => tag.classList.remove("show");
+
+    wrap.addEventListener("mousemove", handleMove);
+    wrap.addEventListener("mouseleave", handleLeave);
+    return () => {
+      wrap.removeEventListener("mousemove", handleMove);
+      wrap.removeEventListener("mouseleave", handleLeave);
+    };
+  }, []);
+
+  return (
+    <div
+      ref={wrapRef}
+      className={cn(
+        "relative bg-card border border-border rounded-nb-lg overflow-hidden",
+        // Dotted-grid background matching the design's canvas-wrap rule
+        "bg-[radial-gradient(circle,#E5DFCE_1px,transparent_1px),radial-gradient(circle,#E5DFCE_1px,transparent_1px)]",
+        "bg-[length:24px_24px,24px_24px] bg-[position:0_0,12px_12px]",
+        "dark:bg-[radial-gradient(circle,#2A2620_1px,transparent_1px),radial-gradient(circle,#2A2620_1px,transparent_1px)]",
+        className,
+      )}
+    >
+      <span
+        ref={tagRef}
+        className={cn(
+          "absolute pointer-events-none opacity-0 transition-opacity",
+          "bg-ink text-canvas font-mono text-[11px] px-2 py-1 rounded-md",
+          "shadow-nb-md whitespace-nowrap z-10",
+          "-translate-x-1/2 -translate-y-[130%]",
+          "[&.show]:opacity-100",
+        )}
+      />
+      <svg
+        viewBox={`0 0 ${VIEWBOX_W} ${VIEWBOX_H}`}
+        preserveAspectRatio="xMidYMid meet"
+        className="block w-full h-auto"
+      >
+        <defs>
+          <ArrowMarker id="nb-arrow-green" color="var(--nb-success, #2E8F5E)" />
+          <ArrowMarker id="nb-arrow-blue" color="var(--nb-info, #3A6FB0)" />
+          <ArrowMarker id="nb-arrow-amber" color="var(--nb-warning, #C98A1B)" />
+          <ArrowMarker id="nb-arrow-red" color="var(--nb-danger, #C2412E)" />
+          <ArrowMarker id="nb-arrow-mute" color="var(--nb-ink-3, #8A8473)" />
+        </defs>
+
+        {/* Edges first so nodes paint over them */}
+        {edges.map((edge) => (
+          <EdgePath
+            key={edge.id}
+            d={drawCurve(edge.endpointId, edge.kind)}
+            edge={edge}
+          />
+        ))}
+
+        {/* Event-type pills floating on the busiest edges */}
+        {pillPositions.map(({ pill, x, y }) => (
+          <EventTypePill key={pill.id} pill={pill} x={x} y={y} />
+        ))}
+
+        {/* Endpoint cards */}
+        {nodes.map((node) => {
+          const pos = layout[node.id];
+          if (!pos) return null;
+          return (
+            <EndpointCard
+              key={node.id}
+              node={node}
+              x={pos.x}
+              y={pos.y}
+              selected={selectedNodeId === node.id}
+              onClick={() =>
+                onSelectNode(selectedNodeId === node.id ? undefined : node.id)
+              }
+            />
+          );
+        })}
+
+        {/* Bus hub */}
+        <g transform={`translate(${HUB_CX - HUB_W / 2}, ${HUB_CY - HUB_H / 2})`}>
+          <rect width={HUB_W} height={HUB_H} rx={HUB_H / 2} fill="#1A1814" />
+          <text
+            x={HUB_W / 2}
+            y={HUB_H / 2 - 4}
+            textAnchor="middle"
+            fill="#F4F2EA"
+            fontFamily="Manrope, sans-serif"
+            fontWeight={800}
+            fontSize={13}
+          >
+            NimBus
+          </text>
+          <text
+            x={HUB_W / 2}
+            y={HUB_H / 2 + 14}
+            textAnchor="middle"
+            fill="#8A8473"
+            fontFamily="JetBrains Mono, monospace"
+            fontSize={10}
+            letterSpacing="0.1em"
+          >
+            EVENT BUS
+          </text>
+        </g>
+      </svg>
+    </div>
+  );
+};
+
+const ArrowMarker: React.FC<{ id: string; color: string }> = ({ id, color }) => (
+  <marker
+    id={id}
+    viewBox="0 0 10 10"
+    refX={9}
+    refY={5}
+    markerWidth={6}
+    markerHeight={6}
+    orient="auto-start-reverse"
+  >
+    <path d="M 0 0 L 10 5 L 0 10 z" fill={color} />
+  </marker>
+);
+
+interface EdgePathProps {
+  d: string;
+  edge: TopologyEdge;
+}
+
+const EdgePath: React.FC<EdgePathProps> = ({ d, edge }) => {
+  const colorClass = {
+    healthy: "stroke-[var(--nb-success,#2E8F5E)]",
+    warn: "stroke-[var(--nb-warning,#C98A1B)]",
+    fail: "stroke-[var(--nb-danger,#C2412E)]",
+    idle: "stroke-[var(--nb-ink-3,#8A8473)]",
+  }[edge.health];
+  const markerEnd = {
+    healthy: "url(#nb-arrow-green)",
+    warn: "url(#nb-arrow-amber)",
+    fail: "url(#nb-arrow-red)",
+    idle: edge.kind === "subscribe"
+      ? "url(#nb-arrow-mute)"
+      : "url(#nb-arrow-mute)",
+  }[edge.health];
+  // Subscribe edges paint blue when healthy (matches design legend: blue = subscribes).
+  const isSubscribeHealthy = edge.kind === "subscribe" && edge.health === "healthy";
+  const finalColorClass = isSubscribeHealthy
+    ? "stroke-[var(--nb-info,#3A6FB0)]"
+    : colorClass;
+  const finalMarker = isSubscribeHealthy ? "url(#nb-arrow-blue)" : markerEnd;
+  const tooltip = formatEdgeTooltip(edge);
+
+  return (
+    <path
+      d={d}
+      data-tag={tooltip}
+      strokeWidth={1.6}
+      fill="none"
+      className={cn(
+        "transition-opacity",
+        finalColorClass,
+        edge.health === "idle"
+          ? "opacity-40 [stroke-dasharray:2_4]"
+          : "opacity-75 hover:opacity-100",
+        edge.health !== "idle" && "nb-flow-anim",
+        edge.health === "warn" && "[stroke-dasharray:4_3]",
+      )}
+      markerEnd={finalMarker}
+    />
+  );
+};
+
+function formatEdgeTooltip(edge: TopologyEdge): string {
+  const verb = edge.kind === "publish" ? "publishes" : "subscribes";
+  const count = edge.eventTypeIds.length;
+  const types = count === 1 ? "1 event type" : `${count} event types`;
+  const msgs =
+    edge.messages > 0
+      ? ` · ${edge.messages.toLocaleString()} msgs`
+      : "";
+  return `${edge.endpointId} ${verb} ${types}${msgs}`;
+}
+
+interface EndpointCardProps {
+  node: TopologyNode;
+  x: number;
+  y: number;
+  selected: boolean;
+  onClick: () => void;
+}
+
+const EndpointCard: React.FC<EndpointCardProps> = ({
+  node,
+  x,
+  y,
+  selected,
+  onClick,
+}) => {
+  const headFill = {
+    good: "var(--nb-success-50, #DCEFE4)",
+    warn: "var(--nb-warning-50, #F6E7C7)",
+    bad: "var(--nb-danger-50, #F4D9D3)",
+    idle: "var(--nb-surface-2, #ECE7DA)",
+  }[node.health];
+  const pulseFill = {
+    good: "var(--nb-success, #2E8F5E)",
+    warn: "var(--nb-warning, #C98A1B)",
+    bad: "var(--nb-danger, #C2412E)",
+    idle: "var(--nb-ink-3, #8A8473)",
+  }[node.health];
+  const statColor = {
+    good: "var(--nb-success, #2E8F5E)",
+    warn: "var(--nb-warning, #C98A1B)",
+    bad: "var(--nb-danger, #C2412E)",
+    idle: "var(--nb-ink-3, #8A8473)",
+  }[node.health];
+  const tooltip = `${node.name} · P:${node.publishCount} S:${node.subscribeCount} · ${node.failedMessages} failed`;
+
+  const stats = formatNodeStats(node);
+
+  return (
+    <g
+      transform={`translate(${x}, ${y})`}
+      onClick={onClick}
+      data-tag={tooltip}
+      className="cursor-pointer transition-transform hover:-translate-y-px"
+    >
+      <rect
+        x={0}
+        y={0}
+        width={CARD_W}
+        height={CARD_H}
+        rx={10}
+        fill="var(--nb-bg, #F4F2EA)"
+        stroke={selected ? "var(--nb-primary, #E8743C)" : "var(--nb-border-strong, #C9C1AB)"}
+        strokeWidth={selected ? 2 : 1.5}
+      />
+      <rect x={0} y={0} width={CARD_W} height={22} rx={10} fill={headFill} />
+      <rect x={0} y={12} width={CARD_W} height={10} fill={headFill} />
+      <circle cx={12} cy={11} r={3} fill={pulseFill} />
+      <text
+        x={22}
+        y={14}
+        fontFamily="JetBrains Mono, monospace"
+        fontSize={9.5}
+        fill="var(--nb-ink-3, #8A8473)"
+        letterSpacing="0.06em"
+      >
+        Endpoint
+      </text>
+      <text
+        x={12}
+        y={42}
+        fontFamily="Manrope, sans-serif"
+        fontWeight={700}
+        fontSize={13}
+        fill="var(--nb-ink, #1A1814)"
+      >
+        {truncate(node.name, 18)}
+      </text>
+      <text
+        x={12}
+        y={62}
+        fontFamily="JetBrains Mono, monospace"
+        fontSize={10.5}
+        fill="var(--nb-ink-2, #4A463D)"
+      >
+        P: {node.publishCount}  ·  S: {node.subscribeCount}
+      </text>
+      <text
+        x={12}
+        y={74}
+        fontFamily="JetBrains Mono, monospace"
+        fontSize={10.5}
+        fill={statColor}
+      >
+        {stats}
+      </text>
+    </g>
+  );
+};
+
+function formatNodeStats(node: TopologyNode): string {
+  if (
+    node.health === "idle" ||
+    (node.handledMessages === 0 && node.failedMessages === 0)
+  ) {
+    return "no traffic";
+  }
+  const ok = (node.handledMessages - node.failedMessages).toLocaleString();
+  const failed = node.failedMessages.toLocaleString();
+  return `${ok} ok · ${failed} failed`;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s;
+}
+
+interface PillProps {
+  pill: EventPill;
+  x: number;
+  y: number;
+}
+
+const EventTypePill: React.FC<PillProps> = ({ pill, x, y }) => {
+  // Heuristic width — character count * average char width + padding
+  const w = Math.max(80, pill.label.length * 7.5 + 20);
+  const h = 22;
+  return (
+    <g
+      transform={`translate(${x - w / 2}, ${y - h / 2})`}
+      data-tag={pill.tooltip}
+      className="cursor-pointer"
+    >
+      <rect
+        x={0}
+        y={0}
+        width={w}
+        height={h}
+        rx={h / 2}
+        fill="var(--nb-purple-50, #ECE2F4)"
+        stroke="#D6BFE9"
+      />
+      <text
+        x={w / 2}
+        y={h / 2 + 4}
+        textAnchor="middle"
+        fontFamily="JetBrains Mono, monospace"
+        fontSize={10.5}
+        fontWeight={600}
+        fill="var(--nb-purple, #6B3FA3)"
+      >
+        {truncate(pill.label, 24)}
+      </text>
+    </g>
+  );
+};

--- a/src/NimBus.WebApp/ClientApp/src/components/topology/topology-graph.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/topology/topology-graph.tsx
@@ -481,16 +481,21 @@ const ZoomButton: React.FC<ZoomButtonProps> = ({
 );
 
 const ArrowMarker: React.FC<{ id: string; color: string }> = ({ id, color }) => (
+  // `userSpaceOnUse` decouples marker size from stroke-width, so even thin
+  // 1.5px lines get a confidently sized arrowhead. The triangle has a slight
+  // back-notch so the direction reads as a chevron rather than a dot at the
+  // end of a line — much more legible at small viewport sizes.
   <marker
     id={id}
-    viewBox="0 0 10 10"
-    refX={9}
-    refY={5}
-    markerWidth={6}
-    markerHeight={6}
+    viewBox="0 0 12 12"
+    refX={11}
+    refY={6}
+    markerUnits="userSpaceOnUse"
+    markerWidth={12}
+    markerHeight={12}
     orient="auto-start-reverse"
   >
-    <path d="M 0 0 L 10 5 L 0 10 z" fill={color} />
+    <path d="M 0 0 L 12 6 L 0 12 L 3 6 Z" fill={color} />
   </marker>
 );
 
@@ -526,14 +531,17 @@ const EdgePath: React.FC<EdgePathProps> = ({ d, edge }) => {
     <path
       d={d}
       data-tag={tooltip}
-      strokeWidth={1.6}
+      strokeWidth={1.8}
       fill="none"
       className={cn(
-        "transition-opacity",
+        // `stroke-opacity` (not the catch-all `opacity`) so the marker's
+        // fill stays fully saturated and the arrowhead remains readable
+        // even when the line itself is dimmed for idle edges.
+        "transition-[stroke-opacity]",
         finalColorClass,
         edge.health === "idle"
-          ? "opacity-40 [stroke-dasharray:2_4]"
-          : "opacity-75 hover:opacity-100",
+          ? "[stroke-opacity:0.55] [stroke-dasharray:3_5]"
+          : "[stroke-opacity:0.85] hover:[stroke-opacity:1]",
         edge.health !== "idle" && "nb-flow-anim",
         edge.health === "warn" && "[stroke-dasharray:4_3]",
       )}

--- a/src/NimBus.WebApp/ClientApp/src/components/topology/topology-graph.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/topology/topology-graph.tsx
@@ -351,12 +351,17 @@ const EndpointCard: React.FC<EndpointCardProps> = ({
   const stats = formatNodeStats(node);
 
   return (
-    <g
-      transform={`translate(${x}, ${y})`}
-      onClick={onClick}
-      data-tag={tooltip}
-      className="cursor-pointer transition-transform hover:-translate-y-px"
-    >
+    // Position transform lives on the outer <g> as an SVG attribute so it
+    // can never be clobbered by a CSS `transform` rule on hover. Interactive
+    // styling (cursor, lift) lives on the inner <g> via CSS; the two layers
+    // compose instead of fighting (the bug that snapped cards to (0,0) on
+    // hover before this split).
+    <g transform={`translate(${x}, ${y})`}>
+      <g
+        onClick={onClick}
+        data-tag={tooltip}
+        className="cursor-pointer"
+      >
       <rect
         x={0}
         y={0}
@@ -408,6 +413,7 @@ const EndpointCard: React.FC<EndpointCardProps> = ({
       >
         {stats}
       </text>
+      </g>
     </g>
   );
 };

--- a/src/NimBus.WebApp/ClientApp/src/components/topology/topology-graph.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/topology/topology-graph.tsx
@@ -90,32 +90,49 @@ export const TopologyGraph: React.FC<TopologyGraphProps> = ({
   // Curve from a card's edge to the hub's edge. We pick the side of the card
   // closest to the hub and the side of the hub closest to the card so the
   // line never visually crosses node bodies.
+  //
+  // Path *direction* depends on `kind` — publishes flow endpoint → hub,
+  // subscribes flow hub → endpoint — so the arrowhead (always painted at
+  // `markerEnd`, the path's last point) lands at the destination of the
+  // message flow rather than always at the hub.
   const drawCurve = (endpointId: string, kind: "publish" | "subscribe") => {
     const pos = layout[endpointId];
     if (!pos) return "";
     // Card center
     const cx = pos.x + CARD_W / 2;
     const cy = pos.y + CARD_H / 2;
-    // Pick exit point on the card facing the hub
+    // Unit vector card → hub; used to pick exit/entry points on each shape.
     const dx = HUB_CX - cx;
     const dy = HUB_CY - cy;
     const len = Math.hypot(dx, dy) || 1;
     const ux = dx / len;
     const uy = dy / len;
-    const startX = cx + ux * (CARD_W / 2 - 6);
-    const startY = cy + uy * (CARD_H / 2 - 6);
-    const endX = HUB_CX - ux * (HUB_W / 2 - 6);
-    const endY = HUB_CY - uy * (HUB_H / 2 - 6);
-    // Control points bend the curve outward so two opposite edges between
-    // the same pair don't visually overlap. We offset perpendicular to the
-    // straight line by ~40px, flipped for publish vs subscribe.
-    const perpX = -uy;
-    const perpY = ux;
-    const sign = kind === "publish" ? 1 : -1;
-    const c1x = startX + ux * 50 + perpX * 36 * sign;
-    const c1y = startY + uy * 50 + perpY * 36 * sign;
-    const c2x = endX - ux * 50 + perpX * 36 * sign;
-    const c2y = endY - uy * 50 + perpY * 36 * sign;
+    const cardAnchorX = cx + ux * (CARD_W / 2 - 6);
+    const cardAnchorY = cy + uy * (CARD_H / 2 - 6);
+    const hubAnchorX = HUB_CX - ux * (HUB_W / 2 - 6);
+    const hubAnchorY = HUB_CY - uy * (HUB_H / 2 - 6);
+
+    // Pick path direction so the arrowhead lands at the flow destination.
+    const isPublish = kind === "publish";
+    const startX = isPublish ? cardAnchorX : hubAnchorX;
+    const startY = isPublish ? cardAnchorY : hubAnchorY;
+    const endX = isPublish ? hubAnchorX : cardAnchorX;
+    const endY = isPublish ? hubAnchorY : cardAnchorY;
+
+    // Re-derive direction unit vector and perpendicular against the chosen
+    // start → end. Always biasing the curve to +perp of the travel direction
+    // means publish and subscribe edges between the same pair bow to
+    // opposite sides automatically (because their travel directions are
+    // opposite), so we keep the no-overlap arrangement without an explicit
+    // sign flip.
+    const tx = (endX - startX) / len;
+    const ty = (endY - startY) / len;
+    const perpX = -ty;
+    const perpY = tx;
+    const c1x = startX + tx * 50 + perpX * 36;
+    const c1y = startY + ty * 50 + perpY * 36;
+    const c2x = endX - tx * 50 + perpX * 36;
+    const c2y = endY - ty * 50 + perpY * 36;
     return `M ${startX} ${startY} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${endX} ${endY}`;
   };
 

--- a/src/NimBus.WebApp/ClientApp/src/components/topology/topology-inspector.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/topology/topology-inspector.tsx
@@ -1,0 +1,277 @@
+import { Link } from "react-router-dom";
+import { Badge } from "components/ui/badge";
+import { cn } from "lib/utils";
+import type { TopologyData, TopologyNode } from "./types";
+
+interface TopologyInspectorProps {
+  data: TopologyData;
+  selectedNodeId?: string;
+  lastUpdated?: Date;
+  /** Display name of the selected period — e.g. "1h" — for KPI label suffixes. */
+  periodLabel: string;
+  className?: string;
+}
+
+/**
+ * Sticky right rail surfacing details on the selected endpoint:
+ * - mini KPI grid (handled, failed, latency placeholder, backlog placeholder)
+ * - lists of published / subscribed event types (deep-linkable)
+ * - downstream endpoints with failure callouts
+ * - "Open endpoint ›" footer linking into the full Endpoint Details page
+ *
+ * When no endpoint is selected, a short prompt nudges the operator to click
+ * one — keeps the rail useful instead of blank.
+ */
+export const TopologyInspector: React.FC<TopologyInspectorProps> = ({
+  data,
+  selectedNodeId,
+  lastUpdated,
+  periodLabel,
+  className,
+}) => {
+  const node = selectedNodeId
+    ? data.nodes.find((n) => n.id === selectedNodeId)
+    : undefined;
+
+  if (!node) {
+    return (
+      <aside
+        className={cn(
+          "bg-card border border-border rounded-nb-lg p-5",
+          "self-start sticky top-20",
+          className,
+        )}
+      >
+        <p className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground m-0 mb-2">
+          Inspector
+        </p>
+        <p className="text-sm text-muted-foreground italic m-0">
+          Click any endpoint to focus its sub-graph.
+        </p>
+      </aside>
+    );
+  }
+
+  // Distinct event types this endpoint publishes / subscribes — derived from
+  // the edges that include the selected node.
+  const publishEdge = data.edges.find(
+    (e) => e.kind === "publish" && e.endpointId === node.id,
+  );
+  const subscribeEdge = data.edges.find(
+    (e) => e.kind === "subscribe" && e.endpointId === node.id,
+  );
+
+  // Downstream — endpoints whose subscribe edges reference any event type this
+  // node publishes. (Approximation: we don't track per-pair on the client.)
+  const publishedTypeIds = new Set(publishEdge?.eventTypeIds ?? []);
+  const downstream = data.nodes.filter((other) => {
+    if (other.id === node.id) return false;
+    const sub = data.edges.find(
+      (e) => e.kind === "subscribe" && e.endpointId === other.id,
+    );
+    if (!sub) return false;
+    return sub.eventTypeIds.some((t) => publishedTypeIds.has(t));
+  });
+
+  return (
+    <aside
+      className={cn(
+        "bg-card border border-border rounded-nb-lg p-5",
+        "flex flex-col gap-4 self-start sticky top-20",
+        "max-h-[calc(100vh-100px)] overflow-auto",
+        className,
+      )}
+    >
+      <div>
+        <p className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground m-0 mb-1">
+          Selected endpoint
+        </p>
+        <h3 className="m-0 text-base font-bold tracking-tight">{node.name}</h3>
+        <p className="text-[12.5px] text-muted-foreground m-0 mt-1">
+          Owned by <b className="text-foreground">{node.role}</b>
+        </p>
+      </div>
+
+      {/* 2×2 KPI grid. Latency & backlog stay placeholders until the API exposes
+          them — better to show a dash than a fake number. */}
+      <div className="grid grid-cols-2 gap-1.5">
+        <MiniKpi
+          label={`Handled · ${periodLabel}`}
+          value={node.handledMessages.toLocaleString()}
+          tone="ok"
+        />
+        <MiniKpi
+          label={`Failed · ${periodLabel}`}
+          value={node.failedMessages.toLocaleString()}
+          tone={node.failedMessages > 0 ? "bad" : "muted"}
+        />
+        <MiniKpi label="Avg latency" value="—" suffix=" ms" tone="muted" />
+        <MiniKpi label="Backlog" value="—" tone="muted" />
+      </div>
+
+      <EventList
+        title="Publishes"
+        accent="success"
+        count={publishEdge?.eventTypeIds.length ?? 0}
+        eventTypeIds={publishEdge?.eventTypeIds ?? []}
+      />
+
+      <EventList
+        title="Subscribes"
+        accent="info"
+        count={subscribeEdge?.eventTypeIds.length ?? 0}
+        eventTypeIds={subscribeEdge?.eventTypeIds ?? []}
+      />
+
+      {downstream.length > 0 && (
+        <div>
+          <SectionTitle>Downstream</SectionTitle>
+          <div className="flex flex-col gap-1">
+            {downstream.map((d) => (
+              <DownstreamRow key={d.id} node={d} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="flex justify-between items-center pt-2 border-t border-border font-mono text-[11px] text-muted-foreground">
+        <span>{formatUpdatedAgo(lastUpdated)}</span>
+        <Link
+          to={`/Endpoints/Details/${node.id}`}
+          className="text-primary-600 hover:text-primary font-semibold no-underline"
+        >
+          Open endpoint ›
+        </Link>
+      </div>
+    </aside>
+  );
+};
+
+const SectionTitle: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <p className="font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground m-0 mb-2">
+    {children}
+  </p>
+);
+
+interface MiniKpiProps {
+  label: string;
+  value: string;
+  suffix?: string;
+  tone: "ok" | "warn" | "bad" | "muted";
+}
+
+const MiniKpi: React.FC<MiniKpiProps> = ({ label, value, suffix, tone }) => {
+  const toneClass = {
+    ok: "text-status-success",
+    warn: "text-status-warning",
+    bad: "text-status-danger",
+    muted: "text-foreground",
+  }[tone];
+  return (
+    <div className="bg-background border border-border rounded-md px-2.5 py-2">
+      <div className="font-mono text-[9.5px] uppercase tracking-[0.12em] text-muted-foreground mb-1">
+        {label}
+      </div>
+      <div className={cn("text-base font-bold leading-tight tabular-nums", toneClass)}>
+        {value}
+        {suffix && (
+          <small className="text-[11px] font-medium text-muted-foreground ml-0.5">
+            {suffix}
+          </small>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface EventListProps {
+  title: string;
+  accent: "success" | "info";
+  count: number;
+  eventTypeIds: string[];
+}
+
+const EventList: React.FC<EventListProps> = ({
+  title,
+  accent,
+  count,
+  eventTypeIds,
+}) => {
+  const accentColor = accent === "success" ? "text-status-success" : "text-status-info";
+  const dotColor = accent === "success" ? "bg-status-success" : "bg-status-info";
+  return (
+    <div>
+      <SectionTitle>
+        {title}{" "}
+        <span className={cn("font-mono font-semibold ml-1", accentColor)}>
+          {count}
+        </span>
+      </SectionTitle>
+      {eventTypeIds.length === 0 ? (
+        <p className="text-[12px] text-muted-foreground italic m-0">none</p>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {eventTypeIds.map((id) => (
+            <Link
+              key={id}
+              to={`/EventTypes/Details/${id}`}
+              className={cn(
+                "flex items-center gap-2 px-2 py-1.5 rounded-md no-underline",
+                "bg-background border border-border text-foreground text-[12.5px]",
+                "hover:border-border-strong",
+              )}
+            >
+              <span
+                aria-hidden="true"
+                className={cn("w-1.5 h-1.5 rounded-full shrink-0", dotColor)}
+              />
+              <span className="font-semibold flex-1 truncate">{id}</span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface DownstreamRowProps {
+  node: TopologyNode;
+}
+
+const DownstreamRow: React.FC<DownstreamRowProps> = ({ node }) => {
+  const isFailing = node.failedMessages > 0;
+  return (
+    <Link
+      to={`/Endpoints/Details/${node.id}`}
+      className={cn(
+        "flex items-center gap-2 px-2 py-1.5 rounded-md no-underline text-[12.5px]",
+        isFailing
+          ? "bg-status-danger-50 border border-status-danger-50 text-status-danger-ink"
+          : "bg-background border border-border text-foreground hover:border-border-strong",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "w-1.5 h-1.5 rounded-full shrink-0",
+          isFailing ? "bg-status-danger" : "bg-status-success",
+        )}
+      />
+      <span className="font-semibold flex-1 truncate">{node.name}</span>
+      {isFailing && (
+        <Badge variant="failed" size="sm">
+          {node.failedMessages} fail
+        </Badge>
+      )}
+    </Link>
+  );
+};
+
+function formatUpdatedAgo(d: Date | undefined): string {
+  if (!d) return "—";
+  const seconds = Math.max(0, Math.floor((Date.now() - d.getTime()) / 1000));
+  if (seconds < 60) return `Updated ${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `Updated ${minutes}m ago`;
+  return `Updated ${Math.floor(minutes / 60)}h ago`;
+}

--- a/src/NimBus.WebApp/ClientApp/src/components/topology/types.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/topology/types.ts
@@ -1,0 +1,76 @@
+// Domain model for the Topology page — derived client-side from
+// /eventtypes + per-event-type /eventtypes/{id} producer/consumer arrays +
+// /metrics/overview rollups. Kept in its own module so the data hook,
+// graph, and inspector all share the same shape.
+
+export type NodeHealth = "good" | "warn" | "bad" | "idle";
+
+export interface TopologyNode {
+  /** Stable endpoint id (matches `EndpointId` everywhere in the app). */
+  id: string;
+  /** Display name; falls back to id when the platform-config name is empty. */
+  name: string;
+  /** "Endpoint" today; reserved for "Sink"/"Source" if we ever expose them. */
+  role: string;
+  /** Distinct event types this endpoint publishes. */
+  publishCount: number;
+  /** Distinct event types this endpoint subscribes to. */
+  subscribeCount: number;
+  /** Sum of `published` rows for this endpoint over the selected window. */
+  publishedMessages: number;
+  /** Sum of `handled` rows for this endpoint over the selected window. */
+  handledMessages: number;
+  /** Sum of `failed` rows for this endpoint over the selected window. */
+  failedMessages: number;
+  /** Derived: bad > warn > idle > good. */
+  health: NodeHealth;
+}
+
+export type EdgeKind = "publish" | "subscribe";
+
+export interface TopologyEdge {
+  /** Stable composite key — kind + endpoint id; used for React reconciliation. */
+  id: string;
+  /** Which direction this edge represents relative to the bus. */
+  kind: EdgeKind;
+  /**
+   * For `publish` edges this is the producer endpoint; for `subscribe` edges
+   * this is the consumer endpoint. The other end is always the bus hub.
+   */
+  endpointId: string;
+  /** Event types collapsed into this edge (one endpoint may publish/subscribe many). */
+  eventTypeIds: string[];
+  /** Sum of message counts across the collapsed event types. */
+  messages: number;
+  /** Derived edge health — `idle` when no traffic, `fail` when any failures, else `healthy`. */
+  health: "healthy" | "warn" | "fail" | "idle";
+}
+
+export interface EventPill {
+  /** Event-type id (becomes both the label and the deep-link target). */
+  id: string;
+  /** Display label — usually the unqualified name; falls back to id. */
+  label: string;
+  /** The endpoint this pill should anchor against in the graph layout. */
+  anchorEndpointId: string;
+  /** Edge kind we should attach to (publish vs subscribe). */
+  kind: EdgeKind;
+  /** Tooltip body, e.g. "ErpEndpoint → CrmEndpoint, AnalyticsEndpoint · 7,412 / 1h". */
+  tooltip: string;
+}
+
+export interface TopologyData {
+  nodes: TopologyNode[];
+  edges: TopologyEdge[];
+  pills: EventPill[];
+  /** Aggregate counts for the summary strip; cheap to compute alongside the rest. */
+  summary: {
+    endpoints: number;
+    eventTypes: number;
+    edges: number;
+    edgesWithFailures: number;
+    namespaces: number;
+    producingEndpoints: number;
+    consumingEndpoints: number;
+  };
+}

--- a/src/NimBus.WebApp/ClientApp/src/components/topology/use-topology-data.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/topology/use-topology-data.ts
@@ -1,0 +1,367 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import * as api from "api-client";
+import type {
+  EdgeKind,
+  EventPill,
+  NodeHealth,
+  TopologyData,
+  TopologyEdge,
+  TopologyNode,
+} from "./types";
+
+const MAX_EVENT_PILLS = 6;
+
+interface UseTopologyDataOptions {
+  /** Selected time window for the metrics overlay. */
+  period: api.Period;
+  /** Optional namespace filter — when set, only event types matching are included. */
+  namespace?: string;
+}
+
+interface UseTopologyDataResult {
+  data: TopologyData | undefined;
+  loading: boolean;
+  /** Re-runs every fetch (event types + per-id details + metrics). */
+  refresh: () => Promise<void>;
+  lastUpdated?: Date;
+  error?: string;
+}
+
+/**
+ * Collects Topology data from existing read-only endpoints and rolls it into
+ * `TopologyData`. Two-step fetch:
+ *
+ *   1. `getEventTypes()`           — one round-trip for the catalog.
+ *   2. `getEventtypesEventtypeid()` per event type, in parallel — produces the
+ *      producer/consumer arrays we need to render edges.
+ *
+ * Metrics (`getMetricsOverview`) hang off the time-range knob and re-fetch
+ * independently when only `period` changes. We memoise the per-event-type
+ * details by id so the same call isn't repeated as the user flips the
+ * time range.
+ *
+ * The hook intentionally fails soft: if an individual event-type detail call
+ * errors we drop that event type rather than blowing up the whole graph.
+ */
+export function useTopologyData({
+  period,
+  namespace,
+}: UseTopologyDataOptions): UseTopologyDataResult {
+  const [eventTypes, setEventTypes] = useState<api.EventType[]>([]);
+  const [detailsById, setDetailsById] = useState<
+    Record<string, api.EventTypeDetails>
+  >({});
+  const [metrics, setMetrics] = useState<api.MetricsOverview | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>();
+  const [lastUpdated, setLastUpdated] = useState<Date | undefined>();
+
+  // Lock subsequent renders from clobbering an in-flight refresh — the user
+  // can spam the Refresh button or rapidly flip time ranges.
+  const inFlight = useRef(0);
+
+  const fetchCatalogAndDetails = useCallback(async () => {
+    const client = new api.Client(api.CookieAuth());
+    const all = await client.getEventTypes();
+    const valid = all.filter((et) => !!et.id);
+    setEventTypes(valid);
+
+    const detailsEntries = await Promise.all(
+      valid.map(async (et) => {
+        try {
+          const d = await client.getEventtypesEventtypeid(et.id!);
+          return [et.id!, d] as const;
+        } catch {
+          return null;
+        }
+      }),
+    );
+    const next: Record<string, api.EventTypeDetails> = {};
+    for (const entry of detailsEntries) {
+      if (entry) {
+        next[entry[0]] = entry[1];
+      }
+    }
+    setDetailsById(next);
+  }, []);
+
+  const fetchMetrics = useCallback(async (p: api.Period) => {
+    const client = new api.Client(api.CookieAuth());
+    try {
+      const m = await client.getMetricsOverview(p);
+      setMetrics(m);
+    } catch {
+      // Metrics overlay is a nice-to-have — graph still renders without it.
+      setMetrics(undefined);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const ticket = ++inFlight.current;
+    setLoading(true);
+    setError(undefined);
+    try {
+      await Promise.all([fetchCatalogAndDetails(), fetchMetrics(period)]);
+      if (ticket === inFlight.current) {
+        setLastUpdated(new Date());
+      }
+    } catch (err) {
+      console.error("Failed to refresh topology", err);
+      if (ticket === inFlight.current) {
+        setError("Failed to load topology");
+      }
+    } finally {
+      if (ticket === inFlight.current) {
+        setLoading(false);
+      }
+    }
+  }, [fetchCatalogAndDetails, fetchMetrics, period]);
+
+  // Initial load + reload on period change. We refetch metrics on period
+  // change but reuse the cached event-type details since they don't depend
+  // on the time window.
+  useEffect(() => {
+    let cancelled = false;
+    if (eventTypes.length === 0) {
+      void refresh();
+    } else {
+      setLoading(true);
+      void fetchMetrics(period).finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+          setLastUpdated(new Date());
+        }
+      });
+    }
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [period]);
+
+  const data = useMemo<TopologyData | undefined>(() => {
+    if (eventTypes.length === 0) return undefined;
+    return buildTopology(eventTypes, detailsById, metrics, namespace);
+  }, [eventTypes, detailsById, metrics, namespace]);
+
+  return { data, loading, refresh, lastUpdated, error };
+}
+
+function buildTopology(
+  eventTypes: api.EventType[],
+  detailsById: Record<string, api.EventTypeDetails>,
+  metrics: api.MetricsOverview | undefined,
+  namespace: string | undefined,
+): TopologyData {
+  // 1. Filter by namespace if requested.
+  const filteredTypes = namespace
+    ? eventTypes.filter((et) => et.namespace === namespace)
+    : eventTypes;
+
+  // 2. Index metrics so we can answer "how many published / handled / failed
+  //    for endpoint X event type Y in this window?" in O(1).
+  const published = indexCounts(metrics?.published);
+  const handled = indexCounts(metrics?.handled);
+  const failed = indexCounts(metrics?.failed);
+
+  // 3. Walk every event type and accumulate node + edge state.
+  type NodeAccum = {
+    publishedTypeIds: Set<string>;
+    subscribedTypeIds: Set<string>;
+    publishedMessages: number;
+    handledMessages: number;
+    failedMessages: number;
+  };
+  const nodeAccum = new Map<string, NodeAccum>();
+  const ensureNode = (id: string) => {
+    let n = nodeAccum.get(id);
+    if (!n) {
+      n = {
+        publishedTypeIds: new Set(),
+        subscribedTypeIds: new Set(),
+        publishedMessages: 0,
+        handledMessages: 0,
+        failedMessages: 0,
+      };
+      nodeAccum.set(id, n);
+    }
+    return n;
+  };
+
+  // We collapse multi-event-type edges between the same (endpoint, kind) into
+  // a single rendered edge by keying on `kind + endpoint`.
+  type EdgeAccum = {
+    kind: EdgeKind;
+    endpointId: string;
+    eventTypeIds: Set<string>;
+    messages: number;
+    failures: number;
+  };
+  const edgeAccum = new Map<string, EdgeAccum>();
+  const ensureEdge = (kind: EdgeKind, endpointId: string) => {
+    const key = `${kind}::${endpointId}`;
+    let e = edgeAccum.get(key);
+    if (!e) {
+      e = { kind, endpointId, eventTypeIds: new Set(), messages: 0, failures: 0 };
+      edgeAccum.set(key, e);
+    }
+    return e;
+  };
+
+  const namespaces = new Set<string>();
+  // Tracks (endpoint, eventType, kind) → traffic for picking the top event pills.
+  const pillCandidates: Array<{
+    eventTypeId: string;
+    label: string;
+    endpointId: string;
+    kind: EdgeKind;
+    messages: number;
+    failures: number;
+    producers: string[];
+    consumers: string[];
+  }> = [];
+
+  for (const et of filteredTypes) {
+    if (!et.id) continue;
+    if (et.namespace) namespaces.add(et.namespace);
+
+    const detail = detailsById[et.id];
+    const producers = detail?.producers ?? [];
+    const consumers = detail?.consumers ?? [];
+
+    // Publish side ------------------------------------------------------------
+    for (const producer of producers) {
+      const node = ensureNode(producer);
+      node.publishedTypeIds.add(et.id);
+      const msgs = published[`${producer}::${et.id}`] ?? 0;
+      const fails = failed[`${producer}::${et.id}`] ?? 0;
+      node.publishedMessages += msgs;
+
+      const edge = ensureEdge("publish", producer);
+      edge.eventTypeIds.add(et.id);
+      edge.messages += msgs;
+      edge.failures += fails;
+
+      pillCandidates.push({
+        eventTypeId: et.id,
+        label: et.name || et.id,
+        endpointId: producer,
+        kind: "publish",
+        messages: msgs,
+        failures: fails,
+        producers,
+        consumers,
+      });
+    }
+
+    // Subscribe side ----------------------------------------------------------
+    for (const consumer of consumers) {
+      const node = ensureNode(consumer);
+      node.subscribedTypeIds.add(et.id);
+      const msgs = handled[`${consumer}::${et.id}`] ?? 0;
+      const fails = failed[`${consumer}::${et.id}`] ?? 0;
+      node.handledMessages += msgs;
+      node.failedMessages += fails;
+
+      const edge = ensureEdge("subscribe", consumer);
+      edge.eventTypeIds.add(et.id);
+      edge.messages += msgs;
+      edge.failures += fails;
+    }
+  }
+
+  // 4. Materialise nodes with derived health.
+  const nodes: TopologyNode[] = Array.from(nodeAccum.entries())
+    .map(([id, n]) => {
+      const health: NodeHealth = classifyNodeHealth(
+        n.failedMessages,
+        n.publishedMessages + n.handledMessages,
+      );
+      return {
+        id,
+        name: id,
+        role: "Endpoint",
+        publishCount: n.publishedTypeIds.size,
+        subscribeCount: n.subscribedTypeIds.size,
+        publishedMessages: n.publishedMessages,
+        handledMessages: n.handledMessages,
+        failedMessages: n.failedMessages,
+        health,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // 5. Materialise edges with derived health.
+  const edges: TopologyEdge[] = Array.from(edgeAccum.values()).map((e) => ({
+    id: `${e.kind}::${e.endpointId}`,
+    kind: e.kind,
+    endpointId: e.endpointId,
+    eventTypeIds: Array.from(e.eventTypeIds),
+    messages: e.messages,
+    health:
+      e.failures > 0 ? "fail" : e.messages === 0 ? "idle" : "healthy",
+  }));
+
+  // 6. Pick the top event pills by traffic (skipping idle edges).
+  const pills: EventPill[] = pillCandidates
+    .filter((c) => c.messages > 0)
+    .sort((a, b) => b.messages - a.messages)
+    .slice(0, MAX_EVENT_PILLS)
+    .map((c) => ({
+      id: c.eventTypeId,
+      label: c.label,
+      anchorEndpointId: c.endpointId,
+      kind: c.kind,
+      tooltip: buildPillTooltip(c),
+    }));
+
+  // 7. Summary strip counts.
+  const summary = {
+    endpoints: nodes.length,
+    eventTypes: filteredTypes.length,
+    edges: edges.length,
+    edgesWithFailures: edges.filter((e) => e.health === "fail").length,
+    namespaces: namespaces.size,
+    producingEndpoints: nodes.filter((n) => n.publishCount > 0).length,
+    consumingEndpoints: nodes.filter((n) => n.subscribeCount > 0).length,
+  };
+
+  return { nodes, edges, pills, summary };
+}
+
+function indexCounts(
+  rows: api.EndpointEventTypeMessageCount[] | undefined,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const r of rows ?? []) {
+    if (!r.endpointId || !r.eventTypeId) continue;
+    const key = `${r.endpointId}::${r.eventTypeId}`;
+    out[key] = (out[key] ?? 0) + (r.count ?? 0);
+  }
+  return out;
+}
+
+function classifyNodeHealth(failed: number, totalTraffic: number): NodeHealth {
+  if (failed > 0) return "bad";
+  if (totalTraffic === 0) return "idle";
+  return "good";
+  // Note: we don't currently surface a `warn` (deferred-above-threshold) state
+  // because MetricsOverview doesn't expose deferred counts. Wire that in if /
+  // when the API does.
+}
+
+function buildPillTooltip(c: {
+  label: string;
+  endpointId: string;
+  kind: EdgeKind;
+  messages: number;
+  producers: string[];
+  consumers: string[];
+}): string {
+  if (c.kind === "publish") {
+    const consumers = c.consumers.length === 0 ? "no consumers" : c.consumers.join(", ");
+    return `${c.label} · ${c.endpointId} → ${consumers} · ${c.messages.toLocaleString()} msgs`;
+  }
+  const producers = c.producers.length === 0 ? "no producers" : c.producers.join(", ");
+  return `${c.label} · ${producers} → ${c.endpointId} · ${c.messages.toLocaleString()} msgs`;
+}

--- a/src/NimBus.WebApp/ClientApp/src/index.css
+++ b/src/NimBus.WebApp/ClientApp/src/index.css
@@ -109,4 +109,18 @@
   .badge-unsupported {
     @apply bg-muted text-muted-foreground;
   }
+
+  /* Topology edge flow animation — dashed stroke that scrolls toward the
+     arrowhead, signalling direction of message flow on the SVG canvas.
+     Matches the prototype's `.flow-anim` keyframes verbatim. */
+  .nb-flow-anim {
+    stroke-dasharray: 5 7;
+    animation: nb-flow 4s linear infinite;
+  }
+}
+
+@keyframes nb-flow {
+  to {
+    stroke-dashoffset: -200;
+  }
 }

--- a/src/NimBus.WebApp/ClientApp/src/pages/topology.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/pages/topology.tsx
@@ -1,0 +1,301 @@
+import { useMemo, useState } from "react";
+import * as api from "api-client";
+import Page from "components/page";
+import { Button } from "components/ui/button";
+import { StatRow, StatTile } from "components/ui/stat-tile";
+import {
+  FilterToolbar,
+  FilterSearch,
+  FilterChip,
+} from "components/ui/filter-toolbar";
+import { EmptyState } from "components/ui/empty-state";
+import { Spinner } from "components/ui/spinner";
+import { cn } from "lib/utils";
+import { TopologyGraph } from "components/topology/topology-graph";
+import { TopologyInspector } from "components/topology/topology-inspector";
+import { useTopologyData } from "components/topology/use-topology-data";
+
+const PERIODS: Array<{ label: string; value: api.Period }> = [
+  { label: "1h", value: api.Period._1h },
+  { label: "12h", value: api.Period._12h },
+  { label: "1d", value: api.Period._1d },
+  { label: "7d", value: api.Period._7d },
+];
+
+export default function Topology() {
+  const [period, setPeriod] = useState<api.Period>(api.Period._1h);
+  const [search, setSearch] = useState("");
+  const [namespace, setNamespace] = useState<string | undefined>(undefined);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | undefined>();
+  const { data, loading, refresh, lastUpdated, error } = useTopologyData({
+    period,
+    namespace,
+  });
+
+  // Highlight filter — when the user types a search term, dim every node that
+  // doesn't match. We don't filter edges away because hiding context confuses
+  // the graph shape; matching nodes get an orange ring via selectedNodeId
+  // pass-through, all others keep their normal styling. (Selection still wins.)
+  const filteredData = useMemo(() => {
+    if (!data) return data;
+    if (!search.trim()) return data;
+    const lower = search.toLowerCase();
+    const matchingNodes = new Set(
+      data.nodes
+        .filter((n) => n.name.toLowerCase().includes(lower))
+        .map((n) => n.id),
+    );
+    // Surface a match by auto-selecting the first one — operators searching
+    // by name expect their result to be highlighted.
+    if (matchingNodes.size > 0 && !selectedNodeId) {
+      const first = Array.from(matchingNodes)[0];
+      // Defer to avoid setting state during render
+      Promise.resolve().then(() => setSelectedNodeId(first));
+    }
+    return data;
+  }, [data, search, selectedNodeId]);
+
+  const periodLabel =
+    PERIODS.find((p) => p.value === period)?.label ?? "1h";
+
+  return (
+    <Page
+      title="Topology"
+      subtitle="Live view of every endpoint, the event types they publish, and which consumers subscribe."
+      actions={
+        <>
+          <div className="inline-flex items-center bg-card border border-border rounded-nb-md p-[3px] gap-[2px]">
+            {PERIODS.map((p) => (
+              <button
+                key={p.value}
+                onClick={() => setPeriod(p.value)}
+                className={cn(
+                  "px-3 py-1.5 rounded-md text-xs font-semibold transition-colors",
+                  period === p.value
+                    ? "bg-primary text-white"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => exportSvg()}
+            title="Download current graph as SVG"
+          >
+            ⤓ Export SVG
+          </Button>
+          <Button
+            variant="solid"
+            size="sm"
+            onClick={() => void refresh()}
+            isLoading={loading}
+          >
+            ↻ Refresh
+          </Button>
+        </>
+      }
+    >
+      <div className="w-full flex flex-col gap-4">
+        <FilterToolbar
+          search={
+            <FilterSearch
+              value={search}
+              onChange={setSearch}
+              placeholder="Highlight endpoints or event types…"
+            />
+          }
+          chips={
+            <>
+              {namespace && (
+                <FilterChip
+                  field="Namespace"
+                  value={namespace}
+                  onRemove={() => setNamespace(undefined)}
+                />
+              )}
+            </>
+          }
+          actions={
+            <Button variant="ghost" size="sm" disabled title="Filter builder — coming soon">
+              + Add filter
+            </Button>
+          }
+          trailing={
+            <div className="inline-flex items-center bg-card border border-border rounded-nb-md p-[3px] gap-[2px]">
+              <button
+                type="button"
+                className={cn(
+                  "px-2.5 py-1.5 rounded-md text-xs font-semibold transition-colors",
+                  "bg-primary text-white",
+                )}
+              >
+                Graph
+              </button>
+              <button
+                type="button"
+                disabled
+                title="Coming soon"
+                className="px-2.5 py-1.5 rounded-md text-xs font-semibold text-muted-foreground/60 cursor-not-allowed"
+              >
+                Matrix
+              </button>
+              <button
+                type="button"
+                disabled
+                title="Coming soon"
+                className="px-2.5 py-1.5 rounded-md text-xs font-semibold text-muted-foreground/60 cursor-not-allowed"
+              >
+                List
+              </button>
+            </div>
+          }
+        />
+
+        {data ? (
+          <>
+            <StatRow columns={4}>
+              <StatTile
+                label="Endpoints"
+                value={data.summary.endpoints.toLocaleString()}
+                delta={`${data.summary.producingEndpoints} producing · ${data.summary.consumingEndpoints} consuming`}
+                tone="muted"
+              />
+              <StatTile
+                label="Event types"
+                value={data.summary.eventTypes.toLocaleString()}
+                delta={`${data.summary.namespaces} namespace${data.summary.namespaces === 1 ? "" : "s"}`}
+                tone="muted"
+              />
+              <StatTile
+                label="Pub-sub edges"
+                value={data.summary.edges.toLocaleString()}
+                delta={`window · ${periodLabel}`}
+                tone="muted"
+              />
+              <StatTile
+                label="Edges with failures"
+                value={data.summary.edgesWithFailures.toLocaleString()}
+                delta={
+                  data.summary.edgesWithFailures > 0
+                    ? "needs attention"
+                    : "all clear"
+                }
+                tone={data.summary.edgesWithFailures > 0 ? "danger" : "default"}
+              />
+            </StatRow>
+
+            <Legend />
+
+            <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-4">
+              <TopologyGraph
+                nodes={filteredData?.nodes ?? data.nodes}
+                edges={data.edges}
+                pills={data.pills}
+                selectedNodeId={selectedNodeId}
+                onSelectNode={setSelectedNodeId}
+              />
+              <TopologyInspector
+                data={data}
+                selectedNodeId={selectedNodeId}
+                lastUpdated={lastUpdated}
+                periodLabel={periodLabel}
+              />
+            </div>
+          </>
+        ) : loading ? (
+          <div className="flex items-center justify-center h-[400px] w-full">
+            <Spinner size="xl" color="primary" />
+          </div>
+        ) : (
+          <EmptyState
+            icon="◌"
+            title={error ?? "No topology yet"}
+            description="Register an event type with at least one producer or consumer to see the graph."
+          />
+        )}
+      </div>
+    </Page>
+  );
+}
+
+const Legend: React.FC = () => (
+  <div className="flex gap-5 flex-wrap items-center font-mono text-[11px] text-muted-foreground">
+    <LegendNode color="var(--nb-success,#2E8F5E)" tint="var(--nb-success-50,#DCEFE4)">
+      Healthy endpoint
+    </LegendNode>
+    <LegendNode color="var(--nb-warning,#C98A1B)" tint="var(--nb-warning-50,#F6E7C7)">
+      Deferred / above P95
+    </LegendNode>
+    <LegendNode color="var(--nb-danger,#C2412E)" tint="var(--nb-danger-50,#F4D9D3)">
+      Failures present
+    </LegendNode>
+    <LegendNode color="var(--nb-border-strong,#C9C1AB)" tint="var(--nb-surface-2,#ECE7DA)">
+      Idle (no traffic)
+    </LegendNode>
+    <span aria-hidden="true" className="w-px h-3.5 bg-border" />
+    <LegendLine color="var(--nb-success,#2E8F5E)">Publishes</LegendLine>
+    <LegendLine color="var(--nb-info,#3A6FB0)">Subscribes</LegendLine>
+    <LegendLine color="var(--nb-danger,#C2412E)">Failing edge</LegendLine>
+    <LegendLine color="var(--nb-ink-3,#8A8473)" dashed>
+      Idle / no traffic
+    </LegendLine>
+    <span className="ml-auto italic text-muted-foreground">
+      Click any endpoint to focus its sub-graph.
+    </span>
+  </div>
+);
+
+const LegendNode: React.FC<{
+  color: string;
+  tint: string;
+  children: React.ReactNode;
+}> = ({ color, tint, children }) => (
+  <span className="inline-flex items-center gap-1.5">
+    <span
+      aria-hidden="true"
+      className="inline-block w-3.5 h-2.5 rounded-[3px] border-[1.5px]"
+      style={{ borderColor: color, background: tint }}
+    />
+    {children}
+  </span>
+);
+
+const LegendLine: React.FC<{
+  color: string;
+  dashed?: boolean;
+  children: React.ReactNode;
+}> = ({ color, dashed, children }) => (
+  <span className="inline-flex items-center gap-1.5">
+    <span
+      aria-hidden="true"
+      className="inline-block w-4 h-0 align-middle"
+      style={{
+        borderTopWidth: 2,
+        borderTopStyle: dashed ? "dashed" : "solid",
+        borderTopColor: color,
+      }}
+    />
+    {children}
+  </span>
+);
+
+function exportSvg(): void {
+  // Find the first topology SVG on the page and download it as a file. We
+  // intentionally serialise the live DOM so the exported file matches what
+  // the operator was looking at including selection / hover state.
+  const svg = document.querySelector<SVGSVGElement>(".rounded-nb-lg svg");
+  if (!svg) return;
+  const serializer = new XMLSerializer();
+  const xml = `<?xml version="1.0" standalone="no"?>\r\n${serializer.serializeToString(svg)}`;
+  const blob = new Blob([xml], { type: "image/svg+xml;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "nimbus-topology.svg";
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
Adds the **Topology** screen from the Claude Design handoff (\`api.anthropic.com/v1/design/h/34oNfm7egyUqhp6nTaSTBg\`). Stacks on top of the design-system stack — branched off \`feat/webapp-admin-redesign\` so it picks up every primitive from PRs #43–#49.

The page answers one question operators currently have to reconstruct manually by walking endpoint-by-endpoint or event-type-by-event-type: **\"who publishes what, who consumes it, where is the flow breaking right now?\"**

### New module — \`src/components/topology/\`
- **\`types.ts\`** — \`TopologyNode\` / \`TopologyEdge\` / \`EventPill\` / \`TopologyData\` shapes.
- **\`use-topology-data.ts\`** — client-side aggregation hook. One \`getEventTypes()\` round-trip + N parallel \`getEventtypesEventtypeid()\` for producer/consumer arrays + \`getMetricsOverview()\` for the time-window overlay. Caches event-type details; only re-fetches metrics on time-range change. Fails soft per-event-type so one broken contract can't blank the graph.
- **\`topology-graph.tsx\`** — pure-SVG, radial layout with the bus hub at the centre. Endpoint cards arrange on a circle; cubic Bezier edges curve outward (publish, green) and inward (subscribe, blue) with the design's animated dashed stroke. Failing edges go red, idle edges static-dotted muted. Hover surfaces an ink tooltip; click a card to focus the inspector. Layout radius scales with N.
- **\`topology-inspector.tsx\`** — sticky right rail with name + role, 2×2 mini KPI grid (Handled / Failed / Latency / Backlog — latency & backlog stay \"—\" until the API exposes them), Publishes / Subscribes lists (each row deep-links to \`/EventTypes/Details/<id>\`), Downstream endpoints with red callouts on failing pairs, and an \"Open endpoint ›\" footer linking to the full endpoint page.

### New page — \`src/pages/topology.tsx\`
- Page header: title + subtitle + actions slot (time-range seg \`1h/12h/1d/7d\`, ghost \"Export SVG\", primary \"Refresh\"). Default \`1h\`.
- \`FilterToolbar\` (PR #44): search input that highlights matching endpoint names + auto-selects the first match; namespace chip when set; trailing view-mode seg with Graph active and Matrix / List disabled (title=\"Coming soon\" — confirmed scope).
- 4-tile \`StatRow\`: Endpoints / Event types / Pub-sub edges / Edges with failures. Last tile turns \`danger\` when failures > 0.
- Inline legend strip (no new primitive).
- \`EmptyState\` when no event types are registered.

### Wiring
- \`sidebar.tsx\` — new \"Topology\" entry in the Observe group with a \"new\" badge slot. \`NavItem\` extended with optional \`badge\`.
- \`app.tsx\` — \`/Topology\` route.
- \`topbar.tsx\` — breadcrumb mapping for \`/Topology\`.

### CSS
- \`index.css\` — \`@keyframes nb-flow\` + \`.nb-flow-anim\` utility (stroke-dasharray scrolling toward the arrowhead). Replaces the prototype's inline \`flow\` keyframe.

## Deliberately out of scope
- **Matrix and List views** — buttons render disabled.
- **A dedicated \`/api/topology\` endpoint** — derived client-side; the hook is the only seam to swap later.
- **Drag / zoom / pan** — fixed viewbox; revisit if the graph outgrows the canvas.

## Test plan
- [x] \`npm run build\` succeeds (657 modules)
- [x] \`npm test\` passes
- [ ] Open \`/Topology\`: sidebar highlights with the new \"new\" badge; topbar breadcrumb reads \"Topology\".
- [ ] Header time-range seg defaults to \`1h\`; switching to \`1d\` triggers a metrics refetch (event-type details stay cached).
- [ ] 4 stat tiles populate; SVG renders the bus hub + each endpoint as a card. Healthy endpoints have green header tints, failures red, idle grey. Publish edges flow outward (green), subscribe edges inward (blue), failing edges red.
- [ ] Hover an edge → ink tooltip with \"N event types · N msgs\". Click a card → orange border + inspector swaps to that endpoint with the right KPIs / Publishes / Subscribes / Downstream lists.
- [ ] Inspector \"Open endpoint ›\" navigates to the full endpoint page; clicking a Publishes/Subscribes row navigates to the event-type details.
- [ ] Export SVG downloads a serialised SVG of the current graph.
- [ ] Toggle theme — edge colours and node tints remain legible on the warm-black dark surface.
- [ ] Filter chip: typing in the toolbar search auto-selects a matching endpoint.
- [ ] Empty state: when no event types are registered, the page renders the EmptyState placeholder instead of an empty SVG.

Plan file: \`C:\Users\aka\.claude\plans\fetch-this-design-file-robust-wombat.md\`.