### PR TITLE
feat(crm-erp-demo): DataPlatform adapter — single-subscription sink

### DIFF
--- a/samples/CrmErpDemo/CrmErpDemo.AppHost/CrmErpDemo.AppHost.csproj
+++ b/samples/CrmErpDemo/CrmErpDemo.AppHost/CrmErpDemo.AppHost.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\Crm.Adapter\Crm.Adapter.csproj" />
     <ProjectReference Include="..\Erp.Api\Erp.Api.csproj" />
     <ProjectReference Include="..\Erp.Adapter.Functions\Erp.Adapter.Functions.csproj" />
+    <ProjectReference Include="..\DataPlatform.Adapter.Functions\DataPlatform.Adapter.Functions.csproj" />
     <ProjectReference Include="..\..\..\src\NimBus.Resolver\NimBus.Resolver.csproj" />
     <ProjectReference Include="..\..\..\src\NimBus.WebApp\NimBus.WebApp.csproj" />
   </ItemGroup>

--- a/samples/CrmErpDemo/CrmErpDemo.AppHost/Program.cs
+++ b/samples/CrmErpDemo/CrmErpDemo.AppHost/Program.cs
@@ -193,4 +193,16 @@ builder.AddViteApp("erp-web", "../Erp.Web")
     .WithExternalHttpEndpoints()
     .WaitFor(erpApi);
 
+// DataPlatform sink. Pure terminal subscriber for ErpCustomerCreated —
+// mirrors the Erp adapter's Functions hosting model. No Api / Web companion
+// projects (the handler logs the inbound event; a real sink would write to
+// a lake / warehouse here).
+var dataPlatformAdapter = builder
+    .AddAzureFunctionsProject<Projects.DataPlatform_Adapter_Functions>("dataplatform-adapter")
+    .WithReference(servicebus)
+    .WithEnvironment("AzureWebJobsServiceBus", servicebus.Resource.ConnectionStringExpression)
+    .WithEnvironment("TopicName", "DataPlatformEndpoint")
+    .WithEnvironment("SubscriptionName", "DataPlatformEndpoint");
+if (provisioner is not null) dataPlatformAdapter.WaitFor(provisioner);
+
 builder.Build().Run();

--- a/samples/CrmErpDemo/CrmErpDemo.Contracts/CrmErpPlatformConfiguration.cs
+++ b/samples/CrmErpDemo/CrmErpDemo.Contracts/CrmErpPlatformConfiguration.cs
@@ -9,5 +9,6 @@ public class CrmErpPlatformConfiguration : Platform
     {
         AddEndpoint(new CrmEndpoint());
         AddEndpoint(new ErpEndpoint());
+        AddEndpoint(new DataPlatformEndpoint());
     }
 }

--- a/samples/CrmErpDemo/CrmErpDemo.Contracts/Endpoints/DataPlatformEndpoint.cs
+++ b/samples/CrmErpDemo/CrmErpDemo.Contracts/Endpoints/DataPlatformEndpoint.cs
@@ -1,0 +1,22 @@
+using CrmErpDemo.Contracts.Events;
+using NimBus.Core.Endpoints;
+
+namespace CrmErpDemo.Contracts.Endpoints;
+
+public class DataPlatformEndpoint : Endpoint
+{
+    public DataPlatformEndpoint()
+    {
+        Consumes<ErpCustomerCreated>();
+    }
+
+    public override ISystem System => new DataPlatformSystem();
+
+    public override string Description =>
+        "Data-platform sink endpoint. Subscribes to ErpCustomerCreated for downstream analytics; publishes nothing.";
+}
+
+internal sealed class DataPlatformSystem : ISystem
+{
+    public string SystemId => "DataPlatform";
+}

