### PR TITLE
feat(webapp): wire the ⌘K command palette

### DIFF
--- a/src/NimBus.WebApp/ClientApp/src/app.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/app.tsx
@@ -15,6 +15,7 @@ import AuditsList from "pages/audits-list";
 import Footer from "components/footer";
 import { Navigation } from "models/navigation";
 import { ToastProvider } from "components/ui/toast";
+import { CommandPaletteProvider } from "components/command-palette";
 import { ThemeProvider } from "hooks/use-theme";
 
 const navigation: Navigation = [
@@ -102,26 +103,28 @@ function App() {
   return (
     <ThemeProvider>
       <ToastProvider>
-        <div className="flex min-h-screen bg-background">
-          <Sidebar />
-          <div className="flex flex-col flex-1 min-w-0">
-            <Topbar />
-            <main className="flex-1 flex flex-col min-w-0">
-              <Routes>
-                {navigation
-                  .filter((x) => x.render)
-                  .map((route) => (
-                    <Route
-                      key={route.path}
-                      path={route.path}
-                      element={route.render!()}
-                    />
-                  ))}
-              </Routes>
-            </main>
-            <Footer />
+        <CommandPaletteProvider>
+          <div className="flex min-h-screen bg-background">
+            <Sidebar />
+            <div className="flex flex-col flex-1 min-w-0">
+              <Topbar />
+              <main className="flex-1 flex flex-col min-w-0">
+                <Routes>
+                  {navigation
+                    .filter((x) => x.render)
+                    .map((route) => (
+                      <Route
+                        key={route.path}
+                        path={route.path}
+                        element={route.render!()}
+                      />
+                    ))}
+                </Routes>
+              </main>
+              <Footer />
+            </div>
           </div>
-        </div>
+        </CommandPaletteProvider>
       </ToastProvider>
     </ThemeProvider>
   );

--- a/src/NimBus.WebApp/ClientApp/src/components/command-palette/command-palette-context.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/command-palette/command-palette-context.tsx
@@ -1,0 +1,16 @@
+import { createContext } from "react";
+
+export interface CommandPaletteContextValue {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+/**
+ * Internal context — consumers use the `useCommandPalette` hook instead of
+ * touching this directly so the provider stays the single source of truth
+ * for open/close state.
+ */
+export const CommandPaletteContext =
+  createContext<CommandPaletteContextValue | null>(null);

--- a/src/NimBus.WebApp/ClientApp/src/components/command-palette/command-palette-provider.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/command-palette/command-palette-provider.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { CommandPaletteContext } from "./command-palette-context";
+import { CommandPalette } from "./command-palette";
+
+interface CommandPaletteProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Owns the palette's open/close state and the global Cmd+K / Ctrl+K listener.
+ *
+ * The shortcut still fires when focus is in an `<input>` (operators paste GUIDs
+ * mid-typing), but we opt out for `<textarea>` and `contenteditable` regions
+ * where Ctrl/Cmd+K is more likely to mean "edit hyperlink".
+ *
+ * The palette itself is rendered once here so child trees only need to consume
+ * the hook to open it — same pattern as `ToastProvider`.
+ */
+export const CommandPaletteProvider: React.FC<CommandPaletteProviderProps> = ({
+  children,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((v) => !v), []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      // Letter "k" only; ignore Shift+K and other modifiers.
+      if (e.key !== "k" && e.key !== "K") return;
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.shiftKey || e.altKey) return;
+
+      // Don't shadow textarea / rich-text editing shortcuts.
+      const target = e.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (tag === "TEXTAREA") return;
+        if (target.isContentEditable) return;
+      }
+
+      e.preventDefault();
+      toggle();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [toggle]);
+
+  const value = useMemo(
+    () => ({ isOpen, open, close, toggle }),
+    [isOpen, open, close, toggle],
+  );
+
+  return (
+    <CommandPaletteContext.Provider value={value}>
+      {children}
+      <CommandPalette isOpen={isOpen} onClose={close} />
+    </CommandPaletteContext.Provider>
+  );
+};

--- a/src/NimBus.WebApp/ClientApp/src/components/command-palette/command-palette.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/command-palette/command-palette.tsx
@@ -1,0 +1,351 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import { createPortal } from "react-dom";
+import { useNavigate } from "react-router-dom";
+import { cn } from "lib/utils";
+import { Spinner } from "components/ui/spinner";
+import { usePaletteSearch, type PaletteResult } from "./use-palette-search";
+
+interface CommandPaletteProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const SECTION_LABELS: Record<PaletteResult["kind"], string> = {
+  endpoint: "Endpoints",
+  eventType: "Event Types",
+  event: "Events",
+  session: "Sessions",
+};
+
+const SECTION_ORDER: Array<PaletteResult["kind"]> = [
+  "endpoint",
+  "eventType",
+  "event",
+  "session",
+];
+
+const KIND_ICON: Record<PaletteResult["kind"], React.ReactNode> = {
+  endpoint: (
+    <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <rect x="2" y="3" width="12" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M2 6h12" stroke="currentColor" strokeWidth="1.4" />
+    </svg>
+  ),
+  eventType: (
+    <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path d="M2 4h6M2 8h12M2 12h9" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  ),
+  event: (
+    <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path d="M2 4h12v8H2z" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
+      <path d="M2 4l6 5 6-5" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
+    </svg>
+  ),
+  session: (
+    <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M8 5v3l2 2" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  ),
+};
+
+/**
+ * The ⌘K / Ctrl+K command palette. Centred near the top of the viewport,
+ * portalled to body, ESC + outside-click close. Local + remote search lives
+ * in `usePaletteSearch`; this component is concerned only with input,
+ * keyboard navigation, rendering, and routing on selection.
+ */
+export const CommandPalette: React.FC<CommandPaletteProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const [query, setQuery] = useState("");
+  const [highlighted, setHighlighted] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  const { results, catalogLoading, remoteSearching, remoteError } =
+    usePaletteSearch(query, isOpen);
+
+  // Reset when the palette opens so the previous gesture's state isn't sticky.
+  useEffect(() => {
+    if (isOpen) {
+      setQuery("");
+      setHighlighted(0);
+      // Defer focus until after the portal mounts.
+      const id = window.setTimeout(() => inputRef.current?.focus(), 0);
+      return () => window.clearTimeout(id);
+    }
+  }, [isOpen]);
+
+  // Keep the highlight in-range as results change.
+  useEffect(() => {
+    if (highlighted >= results.length) {
+      setHighlighted(results.length === 0 ? 0 : results.length - 1);
+    }
+  }, [results.length, highlighted]);
+
+  // Scroll the highlighted row into view when navigating with the keyboard.
+  useEffect(() => {
+    const node = listRef.current?.querySelector<HTMLElement>(
+      `[data-row-index='${highlighted}']`,
+    );
+    node?.scrollIntoView({ block: "nearest" });
+  }, [highlighted]);
+
+  // Lock body scroll while open. Mirrors what the Modal primitive does so the
+  // page underneath doesn't shift when the palette opens.
+  useEffect(() => {
+    if (!isOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [isOpen]);
+
+  const grouped = useMemo(() => {
+    const map: Record<PaletteResult["kind"], PaletteResult[]> = {
+      endpoint: [],
+      eventType: [],
+      event: [],
+      session: [],
+    };
+    for (const r of results) {
+      map[r.kind].push(r);
+    }
+    return map;
+  }, [results]);
+
+  const handleSelect = (r: PaletteResult) => {
+    onClose();
+    // Defer the navigate until after the close transition starts so the
+    // route doesn't render under a stale overlay.
+    window.requestAnimationFrame(() => navigate(r.route));
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlighted((i) => Math.min(i + 1, Math.max(results.length - 1, 0)));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlighted((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const r = results[highlighted];
+      if (r) handleSelect(r);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const trimmed = query.trim();
+  const showEmptyHint = trimmed.length === 0;
+  const noResults =
+    !showEmptyHint &&
+    results.length === 0 &&
+    !catalogLoading &&
+    !remoteSearching;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 bg-black/50 flex items-start justify-center pt-[10vh] px-4"
+      onMouseDown={(e) => {
+        // Only close if the user clicked the overlay itself, not a descendant.
+        if (e.target === e.currentTarget) onClose();
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+    >
+      <div
+        className={cn(
+          "w-full max-w-xl bg-card text-card-foreground",
+          "rounded-nb-lg border border-border shadow-nb-lg overflow-hidden",
+          "flex flex-col max-h-[70vh]",
+          "animate-zoom-in",
+        )}
+      >
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+          <svg
+            className="w-4 h-4 text-muted-foreground shrink-0"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden
+          >
+            <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M10.5 10.5L13 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+          <input
+            ref={inputRef}
+            type="text"
+            autoComplete="off"
+            spellCheck={false}
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setHighlighted(0);
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder="Jump to endpoint, event, or session…"
+            className={cn(
+              "flex-1 bg-transparent outline-none border-0 text-foreground",
+              "placeholder:text-muted-foreground text-[14px]",
+            )}
+            aria-label="Search"
+            aria-autocomplete="list"
+            aria-controls="cmd-palette-results"
+            aria-activedescendant={
+              results[highlighted]?.key
+                ? `cmd-palette-row-${results[highlighted]!.key}`
+                : undefined
+            }
+          />
+          {(catalogLoading || remoteSearching) && (
+            <Spinner size="sm" color="primary" />
+          )}
+          <kbd
+            className={cn(
+              "font-mono text-[10.5px] bg-muted border border-border",
+              "px-1.5 py-px rounded text-muted-foreground",
+            )}
+          >
+            esc
+          </kbd>
+        </div>
+
+        <div
+          ref={listRef}
+          id="cmd-palette-results"
+          role="listbox"
+          className="flex-1 overflow-y-auto py-1"
+        >
+          {showEmptyHint && (
+            <EmptyHint catalogLoading={catalogLoading} />
+          )}
+          {noResults && <NoResults query={trimmed} />}
+          {remoteError && !remoteSearching && (
+            <div className="px-4 py-3 text-[12.5px] text-status-warning-ink font-mono">
+              ID lookup failed — backend unavailable.
+            </div>
+          )}
+          {SECTION_ORDER.map((kind) => {
+            const items = grouped[kind];
+            if (items.length === 0) return null;
+            return (
+              <section key={kind}>
+                <div
+                  className={cn(
+                    "px-4 pt-3 pb-1 font-mono text-[10.5px] uppercase",
+                    "tracking-[0.12em] text-muted-foreground",
+                  )}
+                >
+                  {SECTION_LABELS[kind]}
+                </div>
+                <ul className="m-0 p-0 list-none">
+                  {items.map((r) => {
+                    const flatIndex = results.indexOf(r);
+                    const isActive = flatIndex === highlighted;
+                    return (
+                      <li
+                        key={r.key}
+                        id={`cmd-palette-row-${r.key}`}
+                        role="option"
+                        aria-selected={isActive}
+                        data-row-index={flatIndex}
+                        onMouseEnter={() => setHighlighted(flatIndex)}
+                        onMouseDown={(e) => {
+                          // mousedown not click — beats the overlay's
+                          // onMouseDown that would otherwise close us first.
+                          e.preventDefault();
+                          handleSelect(r);
+                        }}
+                        className={cn(
+                          "px-4 py-2 flex items-center gap-3 cursor-pointer",
+                          "text-[13px]",
+                          isActive
+                            ? "bg-primary-tint text-primary-600"
+                            : "text-foreground",
+                        )}
+                      >
+                        <span
+                          className={cn(
+                            "shrink-0",
+                            isActive
+                              ? "text-primary-600"
+                              : "text-muted-foreground",
+                          )}
+                        >
+                          {KIND_ICON[r.kind]}
+                        </span>
+                        <span className="flex-1 min-w-0">
+                          <span className="font-semibold truncate block">
+                            {r.title}
+                          </span>
+                          {r.subtitle && (
+                            <span
+                              className={cn(
+                                "font-mono text-[11px] truncate block",
+                                isActive
+                                  ? "text-primary-600/80"
+                                  : "text-muted-foreground",
+                              )}
+                            >
+                              {r.subtitle}
+                            </span>
+                          )}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            );
+          })}
+        </div>
+
+        <div
+          className={cn(
+            "px-4 py-2 border-t border-border bg-muted",
+            "font-mono text-[10.5px] text-muted-foreground",
+            "flex items-center gap-4",
+          )}
+        >
+          <span>↑↓ navigate</span>
+          <span>↵ open</span>
+          <span>esc close</span>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+const EmptyHint: React.FC<{ catalogLoading: boolean }> = ({
+  catalogLoading,
+}) => (
+  <div className="px-4 py-6 text-[12.5px] text-muted-foreground">
+    {catalogLoading
+      ? "Loading catalog…"
+      : "Type to search endpoints, event types, or paste an event ID or session ID. Use ↑↓ Enter to navigate."}
+  </div>
+);
+
+const NoResults: React.FC<{ query: string }> = ({ query }) => (
+  <div className="px-4 py-6 text-[12.5px] text-muted-foreground">
+    No matches for <span className="font-mono text-foreground">{query}</span>.
+    Try a different name or paste a full event / session ID.
+  </div>
+);

--- a/src/NimBus.WebApp/ClientApp/src/components/command-palette/index.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/command-palette/index.ts
@@ -1,0 +1,2 @@
+export { CommandPaletteProvider } from "./command-palette-provider";
+export { useCommandPalette } from "./use-command-palette";

--- a/src/NimBus.WebApp/ClientApp/src/components/command-palette/use-command-palette.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/command-palette/use-command-palette.ts
@@ -1,0 +1,19 @@
+import { useContext } from "react";
+import {
+  CommandPaletteContext,
+  type CommandPaletteContextValue,
+} from "./command-palette-context";
+
+/**
+ * Read the command-palette state from anywhere in the tree.
+ * Throws if used outside `CommandPaletteProvider` so missing wiring fails loudly.
+ */
+export function useCommandPalette(): CommandPaletteContextValue {
+  const ctx = useContext(CommandPaletteContext);
+  if (!ctx) {
+    throw new Error(
+      "useCommandPalette must be used inside <CommandPaletteProvider>",
+    );
+  }
+  return ctx;
+}

--- a/src/NimBus.WebApp/ClientApp/src/components/command-palette/use-palette-search.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/command-palette/use-palette-search.ts
@@ -1,0 +1,240 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import * as api from "api-client";
+
+// 8-4-4-4-12 hex layout OR 32 contiguous hex chars (Service Bus session keys).
+const GUID_DASHED = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const HEX_32 = /^[0-9a-fA-F]{32}$/;
+const REMOTE_DEBOUNCE_MS = 250;
+const MAX_LOCAL_RESULTS = 8;
+const MAX_REMOTE_RESULTS = 25;
+
+export interface PaletteResult {
+  /** Stable key for React reconciliation. */
+  key: string;
+  kind: "endpoint" | "eventType" | "event" | "session";
+  title: string;
+  /** Mono secondary line; usually a namespace or "Session …" descriptor. */
+  subtitle?: string;
+  /** Route to navigate to on selection. */
+  route: string;
+}
+
+export interface PaletteSearchState {
+  /** Whether catalog (endpoints + event types) is still loading. */
+  catalogLoading: boolean;
+  /** Whether a GUID lookup is in flight. */
+  remoteSearching: boolean;
+  /** Soft error from the GUID lookup; UI shows a hint, doesn't crash. */
+  remoteError?: string;
+  results: PaletteResult[];
+}
+
+function looksLikeId(input: string): boolean {
+  return GUID_DASHED.test(input) || HEX_32.test(input);
+}
+
+/**
+ * Aggregates command-palette results from two sources:
+ *
+ * 1. **Catalog (local)** — endpoint names + event types fetched once when the
+ *    palette opens and substring-filtered against the input.
+ * 2. **GUID lookup (remote)** — when the input looks like an ID we hit the
+ *    `/api/messages/search` endpoint twice in parallel (by eventId, by sessionId)
+ *    and surface the hits as `event` / `session` rows.
+ *
+ * Catalog requests run once per page load (the catalog rarely changes during
+ * an operator's session). Remote lookups debounce 250 ms so paste-then-type
+ * doesn't fire 5 round-trips.
+ */
+export function usePaletteSearch(
+  query: string,
+  enabled: boolean,
+): PaletteSearchState {
+  const [endpoints, setEndpoints] = useState<string[] | undefined>(undefined);
+  const [eventTypes, setEventTypes] = useState<api.EventType[] | undefined>(
+    undefined,
+  );
+  const [catalogLoading, setCatalogLoading] = useState(false);
+
+  const [remoteEvents, setRemoteEvents] = useState<api.Message[]>([]);
+  const [remoteSessions, setRemoteSessions] = useState<api.Message[]>([]);
+  const [remoteSearching, setRemoteSearching] = useState(false);
+  const [remoteError, setRemoteError] = useState<string | undefined>(undefined);
+  // Increments every time we kick off a new remote search; only the latest
+  // ticket's response is applied so out-of-order returns can't clobber state.
+  const remoteTicket = useRef(0);
+
+  // 1. Catalog fetch — once, lazily when the palette first opens.
+  useEffect(() => {
+    if (!enabled) return;
+    if (endpoints !== undefined && eventTypes !== undefined) return;
+    let cancelled = false;
+    setCatalogLoading(true);
+    const client = new api.Client(api.CookieAuth());
+    Promise.all([
+      client.getEndpointsAll().catch((): string[] => []),
+      client.getEventTypes().catch((): api.EventType[] => []),
+    ])
+      .then(([eps, types]) => {
+        if (cancelled) return;
+        setEndpoints(eps);
+        setEventTypes(types);
+      })
+      .finally(() => {
+        if (!cancelled) setCatalogLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, endpoints, eventTypes]);
+
+  // 2. Remote GUID lookup — debounced.
+  useEffect(() => {
+    if (!enabled) {
+      setRemoteEvents([]);
+      setRemoteSessions([]);
+      setRemoteError(undefined);
+      return;
+    }
+    const trimmed = query.trim();
+    if (!trimmed || !looksLikeId(trimmed)) {
+      setRemoteEvents([]);
+      setRemoteSessions([]);
+      setRemoteError(undefined);
+      return;
+    }
+
+    const ticket = ++remoteTicket.current;
+    const timer = window.setTimeout(async () => {
+      const client = new api.Client(api.CookieAuth());
+      setRemoteSearching(true);
+      setRemoteError(undefined);
+      try {
+        const byEvent = new api.MessageSearchRequest();
+        byEvent.filter = api.MessageSearchFilter.fromJS({ eventId: trimmed });
+        byEvent.maxItemCount = MAX_REMOTE_RESULTS;
+
+        const bySession = new api.MessageSearchRequest();
+        bySession.filter = api.MessageSearchFilter.fromJS({
+          sessionId: trimmed,
+        });
+        bySession.maxItemCount = MAX_REMOTE_RESULTS;
+
+        const [evRes, seRes] = await Promise.all([
+          client.postMessagesSearch(byEvent).catch(() => undefined),
+          client.postMessagesSearch(bySession).catch(() => undefined),
+        ]);
+
+        if (ticket !== remoteTicket.current) return;
+        setRemoteEvents(evRes?.messages ?? []);
+        setRemoteSessions(seRes?.messages ?? []);
+      } catch (err) {
+        if (ticket !== remoteTicket.current) return;
+        setRemoteError(
+          err instanceof Error ? err.message : "Lookup failed",
+        );
+        setRemoteEvents([]);
+        setRemoteSessions([]);
+      } finally {
+        if (ticket === remoteTicket.current) {
+          setRemoteSearching(false);
+        }
+      }
+    }, REMOTE_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [enabled, query]);
+
+  // 3. Compose results
+  return useMemo<PaletteSearchState>(() => {
+    const trimmed = query.trim();
+    const lower = trimmed.toLowerCase();
+    const results: PaletteResult[] = [];
+
+    // Local matches — only when there's actual input (empty input shows hint).
+    if (trimmed) {
+      const epMatches = (endpoints ?? [])
+        .filter((name) => name.toLowerCase().includes(lower))
+        .slice(0, MAX_LOCAL_RESULTS);
+      for (const name of epMatches) {
+        results.push({
+          key: `endpoint::${name}`,
+          kind: "endpoint",
+          title: name,
+          subtitle: "Endpoint",
+          route: `/Endpoints/Details/${encodeURIComponent(name)}`,
+        });
+      }
+
+      const typeMatches = (eventTypes ?? [])
+        .filter((et) => {
+          const name = (et.name || et.id || "").toLowerCase();
+          const ns = (et.namespace || "").toLowerCase();
+          return name.includes(lower) || ns.includes(lower);
+        })
+        .slice(0, MAX_LOCAL_RESULTS);
+      for (const et of typeMatches) {
+        results.push({
+          key: `eventType::${et.id}`,
+          kind: "eventType",
+          title: et.name || et.id,
+          subtitle: et.namespace || "Event type",
+          route: `/EventTypes/Details/${encodeURIComponent(et.id)}`,
+        });
+      }
+    }
+
+    // Remote — only meaningful when query is GUID-shaped.
+    if (trimmed && looksLikeId(trimmed)) {
+      for (const m of remoteEvents) {
+        if (!m.eventId || !m.endpointId) continue;
+        const ep = m.endpointId;
+        const evId = m.eventId;
+        const short = evId.length > 12 ? `${evId.slice(0, 8)}…` : evId;
+        results.push({
+          key: `event::${ep}::${evId}`,
+          kind: "event",
+          title: `Event ${short}`,
+          subtitle: `${m.eventTypeId ?? "(unknown type)"} · ${ep}`,
+          route: `/Message/Index/${encodeURIComponent(ep)}/${encodeURIComponent(evId)}/0`,
+        });
+      }
+
+      // Sessions can match many messages — collapse to one row per unique session.
+      const sessionSeen = new Set<string>();
+      for (const m of remoteSessions) {
+        if (!m.sessionId) continue;
+        if (sessionSeen.has(m.sessionId)) continue;
+        sessionSeen.add(m.sessionId);
+        const short =
+          m.sessionId.length > 12
+            ? `${m.sessionId.slice(0, 8)}…`
+            : m.sessionId;
+        const ep = m.endpointId ?? m.to ?? "—";
+        results.push({
+          key: `session::${m.sessionId}`,
+          kind: "session",
+          title: `Session ${short}`,
+          subtitle: `Endpoint ${ep}`,
+          route: `/Messages?sessionId=${encodeURIComponent(m.sessionId)}`,
+        });
+      }
+    }
+
+    return {
+      catalogLoading,
+      remoteSearching,
+      remoteError,
+      results,
+    };
+  }, [
+    query,
+    endpoints,
+    eventTypes,
+    remoteEvents,
+    remoteSessions,
+    remoteSearching,
+    remoteError,
+    catalogLoading,
+  ]);
+}

--- a/src/NimBus.WebApp/ClientApp/src/components/topbar.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/topbar.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation, useParams } from "react-router-dom";
 import { useTheme } from "hooks/use-theme";
+import { useCommandPalette } from "components/command-palette";
 import { cn } from "lib/utils";
 
 interface Crumb {
@@ -66,9 +67,15 @@ function useBreadcrumbs(): Crumb[] {
 const Topbar = () => {
   const crumbs = useBreadcrumbs();
   const { resolvedTheme, setTheme } = useTheme();
+  const { open: openCommandPalette } = useCommandPalette();
 
   const toggleTheme = () =>
     setTheme(resolvedTheme === "dark" ? "light" : "dark");
+
+  const isMac =
+    typeof navigator !== "undefined" &&
+    /Mac|iPhone|iPad/.test(navigator.platform);
+  const shortcutLabel = isMac ? "⌘K" : "Ctrl K";
 
   return (
     <header
@@ -105,18 +112,23 @@ const Topbar = () => {
 
       <div className="flex-1" />
 
-      {/* ⌘K command-palette placeholder (recommendation §10). Not wired —
-          renders as a static search affordance for now. */}
-      <div
+      {/* ⌘K command-palette trigger — recommendation §10 from the design
+          handoff. Keyboard users invoke via Cmd+K / Ctrl+K from anywhere
+          (wired in CommandPaletteProvider); this button is the same gesture
+          for mouse-first users. */}
+      <button
+        type="button"
+        onClick={openCommandPalette}
         className={cn(
           "hidden md:flex items-center gap-2",
           "bg-card border border-border rounded-nb-md",
           "px-3 py-1.5 min-w-[280px] text-muted-foreground text-[13px]",
-          "cursor-not-allowed opacity-75",
+          "hover:border-border-strong hover:text-foreground transition-colors",
+          "cursor-pointer",
         )}
-        title="Command palette (not yet wired)"
+        title={`Open command palette (${shortcutLabel})`}
       >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden>
           <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.5" />
           <path
             d="M10.5 10.5L13 13"
@@ -127,9 +139,9 @@ const Topbar = () => {
         </svg>
         <span>Jump to endpoint, event, or session…</span>
         <kbd className="ml-auto font-mono text-[10.5px] bg-muted border border-border px-1.5 py-px rounded text-muted-foreground">
-          ⌘K
+          {shortcutLabel}
         </kbd>
-      </div>
+      </button>
 
       <button
         onClick={toggleTheme}


### PR DESCRIPTION
## Summary
Wires the \"Jump to endpoint, event, or session…\" affordance in the topbar that's been a disabled placeholder since #43. Stacks on #50 (Topology) so it picks up the latest topbar + sidebar.

Closes the last \"wayfinding\" recommendation (§10) from the Claude Design handoff.

### New module — \`src/components/command-palette/\`
- **\`command-palette-context\` + \`use-command-palette\`** — \`ToastProvider\`-shaped context exposing \`{ isOpen, open, close, toggle }\`. Throws when used outside the provider so missing wiring fails loudly.
- **\`command-palette-provider\`** — owns the global Cmd+K / Ctrl+K keydown listener. Fires from anywhere except \`<textarea>\` and \`contenteditable\` regions; deliberately works mid-typing inside regular \`<input>\` so a Messages search doesn't shadow the shortcut.
- **\`use-palette-search\`** — catalog fetch (\`getEndpointsAll\` + \`getEventTypes\`, once per session) plus GUID-shape detection that fires \`postMessagesSearch\` twice in parallel (by \`eventId\` and by \`sessionId\`), debounced 250 ms. Each request carries a monotonic ticket so out-of-order responses can't clobber state.
- **\`command-palette\` UI** — portalled overlay pinned to the top tenth of the viewport, ESC / outside-click close. Grouped results (Endpoints / Event Types / Events / Sessions) with section labels and icons. Highlighted row uses \`bg-primary-tint\`; keyboard nav ↑/↓/Enter/Esc; \`onMouseDown\` selects (beats the overlay's \`onMouseDown\` close that would otherwise consume the click).

### Wiring
- \`app.tsx\` — wrap the tree in \`<CommandPaletteProvider>\` alongside theme + toast providers.
- \`topbar.tsx\` — \`.cmd-search\` becomes a real \`<button>\` that calls \`open()\`. The \"not yet wired\" tooltip and disabled styling are gone. Mac vs Windows shortcut label (\`⌘K\` / \`Ctrl K\`) detected from \`navigator.platform\`.

### Selection routes
| Result | Navigates to |
|---|---|
| Endpoint | \`/Endpoints/Details/<id>\` |
| Event type | \`/EventTypes/Details/<id>\` |
| Event (GUID → \`eventId\`) | \`/Message/Index/<endpointId>/<eventId>/0\` |
| Session (GUID → \`sessionId\`) | \`/Messages?sessionId=<id>\` (Messages page already reads this via \`useUrlFilters\`) |

## Out of scope (deferred follow-ups)
- Recent-items history.
- Fuzzy ranking — substring is plenty at sub-100 endpoints.
- Command actions (\"Compose event\", \"Purge session\") — palette is search-only.

## Test plan
- [x] \`npm run build\` succeeds
- [x] \`npm test\` passes
- [ ] Topbar's \`.cmd-search\` is now hover-able. Tooltip reads \"Open command palette (⌘K)\" on Mac, \"(Ctrl K)\" on Windows.
- [ ] Click it → palette opens centered near top, input focused.
- [ ] Esc closes. Click outside closes.
- [ ] Cmd+K (Mac) / Ctrl+K (Win) toggles from any page; works even with focus inside the Endpoints search box; does NOT fire when focus is in a textarea.
- [ ] Type \`Crm\` → Endpoint and Event-Type matches grouped; ↑/↓ moves highlight; Enter navigates.
- [ ] Paste a real \`eventId\` → Events group surfaces a row; Enter navigates to the event details page.
- [ ] Paste a real \`sessionId\` → Sessions group shows one row per unique session (collapsed); Enter pre-filters \`/Messages\`.
- [ ] Dark theme — palette readable on warm-black surface.