### PR TITLE
fix: UTC timestamps in Cosmos/CLI + parallel endpoint status counts

### DIFF
--- a/src/NimBus.CommandLine/Container.cs
+++ b/src/NimBus.CommandLine/Container.cs
@@ -161,7 +161,7 @@ static class Container
 
             foreach (var @event in searchResponse.Events)
             {
-                if (@event.UpdatedAt < DateTime.Now.AddMinutes(-10))
+                if (@event.UpdatedAt < DateTime.UtcNow.AddMinutes(-10))
                 {
                     @event.ResolutionStatus = resolutionStatus;
                     @event.MessageType = MessageType.EventRequest;

--- a/src/NimBus.MessageStore.CosmosDb/CosmosDbClient.cs
+++ b/src/NimBus.MessageStore.CosmosDb/CosmosDbClient.cs
@@ -159,7 +159,7 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         return new EndpointStateCount
         {
             EndpointId = endpointId,
-            EventTime = DateTime.Now,
+            EventTime = DateTime.UtcNow,
             DeferredCount = resultDict.ContainsKey(DeferredStatus) ? resultDict[DeferredStatus] : 0,
             PendingCount = resultDict.ContainsKey(PendingStatus) ? resultDict[PendingStatus] : 0,
             FailedCount = resultDict.ContainsKey(FailedStatus) ? resultDict[FailedStatus] : 0,

--- a/src/NimBus.Testing/Conformance/InMemoryMessageStore.cs
+++ b/src/NimBus.Testing/Conformance/InMemoryMessageStore.cs
@@ -105,7 +105,7 @@ public class InMemoryMessageStore : INimBusMessageStore
         return Task.FromResult(new SearchResponse { Events = results });
     }
 
-    public Task<EndpointStateCount> DownloadEndpointStateCount(string endpointId)
+    public virtual Task<EndpointStateCount> DownloadEndpointStateCount(string endpointId)
     {
         var grouped = _events.Values.Where(e => e.EndpointId == endpointId).GroupBy(e => e.ResolutionStatus).ToDictionary(g => g.Key, g => g.Count());
         return Task.FromResult(new EndpointStateCount

--- a/src/NimBus.WebApp/Controllers/ApiContract/EndpointImplementation.cs
+++ b/src/NimBus.WebApp/Controllers/ApiContract/EndpointImplementation.cs
@@ -75,16 +75,22 @@ public class EndpointImplementation : IEndpointApiController
     {
         var endpointIds = platform.Endpoints
             .Where(endpoint => _authorizationService.IsManagerOfEndpoint(endpoint.Id) && ShowEndpoint(endpoint.Id))
-            .Select(e => e.Id);
+            .Select(e => e.Id)
+            .ToList();
 
-        var endpointStateCounts = new List<EndpointStateCount>();
+        // Each count is an independent storage aggregate query (~100-500ms against
+        // Cosmos); run them concurrently (bounded) rather than serially so a
+        // 40-endpoint list doesn't block for many seconds. Results go into a
+        // pre-sized array by index to preserve endpoint order.
+        var endpointStateCounts = new EndpointStateCount[endpointIds.Count];
 
         try
         {
-            foreach (var endpointId in endpointIds)
+            var countOptions = new ParallelOptions { MaxDegreeOfParallelism = Math.Min(System.Environment.ProcessorCount, 4) };
+            await Parallel.ForEachAsync(Enumerable.Range(0, endpointIds.Count), countOptions, async (i, _) =>
             {
-                endpointStateCounts.Add(await cosmosClient.DownloadEndpointStateCount(endpointId));
-            }
+                endpointStateCounts[i] = await cosmosClient.DownloadEndpointStateCount(endpointIds[i]);
+            });
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {

--- a/tests/NimBus.MessageStore.CosmosDb.Tests/CosmosDbClientUnitTests.cs
+++ b/tests/NimBus.MessageStore.CosmosDb.Tests/CosmosDbClientUnitTests.cs
@@ -1,0 +1,91 @@
+#pragma warning disable CA1707, CA2007
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace NimBus.MessageStore.CosmosDb.Tests;
+
+/// <summary>
+/// Pure unit tests for <see cref="CosmosDbClient"/> backed by fake adapters.
+/// Unlike the conformance suite these run without a live Cosmos account.
+/// </summary>
+[TestClass]
+public sealed class CosmosDbClientUnitTests
+{
+    [TestMethod]
+    public async Task DownloadEndpointStateCount_stamps_EventTime_in_utc()
+    {
+        var client = new CosmosDbClient(new FakeCosmosClientAdapter());
+
+        var state = await client.DownloadEndpointStateCount("endpoint-1");
+
+        Assert.AreEqual(DateTimeKind.Utc, state.EventTime.Kind,
+            "EventTime must be UTC — the SQL Server and in-memory stores stamp UtcNow; local time skews cross-provider comparisons.");
+        Assert.IsTrue(Math.Abs((DateTime.UtcNow - state.EventTime).TotalMinutes) < 1.0,
+            $"EventTime {state.EventTime:O} should be within a minute of DateTime.UtcNow.");
+    }
+
+    private sealed class FakeCosmosClientAdapter : ICosmosClientAdapter
+    {
+        public ICosmosDatabaseAdapter GetDatabase(string id) => new FakeDatabaseAdapter();
+    }
+
+    private sealed class FakeDatabaseAdapter : ICosmosDatabaseAdapter
+    {
+        public ICosmosContainerAdapter GetContainer(string id) => new FakeContainerAdapter();
+
+        public Task<ICosmosContainerAdapter> CreateContainerIfNotExistsAsync(string id, string partitionKeyPath)
+            => Task.FromResult<ICosmosContainerAdapter>(new FakeContainerAdapter());
+    }
+
+    private sealed class FakeContainerAdapter : ICosmosContainerAdapter
+    {
+        public FeedIterator<T> GetItemQueryIterator<T>(QueryDefinition queryDefinition)
+            => new EmptyFeedIterator<T>();
+
+        public FeedIterator<T> GetItemQueryIterator<T>(QueryDefinition queryDefinition, string? continuationToken = null, QueryRequestOptions? requestOptions = null)
+            => new EmptyFeedIterator<T>();
+
+        public FeedIterator<T> GetItemQueryIterator<T>(string queryText)
+            => new EmptyFeedIterator<T>();
+
+        public FeedIterator<T> GetItemQueryIterator<T>(string queryText, string? continuationToken = null, QueryRequestOptions? requestOptions = null)
+            => new EmptyFeedIterator<T>();
+
+        public IOrderedQueryable<T> GetItemLinqQueryable<T>(bool allowSynchronousQueryExecution = false, string? continuationToken = null, QueryRequestOptions? requestOptions = null)
+            => throw new NotSupportedException();
+
+        public Task<ItemResponse<T>> UpsertItemAsync<T>(T item, PartitionKey partitionKey = default)
+            => throw new NotSupportedException();
+
+        public Task<ItemResponse<T>> DeleteItemAsync<T>(string id, PartitionKey partitionKey)
+            => throw new NotSupportedException();
+
+        public Task<ItemResponse<T>> ReadItemAsync<T>(string id, PartitionKey partitionKey)
+            => throw new NotSupportedException();
+
+        public Task<ItemResponse<T>> ReadItemAsync<T>(string id, PartitionKey partitionKey, ItemRequestOptions requestOptions)
+            => throw new NotSupportedException();
+
+        public Task<ItemResponse<T>> PatchItemAsync<T>(string id, PartitionKey partitionKey, IReadOnlyList<PatchOperation> patchOperations)
+            => throw new NotSupportedException();
+
+        public Task<ContainerResponse> DeleteContainerAsync()
+            => throw new NotSupportedException();
+
+        public Task<FeedResponse<T>> ReadManyItemsAsync<T>(IReadOnlyList<(string id, PartitionKey partitionKey)> items)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class EmptyFeedIterator<T> : FeedIterator<T>
+    {
+        public override bool HasMoreResults => false;
+
+        public override Task<FeedResponse<T>> ReadNextAsync(CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Iterator is empty.");
+    }
+}

--- a/tests/NimBus.WebApp.Tests/EndpointStatusAllTests.cs
+++ b/tests/NimBus.WebApp.Tests/EndpointStatusAllTests.cs
@@ -1,0 +1,176 @@
+#pragma warning disable CA1707, CA2007
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NimBus.Core;
+using NimBus.Core.Endpoints;
+using NimBus.Core.Events;
+using NimBus.MessageStore;
+using NimBus.MessageStore.Abstractions;
+using NimBus.MessageStore.States;
+using NimBus.Testing.Conformance;
+using NimBus.WebApp.Controllers;
+using NimBus.WebApp.ManagementApi;
+using NimBus.WebApp.Services;
+
+namespace NimBus.WebApp.Tests;
+
+/// <summary>
+/// Behavior of <see cref="EndpointImplementation.EndpointstatusAllAsync"/>:
+/// per-endpoint state counts are independent storage aggregate queries
+/// (~100-500ms each against Cosmos), so they must run concurrently rather
+/// than serially, while preserving result order and the 404 mapping for
+/// missing endpoint storage.
+/// </summary>
+[TestClass]
+public sealed class EndpointStatusAllTests
+{
+    [TestMethod]
+    public async Task EndpointstatusAllAsync_downloads_counts_concurrently()
+    {
+        var store = new ConcurrencyTrackingStore();
+        var sut = CreateSut(store, "ep-1", "ep-2", "ep-3", "ep-4");
+
+        var result = await sut.EndpointstatusAllAsync();
+
+        var ok = result.Result as OkObjectResult;
+        Assert.IsNotNull(ok, $"Expected 200 OK, got {result.Result?.GetType().Name}");
+        Assert.IsTrue(store.MaxObservedConcurrency >= 2,
+            $"Expected per-endpoint count queries to overlap, but max observed concurrency was {store.MaxObservedConcurrency} (serial execution).");
+    }
+
+    [TestMethod]
+    public async Task EndpointstatusAllAsync_preserves_endpoint_order()
+    {
+        var store = new ConcurrencyTrackingStore();
+        var sut = CreateSut(store, "ep-1", "ep-2", "ep-3", "ep-4");
+
+        var result = await sut.EndpointstatusAllAsync();
+
+        var ok = result.Result as OkObjectResult;
+        Assert.IsNotNull(ok);
+        var counts = ((IEnumerable<EndpointStatusCount>)ok.Value).Select(c => c.EndpointId).ToList();
+        CollectionAssert.AreEqual(new List<string> { "ep-1", "ep-2", "ep-3", "ep-4" }, counts);
+    }
+
+    [TestMethod]
+    public async Task EndpointstatusAllAsync_maps_missing_endpoint_storage_to_404()
+    {
+        var store = new ConcurrencyTrackingStore { ThrowNotFoundFor = "ep-3" };
+        var sut = CreateSut(store, "ep-1", "ep-2", "ep-3", "ep-4");
+
+        var result = await sut.EndpointstatusAllAsync();
+
+        Assert.IsInstanceOfType(result.Result, typeof(NotFoundObjectResult));
+    }
+
+    private static EndpointImplementation CreateSut(INimBusMessageStore store, params string[] endpointIds)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { ["Environment"] = "dev" })
+            .Build();
+
+        return new EndpointImplementation(
+            new HttpContextAccessor { HttpContext = new DefaultHttpContext() },
+            new FakePlatform(endpointIds),
+            configuration,
+            store,
+            serviceBusManagement: null,
+            new AllowAllAuthorizationService(),
+            NullLogger<EndpointImplementation>.Instance,
+            auditLogService: null);
+    }
+
+    /// <summary>
+    /// In-memory store whose <see cref="DownloadEndpointStateCount"/> holds each
+    /// call open briefly and records how many calls were in flight at once.
+    /// </summary>
+    private sealed class ConcurrencyTrackingStore : InMemoryMessageStore
+    {
+        private int _inFlight;
+        private int _maxObserved;
+
+        public string? ThrowNotFoundFor { get; init; }
+
+        public int MaxObservedConcurrency => Volatile.Read(ref _maxObserved);
+
+        public override async Task<EndpointStateCount> DownloadEndpointStateCount(string endpointId)
+        {
+            if (endpointId == ThrowNotFoundFor)
+            {
+                throw new EndpointNotFoundException(endpointId);
+            }
+
+            var inFlight = Interlocked.Increment(ref _inFlight);
+            try
+            {
+                int seen;
+                while (inFlight > (seen = Volatile.Read(ref _maxObserved)) &&
+                       Interlocked.CompareExchange(ref _maxObserved, inFlight, seen) != seen)
+                {
+                }
+
+                // Hold the call open long enough for overlapping queries to be observable.
+                await Task.Delay(100);
+                return await base.DownloadEndpointStateCount(endpointId);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _inFlight);
+            }
+        }
+    }
+
+    private sealed class FakePlatform : IPlatform
+    {
+        private readonly List<IEndpoint> _endpoints;
+
+        public FakePlatform(IEnumerable<string> endpointIds)
+        {
+            _endpoints = endpointIds.Select(id => (IEndpoint)new FakeEndpoint(id)).ToList();
+        }
+
+        public IEnumerable<IEndpoint> Endpoints => _endpoints;
+
+        public IEnumerable<IEventType> EventTypes => Enumerable.Empty<IEventType>();
+
+        public IEnumerable<IEndpoint> GetConsumers(IEventType eventType) => Enumerable.Empty<IEndpoint>();
+
+        public IEnumerable<IEndpoint> GetProducers(IEventType eventType) => Enumerable.Empty<IEndpoint>();
+    }
+
+    private sealed class FakeEndpoint : IEndpoint
+    {
+        public FakeEndpoint(string id)
+        {
+            Id = id;
+        }
+
+        public string Id { get; }
+        public string Name => Id;
+        public string Description => string.Empty;
+        public string Namespace => string.Empty;
+        public string SecurityGroupName => string.Empty;
+        public ISystem System => null!;
+        public IEnumerable<IEventType> EventTypesProduced => Enumerable.Empty<IEventType>();
+        public IEnumerable<IEventType> EventTypesConsumed => Enumerable.Empty<IEventType>();
+        public IEnumerable<IRoleAssignment> RoleAssignments => Enumerable.Empty<IRoleAssignment>();
+    }
+
+    private sealed class AllowAllAuthorizationService : IEndpointAuthorizationService
+    {
+        public bool IsManagerOfEndpoint(string endpointId) => true;
+
+        [Obsolete("Bridge member required by the interface; not used in these tests.")]
+        public MessageAuditEntity GetMessageAuditEntity(MessageAuditType type) => throw new NotSupportedException();
+
+        public string GetCurrentUserName() => "test-user";
+    }
+}


### PR DESCRIPTION
## Summary

First batch of fixes from the codebase analysis: two timestamp-correctness bugs and the highest-impact WebApp latency win.

- **`CosmosDbClient.DownloadEndpointStateCount` stamped `EventTime = DateTime.Now`** (local time) while the SQL Server and in-memory stores stamp `DateTime.UtcNow` — the same endpoint reported different `EventTime` values depending on the storage provider.
- **The CLI resubmit eligibility check compared the UTC `UpdatedAt` field against `DateTime.Now`**, skewing the 10-minute age threshold by the host timezone offset. The WebApp equivalent (`AdminService.Resubmit`) already uses `UtcNow`.
- **`EndpointstatusAllAsync` awaited `DownloadEndpointStateCount` serially per endpoint.** Each call is an independent Cosmos aggregate query (~100-500ms), so a 40-endpoint monitor page blocked for seconds. Counts now run via `Parallel.ForEachAsync` with the same bounded concurrency (`min(ProcessorCount, 4)`) the subscription probes in the same file already use, writing into a pre-sized array to preserve endpoint order. The 404 mappings (`CosmosException`/`EndpointNotFoundException`) are unchanged and covered by tests.

## Tests

- New `CosmosDbClientUnitTests` — fake-adapter unit test asserting `EventTime` is UTC; runs without a live Cosmos account (unlike the conformance suite). Watched it fail (`Expected:<Utc>. Actual:<Local>`) before the fix.
- New `EndpointStatusAllTests` — asserts the count queries overlap (failed with "max observed concurrency was 1" against the serial code), plus pinning tests for result order and the 404 mapping.
- `InMemoryMessageStore.DownloadEndpointStateCount` is now `virtual` so tests can observe call concurrency through a subclass.
- Full solution suite: 0 failures (Cosmos live conformance / SQL Server suites skipped as usual without backing services).

Note: the CLI one-liner has no unit test — the logic lives in a private static method in `Container.cs` and extracting it for testability felt disproportionate for a `Now` → `UtcNow` swap.