--- a/samples/CrmErpDemo/DataPlatform.Adapter.Functions/DataPlatform.Adapter.Functions.csproj
+++ b/samples/CrmErpDemo/DataPlatform.Adapter.Functions/DataPlatform.Adapter.Functions.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>DataPlatform.Adapter.Functions</RootNamespace>
+    <AssemblyName>DataPlatform.Adapter.Functions</AssemblyName>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NimBus.SDK\NimBus.SDK.csproj" />
+    <ProjectReference Include="..\..\..\src\NimBus.ServiceDefaults\NimBus.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\CrmErpDemo.Contracts\CrmErpDemo.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/samples/CrmErpDemo/DataPlatform.Adapter.Functions/Functions/DataPlatformEndpointFunction.cs
+++ b/samples/CrmErpDemo/DataPlatform.Adapter.Functions/Functions/DataPlatformEndpointFunction.cs
@@ -1,0 +1,32 @@
+using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.Functions.Worker;
+using NimBus.SDK;
+
+namespace DataPlatform.Adapter.Functions.Functions;
+
+/// <summary>
+/// Azure Functions ServiceBus trigger — the bridge the Functions runtime
+/// uses to actually pull messages off the DataPlatformEndpoint subscription
+/// and hand them to NimBus's <see cref="ISubscriberClient"/>, which then
+/// dispatches to the registered event handlers.
+///
+/// Without this class messages stack up in `Pending` forever because the
+/// Worker host has nothing to invoke. Topic/Subscription names come from
+/// the same %TopicName% / %SubscriptionName% app settings the Erp adapter
+/// uses; sessions stay enabled because the events carry [SessionKey] —
+/// ErpCustomerCreated is keyed on AccountId.
+/// </summary>
+public class DataPlatformEndpointFunction(ISubscriberClient subscriber)
+{
+    [Function("DataPlatformEndpoint")]
+    public Task RunAsync(
+        [ServiceBusTrigger(
+            "%TopicName%",
+            "%SubscriptionName%",
+            Connection = "AzureWebJobsServiceBus",
+            IsSessionsEnabled = true)]
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        ServiceBusSessionMessageActions sessionActions) =>
+        subscriber.Handle(message, messageActions, sessionActions);
+}

--- a/samples/CrmErpDemo/DataPlatform.Adapter.Functions/Handlers/ErpCustomerCreatedHandler.cs
+++ b/samples/CrmErpDemo/DataPlatform.Adapter.Functions/Handlers/ErpCustomerCreatedHandler.cs
@@ -1,0 +1,31 @@
+using CrmErpDemo.Contracts.Events;
+using Microsoft.Extensions.Logging;
+using NimBus.SDK.EventHandlers;
+
+namespace DataPlatform.Adapter.Functions.Handlers;
+
+/// <summary>
+/// Records inbound ErpCustomerCreated events for the data-platform sink.
+/// A real downstream lake / warehouse would write to ADLS / Snowflake here;
+/// for the demo, a structured log line gives operators an observable signal
+/// without coupling the sample to extra infrastructure.
+/// </summary>
+public sealed class ErpCustomerCreatedHandler(
+    ILogger<ErpCustomerCreatedHandler> logger)
+    : IEventHandler<ErpCustomerCreated>
+{
+    public Task Handle(
+        ErpCustomerCreated message,
+        IEventHandlerContext context,
+        CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation(
+            "DataPlatform received ErpCustomerCreated: AccountId={AccountId} CustomerNumber={CustomerNumber} LegalName={LegalName} CountryCode={CountryCode}",
+            message.AccountId,
+            message.CustomerNumber,
+            message.LegalName,
+            message.CountryCode);
+
+        return Task.CompletedTask;
+    }
+}

--- a/samples/CrmErpDemo/DataPlatform.Adapter.Functions/Program.cs
+++ b/samples/CrmErpDemo/DataPlatform.Adapter.Functions/Program.cs
@@ -1,0 +1,42 @@
+using Azure.Messaging.ServiceBus;
+using CrmErpDemo.Contracts.Events;
+using DataPlatform.Adapter.Functions.Handlers;
+using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Azure.Functions.Worker.OpenTelemetry;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NimBus.Core.Extensions;
+using NimBus.SDK.Extensions;
+using NimBus.ServiceBus;
+
+var builder = FunctionsApplication.CreateBuilder(args);
+
+builder.ConfigureFunctionsWebApplication();
+builder.AddServiceDefaults();
+
+builder.Services
+    .AddOpenTelemetry()
+    .UseFunctionsWorkerDefaults();
+
+// ServiceBusClient is provided from the AzureWebJobsServiceBus connection string.
+builder.Services.AddSingleton<ServiceBusClient>(sp =>
+{
+    var cfg = sp.GetRequiredService<IConfiguration>();
+    var connection = cfg["AzureWebJobsServiceBus"]
+        ?? throw new InvalidOperationException("AzureWebJobsServiceBus is required.");
+    return new ServiceBusClient(connection);
+});
+
+builder.Services.AddNimBus(n =>
+{
+    // Pure terminal subscriber — no outbox, no message-store, no publisher.
+    n.WithoutStorageProvider();
+});
+
+builder.Services.AddNimBusSubscriber("DataPlatformEndpoint", sub =>
+{
+    sub.AddHandler<ErpCustomerCreated, ErpCustomerCreatedHandler>();
+});
+
+builder.Build().Run();

--- a/samples/CrmErpDemo/DataPlatform.Adapter.Functions/host.json
+++ b/samples/CrmErpDemo/DataPlatform.Adapter.Functions/host.json
@@ -1,0 +1,23 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "serviceBus": {
+      "prefetchCount": 0,
+      "autoCompleteMessages": false,
+      "maxAutoLockRenewalDuration": "00:05:00",
+      "maxConcurrentSessions": 200,
+      "sessionIdleTimeout": "00:00:30",
+      "clientRetryOptions": {
+        "mode": "Exponential",
+        "tryTimeout": "00:01:00",
+        "delay": "00:00:00.8",
+        "maxDelay": "00:01:00",
+        "maxRetries": 3
+      }
+    }
+  }
+}

--- a/src/NimBus.sln
+++ b/src/NimBus.sln
@@ -130,6 +130,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NimBus.OpenTelemetry", "Nim
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NimBus.OpenTelemetry.Tests", "..\tests\NimBus.OpenTelemetry.Tests\NimBus.OpenTelemetry.Tests.csproj", "{F79BA0B6-0638-4097-862C-7214653F4EC7}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CrmErpDemo", "CrmErpDemo", "{D14C0353-EC22-5820-ED53-5D23171DF4D5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataPlatform.Adapter.Functions", "..\samples\CrmErpDemo\DataPlatform.Adapter.Functions\DataPlatform.Adapter.Functions.csproj", "{360CA61D-591F-46BA-8369-5C2DF645761D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -620,6 +624,18 @@ Global
 		{F79BA0B6-0638-4097-862C-7214653F4EC7}.Release|x64.Build.0 = Release|Any CPU
 		{F79BA0B6-0638-4097-862C-7214653F4EC7}.Release|x86.ActiveCfg = Release|Any CPU
 		{F79BA0B6-0638-4097-862C-7214653F4EC7}.Release|x86.Build.0 = Release|Any CPU
+		{360CA61D-591F-46BA-8369-5C2DF645761D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{360CA61D-591F-46BA-8369-5C2DF645761D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{360CA61D-591F-46BA-8369-5C2DF645761D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{360CA61D-591F-46BA-8369-5C2DF645761D}.Debug|x64.Build.0 = Debug|Any CPU
+		{360CA61D-591F-46BA-8369-5C2DF645761D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{360CA61D-591F-46BA-8369-5C2DF645761D}.Debug|x86.Build.0 = Debug|Any CPU
+		{360CA61D-591F-46BA-8369-5C2DF645761D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{360CA61D-591F-46BA-8369-5C2DF645761D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{360CA61D-591F-46BA-8369-5C2DF645761D}.Release|x64.ActiveCfg = Release|Any CPU
+		{360CA61D-591F-46BA-8369-5C2DF645761D}.Release|x64.Build.0 = Release|Any CPU
+		{360CA61D-591F-46BA-8369-5C2DF645761D}.Release|x86.ActiveCfg = Release|Any CPU
+		{360CA61D-591F-46BA-8369-5C2DF645761D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -671,6 +687,7 @@ Global
 		{D81E4A63-B7DE-4DBE-8058-7DD22E9BC24E} = {A49DBB53-46ED-4FC5-9654-D341671BE016}
 		{F5FB0651-AFDB-4514-8E96-19919E9381DC} = {A49DBB53-46ED-4FC5-9654-D341671BE016}
 		{15D12563-6551-4E81-9C8C-B8DC5AD8C52D} = {A49DBB53-46ED-4FC5-9654-D341671BE016}
+		{360CA61D-591F-46BA-8369-5C2DF645761D} = {D14C0353-EC22-5820-ED53-5D23171DF4D5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {58272779-594B-49E5-BA62-CBA32A55D9BA}


### PR DESCRIPTION
## Summary
Adds a third endpoint to the CrmErpDemo sample — \`DataPlatform\` — that subscribes **only** to \`ErpCustomerCreated\` and publishes nothing. A realistic \"downstream lake / analytics sink\" that exercises the one-publisher → many-consumers topology the demo didn't previously cover. Also surfaces a fan-out edge in the new Topology page once #50 merges.

No UI; hosting mirrors \`Erp.Adapter.Functions\` (Azure Functions Worker, v4, OutputType=Exe, dotnet-isolated).

## Changes
- **Contracts** — \`DataPlatformEndpoint : Endpoint\` with one \`Consumes<ErpCustomerCreated>()\`; registered in \`CrmErpPlatformConfiguration\`. The provisioner picks up the new topic/subscription on next AppHost run; emulator config builder already iterates \`platform.Endpoints\` so it flows through automatically.
- **\`DataPlatform.Adapter.Functions\`** *(new project)* — csproj mirrors Erp's package list verbatim. \`Program.cs\` keeps Erp's HostBuilder shape, prunes the HTTP clients and publisher: just \`AddNimBus(...WithoutStorageProvider())\` + \`AddNimBusSubscriber(\"DataPlatformEndpoint\", ...)\`. Single handler logs the inbound event (a real sink would write to ADLS/Snowflake here).
- **AppHost** — appended an \`AddAzureFunctionsProject<Projects.DataPlatform_Adapter_Functions>(\"dataplatform-adapter\")\` block alongside the existing Erp adapter, without the \`Erp.Api\` \`WithReference\`/\`WaitFor\` — DataPlatform doesn't call out to a backend, it just listens on the bus.
- **Solution** — added under the existing \`CrmErpDemo\` solution folder.

## Test plan
- [x] \`dotnet build src/NimBus.sln\` — 0 errors.
- [ ] \`dotnet run --project samples/CrmErpDemo/CrmErpDemo.AppHost\`:
  - \`dataplatform-adapter\` resource appears in the Aspire dashboard, transitions \`NotStarted → Running → Healthy\`.
  - Provisioner log reports a new topic/subscription pair for \`DataPlatformEndpoint\`.
- [ ] Trigger an \`ErpCustomerCreated\` (via the demo's CRM → ERP flow that ends in the Erp adapter publishing it). Within seconds, the \`dataplatform-adapter\` console logs:  
  \`DataPlatform received ErpCustomerCreated: AccountId=… CustomerNumber=… LegalName=… CountryCode=…\`
- [ ] On the management WebApp:
  - \`/Endpoints\` shows a \`DataPlatformEndpoint\` row.
  - \`/Topology\` (once #50 lands) shows a third endpoint card with \`P: 0 · S: 1\` and a subscribe edge from the bus.

## Out of scope (intentional)
- No business-logic side effect — handler logs only. A real DataPlatform would push to ADLS / Snowflake; that's a follow-up.
- No \`DataPlatform.Api\` / \`DataPlatform.Web\` companion projects — the user explicitly asked for no UI.
- No publishing — \`DataPlatform\` is a pure terminal subscriber.