### PR TITLE
perf: Cosmos query hygiene, batched purges, binder cache + Serilog-to-MEL migration

### DIFF
--- a/src/NimBus.MessageStore.CosmosDb/CosmosDbClient.cs
+++ b/src/NimBus.MessageStore.CosmosDb/CosmosDbClient.cs
@@ -1,4 +1,4 @@
-﻿using Serilog;
+﻿using Microsoft.Extensions.Logging;
 using NimBus.Core.Messages;
 using NimBus.MessageStore.Abstractions;
 using NimBus.MessageStore.States;
@@ -125,16 +125,58 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
     private const string MessagesContainer = "messages";
     private const string AuditsContainer = "audits";
 
-    public CosmosDbClient(CosmosClient cosmosClient, ILogger logger = null)
+    public CosmosDbClient(CosmosClient cosmosClient, ILogger<CosmosDbClient> logger = null)
     {
         _cosmosClient = new CosmosClientAdapter(cosmosClient);
         _logger = logger;
     }
 
-    public CosmosDbClient(ICosmosClientAdapter cosmosClient, ILogger logger = null)
+    public CosmosDbClient(ICosmosClientAdapter cosmosClient, ILogger<CosmosDbClient> logger = null)
     {
         _cosmosClient = cosmosClient;
         _logger = logger;
+    }
+
+    [Obsolete("Use the Microsoft.Extensions.Logging constructor — NimBus standardizes on Microsoft.Extensions.Logging (ADR-006). This bridge remains for callers that still pass a Serilog logger.")]
+    public CosmosDbClient(CosmosClient cosmosClient, Serilog.ILogger logger)
+    {
+        _cosmosClient = new CosmosClientAdapter(cosmosClient);
+        _logger = logger is null ? null : new SerilogBridgeLogger(logger);
+    }
+
+    [Obsolete("Use the Microsoft.Extensions.Logging constructor — NimBus standardizes on Microsoft.Extensions.Logging (ADR-006). This bridge remains for callers that still pass a Serilog logger.")]
+    public CosmosDbClient(ICosmosClientAdapter cosmosClient, Serilog.ILogger logger)
+    {
+        _cosmosClient = cosmosClient;
+        _logger = logger is null ? null : new SerilogBridgeLogger(logger);
+    }
+
+    /// <summary>
+    /// Forwards Microsoft.Extensions.Logging calls to a caller-supplied Serilog logger.
+    /// Only used by the obsolete bridge constructors.
+    /// </summary>
+    private sealed class SerilogBridgeLogger : ILogger
+    {
+        private readonly Serilog.ILogger _serilog;
+
+        public SerilogBridgeLogger(Serilog.ILogger serilog) => _serilog = serilog;
+
+        public IDisposable BeginScope<TState>(TState state) => null;
+
+        public bool IsEnabled(LogLevel logLevel) => _serilog.IsEnabled(ToSerilogLevel(logLevel));
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            => _serilog.Write(ToSerilogLevel(logLevel), exception, "{Message}", formatter(state, exception));
+
+        private static Serilog.Events.LogEventLevel ToSerilogLevel(LogLevel level) => level switch
+        {
+            LogLevel.Trace => Serilog.Events.LogEventLevel.Verbose,
+            LogLevel.Debug => Serilog.Events.LogEventLevel.Debug,
+            LogLevel.Information => Serilog.Events.LogEventLevel.Information,
+            LogLevel.Warning => Serilog.Events.LogEventLevel.Warning,
+            LogLevel.Error => Serilog.Events.LogEventLevel.Error,
+            _ => Serilog.Events.LogEventLevel.Fatal,
+        };
     }
 
 
@@ -317,12 +359,12 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         }
         catch (CosmosException e) when (e.StatusCode == HttpStatusCode.NotFound)
         {
-            _logger?.Information($"COSMOS PAGING: Endpoint container not found for '{endpointId}'");
+            _logger?.LogInformation("COSMOS PAGING: Endpoint container not found for '{EndpointId}'", endpointId);
             return null;
         }
         catch (Exception e)
         {
-            _logger?.Error(e, $"COSMOS PAGING-ERROR: Failed to download endpoint state for '{endpointId}'");
+            _logger?.LogError(e, "COSMOS PAGING-ERROR: Failed to download endpoint state for '{EndpointId}'", endpointId);
             throw;
         }
     }
@@ -375,14 +417,14 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         try
         {
             var response = await container.UpsertItemAsync(eventDbo, new PartitionKey(eventDbo.Id));
-            _logger?.Verbose(
-                $"COSMOS UPSERT-RESPONSE: EventId: {eventId}, SessionId: {sessionId}, HttpStatusCode: {response.StatusCode}, Status : {CompletedStatus}");
+            _logger?.LogTrace(
+                "COSMOS UPSERT-RESPONSE: EventId: {EventId}, SessionId: {SessionId}, HttpStatusCode: {StatusCode}, Status: {Status}", eventId, sessionId, response.StatusCode, CompletedStatus);
             return true;
         }
         catch (CosmosException e)
         {
-            _logger?.Error(e,
-                $"COSMOS UPSERT-ERROR: EventId: {eventId}, SessionId: {sessionId}, Status : {CompletedStatus}");
+            _logger?.LogError(e,
+                "COSMOS UPSERT-ERROR: EventId: {EventId}, SessionId: {SessionId}, Status: {Status}", eventId, sessionId, CompletedStatus);
 
             if (e.StatusCode == HttpStatusCode.TooManyRequests)
             {
@@ -413,8 +455,8 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
                     updateEvent.Deleted = true;
                     updateEvent.TimeToLive = 60; // 1 Minute
                     var response = await container.UpsertItemAsync<EventDbo>(updateEvent, new PartitionKey(updateEvent.Id));
-                    _logger?.Verbose(
-                        $"COSMOS REMOVE-MESSAGE: EventId: {eventId}, SessionId: {sessionId}, HttpStatusCode: {response.StatusCode}");
+                    _logger?.LogTrace(
+                        "COSMOS REMOVE-MESSAGE: EventId: {EventId}, SessionId: {SessionId}, HttpStatusCode: {StatusCode}", eventId, sessionId, response.StatusCode);
                     return true;
                 }
             }
@@ -423,8 +465,8 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         }
         catch (CosmosException e)
         {
-            _logger?.Error(e,
-                $"COSMOS REMOVE-MESSAGE: EventId: {eventId}, SessionId: {sessionId}, HttpStatusCode: {e.StatusCode}");
+            _logger?.LogError(e,
+                "COSMOS REMOVE-MESSAGE: EventId: {EventId}, SessionId: {SessionId}, HttpStatusCode: {StatusCode}", eventId, sessionId, e.StatusCode);
 
             if (e.StatusCode == HttpStatusCode.NotFound)
             {
@@ -445,28 +487,34 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         try
         {
             var container = await GetEndpointContainer(endpointId);
-            var queryDefinition = new QueryDefinition("SELECT * FROM c WHERE c.sessionId = @sessionId")
+            // Only the id is needed for the deletes — don't pull whole EventDbo
+            // documents (the EventJson payload dominates the response size).
+            var queryDefinition = new QueryDefinition("SELECT c.id FROM c WHERE c.sessionId = @sessionId")
                 .WithParameter("@sessionId", sessionId);
-            var result = container.GetItemQueryIterator<EventDbo>(queryDefinition);
+            var result = container.GetItemQueryIterator<IdProjection>(queryDefinition);
 
-            _logger?.Information(
-                $"COSMOS PURGE: Deleted all messages on endpoint {endpointId} in session {sessionId}");
+            _logger?.LogInformation(
+                "COSMOS PURGE: Deleted all messages on endpoint {EndpointId} in session {SessionId}", endpointId, sessionId);
+            // The container is partitioned by /id, so each document lives in its own
+            // logical partition and a TransactionalBatch (single-partition only) can't
+            // apply. The deletes are independent — run them concurrently (bounded)
+            // instead of one round-trip at a time.
+            var deleteOptions = new ParallelOptions { MaxDegreeOfParallelism = 8 };
             while (result.HasMoreResults)
             {
-                var eventDbo = await result.ReadNextAsync();
-                if (eventDbo.Any())
+                var page = await result.ReadNextAsync();
+                await Parallel.ForEachAsync(page, deleteOptions, async (item, _) =>
                 {
-                    foreach (var queryResult in eventDbo)
-                        await container.DeleteItemAsync<EventDbo>(queryResult.Id, new PartitionKey(queryResult.Id));
-                }
+                    await container.DeleteItemAsync<EventDbo>(item.Id, new PartitionKey(item.Id));
+                });
             }
 
             return true;
         }
         catch (Exception e)
         {
-            _logger?.Error(e,
-                $"COSMOS PURGE: Couldn't delete all messages on endpoint {endpointId} in session {sessionId}");
+            _logger?.LogError(e,
+                "COSMOS PURGE: Couldn't delete all messages on endpoint {EndpointId} in session {SessionId}", endpointId, sessionId);
             return false;
         }
     }
@@ -478,13 +526,13 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
             var container = await GetEndpointContainer(endpointId);
 
             await container.DeleteContainerAsync();
-            _logger?.Information($"COSMOS PURGE: Deleted all messages on endpoint {endpointId}");
+            _logger?.LogInformation("COSMOS PURGE: Deleted all messages on endpoint {EndpointId}", endpointId);
 
             return true;
         }
         catch (Exception e)
         {
-            _logger?.Error(e, $"COSMOS PURGE: Couldn't delete all messages on endpoint {endpointId}");
+            _logger?.LogError(e, "COSMOS PURGE: Couldn't delete all messages on endpoint {EndpointId}", endpointId);
             return false;
         }
     }
@@ -729,8 +777,10 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
     public async Task<IEnumerable<UnresolvedEvent>> GetCompletedEventsOnEndpoint(string endpointId)
     {
         var container = await GetEndpointContainer(endpointId);
-        var sqlQuery = $"SELECT * FROM c WHERE c.status ='{CompletedStatus}'";
-        var result = container.GetItemQueryIterator<EventDbo>(sqlQuery, null, new QueryRequestOptions { });
+        // Parameterized rather than interpolated so the SDK can cache the query plan.
+        var queryDefinition = new QueryDefinition("SELECT * FROM c WHERE c.status = @status")
+            .WithParameter("@status", CompletedStatus);
+        var result = container.GetItemQueryIterator<EventDbo>(queryDefinition, null, new QueryRequestOptions { });
         var unresolvedEvents = new List<UnresolvedEvent>();
 
         while (result.HasMoreResults)
@@ -753,29 +803,23 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
 
         var container = await GetEndpointContainer(endpointId);
 
+        // Only four fields feed BlockedMessageEvent — project them server-side
+        // instead of reading whole EventDbo documents (large EventJson payloads).
         var pageQuery = new QueryDefinition(
-            "SELECT * FROM c WHERE c.sessionId = @sessionId AND c.status IN (@pendingStatus, @deferredStatus) AND (NOT IS_DEFINED(c.deleted) or c.deleted != true) ORDER BY c.event.UpdatedAt DESC OFFSET @skip LIMIT @take")
+            "SELECT c.status, c.event.EventId AS eventId, c.event.OriginatingMessageId AS originatingMessageId, c.event.LastMessageId AS lastMessageId FROM c WHERE c.sessionId = @sessionId AND c.status IN (@pendingStatus, @deferredStatus) AND (NOT IS_DEFINED(c.deleted) or c.deleted != true) ORDER BY c.event.UpdatedAt DESC OFFSET @skip LIMIT @take")
             .WithParameter("@sessionId", sessionId)
             .WithParameter("@pendingStatus", PendingStatus)
             .WithParameter("@deferredStatus", DeferredStatus)
             .WithParameter("@skip", safeSkip)
             .WithParameter("@take", safeTake);
-        var pageIterator = container.GetItemQueryIterator<EventDbo>(pageQuery);
+        var pageIterator = container.GetItemQueryIterator<BlockedEventProjection>(pageQuery);
         var items = new List<BlockedMessageEvent>();
         while (pageIterator.HasMoreResults)
         {
-            var eventDbo = await pageIterator.ReadNextAsync();
-            foreach (var queryResult in eventDbo)
+            var page = await pageIterator.ReadNextAsync();
+            foreach (var queryResult in page)
             {
-                items.Add(new BlockedMessageEvent
-                {
-                    EventId = queryResult.Event.EventId,
-                    OriginatingId =
-                        queryResult.Event.OriginatingMessageId.Equals("self", StringComparison.OrdinalIgnoreCase)
-                            ? queryResult.Event.LastMessageId
-                            : queryResult.Event.OriginatingMessageId,
-                    Status = queryResult.Status
-                });
+                items.Add(ToBlockedMessageEvent(queryResult));
             }
         }
 
@@ -825,12 +869,12 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         }
         catch (CosmosException e) when (e.StatusCode == HttpStatusCode.NotFound)
         {
-            _logger?.Information($"COSMOS PENDING-EVENTS: Endpoint container not found for '{endpointId}'");
+            _logger?.LogInformation("COSMOS PENDING-EVENTS: Endpoint container not found for '{EndpointId}'", endpointId);
             return null;
         }
         catch (Exception e)
         {
-            _logger?.Error(e, $"COSMOS PENDING-EVENTS-ERROR: Failed to get pending events for endpoint '{endpointId}'");
+            _logger?.LogError(e, "COSMOS PENDING-EVENTS-ERROR: Failed to get pending events for endpoint '{EndpointId}'", endpointId);
             throw;
         }
 
@@ -840,25 +884,20 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
     public async Task<IEnumerable<BlockedMessageEvent>> GetInvalidEventsOnSession(string endpointId)
     {
         var container = await GetEndpointContainer(endpointId);
-        var sqlQuery =
-            $"SELECT * FROM c WHERE c.event.EndpointRole = '{PublisherRole}' AND (NOT IS_DEFINED(c.deleted) or c.deleted != true)";
-        var result = container.GetItemQueryIterator<EventDbo>(sqlQuery);
+        // Parameterized for query-plan caching; projected because only four fields
+        // feed BlockedMessageEvent (full documents carry the EventJson payload).
+        var queryDefinition = new QueryDefinition(
+            "SELECT c.status, c.event.EventId AS eventId, c.event.OriginatingMessageId AS originatingMessageId, c.event.LastMessageId AS lastMessageId FROM c WHERE c.event.EndpointRole = @publisherRole AND (NOT IS_DEFINED(c.deleted) or c.deleted != true)")
+            .WithParameter("@publisherRole", PublisherRole);
+        var result = container.GetItemQueryIterator<BlockedEventProjection>(queryDefinition);
         var invalidMessageEvents = new List<BlockedMessageEvent>();
 
         while (result.HasMoreResults)
         {
-            var eventDbo = await result.ReadNextAsync();
-            foreach (var queryResult in eventDbo)
+            var page = await result.ReadNextAsync();
+            foreach (var queryResult in page)
             {
-                invalidMessageEvents.Add(new BlockedMessageEvent
-                {
-                    EventId = queryResult.Event.EventId,
-                    OriginatingId =
-                        queryResult.Event.OriginatingMessageId.Equals("self", StringComparison.OrdinalIgnoreCase)
-                            ? queryResult.Event.LastMessageId
-                            : queryResult.Event.OriginatingMessageId,
-                    Status = queryResult.Status
-                });
+                invalidMessageEvents.Add(ToBlockedMessageEvent(queryResult));
             }
         }
 
@@ -895,13 +934,13 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
 
         if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Created)
         {
-            _logger?.Verbose(
-                $"COSMOS SUBSCRIPTION: endpointId: {subscription.EndpointId}, SubscriptionId: {subscription.Id}, HttpStatusCode: {response.StatusCode}");
+            _logger?.LogTrace(
+                "COSMOS SUBSCRIPTION: endpointId: {EndpointId}, SubscriptionId: {SubscriptionId}, HttpStatusCode: {StatusCode}", subscription.EndpointId, subscription.Id, response.StatusCode);
             return subscription;
         }
 
-        _logger?.Error(
-            $"COSMOS SUBSCRIPTION ERROR: endpointId: {subscription.EndpointId}, SubscriptionId: {subscription.Id}, HttpStatusCode: {response.StatusCode}");
+        _logger?.LogError(
+            "COSMOS SUBSCRIPTION ERROR: endpointId: {EndpointId}, SubscriptionId: {SubscriptionId}, HttpStatusCode: {StatusCode}", subscription.EndpointId, subscription.Id, response.StatusCode);
         return null; //Return error?
     }
 
@@ -984,14 +1023,14 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         try
         {
             var response = await subscriptionContainer.DeleteItemAsync<SubscriptionDbo>(subscriptionId, new PartitionKey(subscriptionId));
-            _logger?.Verbose(
-                $"COSMOS REMOVE-SUBSCRIPTION: SubscriptionId: {subscriptionId}, HttpStatusCode: {response.StatusCode}");
+            _logger?.LogTrace(
+                "COSMOS REMOVE-SUBSCRIPTION: SubscriptionId: {SubscriptionId}, HttpStatusCode: {StatusCode}", subscriptionId, response.StatusCode);
             return true;
         }
         catch (Exception e)
         {
-            _logger?.Error(
-                $"COSMOS REMOVE-SUBSCRIPTION: SubscriptionId: {subscriptionId}, Exception: {e.Message}");
+            _logger?.LogError(e,
+                "COSMOS REMOVE-SUBSCRIPTION: SubscriptionId: {SubscriptionId}", subscriptionId);
             return false;
         }
     }
@@ -1004,14 +1043,14 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         try
         {
             var response = await subscriptionContainer.DeleteItemAsync<SubscriptionDbo>(id, new PartitionKey(id));
-            _logger?.Verbose(
-                $"COSMOS REMOVE-SUBSCRIPTION: endpointId: {endpointId}, SubscriptionId: {id}, HttpStatusCode: {response.StatusCode}");
+            _logger?.LogTrace(
+                "COSMOS REMOVE-SUBSCRIPTION: endpointId: {EndpointId}, SubscriptionId: {SubscriptionId}, HttpStatusCode: {StatusCode}", endpointId, id, response.StatusCode);
             return true;
         }
         catch (Exception e)
         {
-            _logger?.Error(
-                $"COSMOS REMOVE-SUBSCRIPTION: endpointId: {endpointId}, SubscriptionId: {id}, Exception: {e.Message}");
+            _logger?.LogError(e,
+                "COSMOS REMOVE-SUBSCRIPTION: endpointId: {EndpointId}, SubscriptionId: {SubscriptionId}", endpointId, id);
             return false;
         }
     }
@@ -1043,8 +1082,8 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         }
         catch (Exception e)
         {
-            _logger?.Error(e,
-                $"COSMOS UPDATE-SUBSCRIPTION: Endpoint: {subscription.EndpointId}, SubscriptionId: {subscription.Id}, Exception: {e.Message}");
+            _logger?.LogError(e,
+                "COSMOS UPDATE-SUBSCRIPTION: Endpoint: {EndpointId}, SubscriptionId: {SubscriptionId}", subscription.EndpointId, subscription.Id);
             return false;
         }
     }
@@ -1055,10 +1094,12 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         // Only the id is used by the caller — project it server-side instead of
         // reading whole EventDbo documents (large EventJson / stack traces), which
         // cut RU and payload by 10-50x. Accumulate then join once (no O(n^2) concat).
-        var sqlQuery =
-            $"SELECT c.id FROM c WHERE c.status IN ('{FailedStatus}', '{DeferredStatus}') AND (NOT IS_DEFINED(c.deleted) or c.deleted != true)";
+        var queryDefinition = new QueryDefinition(
+            "SELECT c.id FROM c WHERE c.status IN (@failedStatus, @deferredStatus) AND (NOT IS_DEFINED(c.deleted) or c.deleted != true)")
+            .WithParameter("@failedStatus", FailedStatus)
+            .WithParameter("@deferredStatus", DeferredStatus);
 
-        var result = container.GetItemQueryIterator<IdProjection>(sqlQuery);
+        var result = container.GetItemQueryIterator<IdProjection>(queryDefinition);
         var ids = new List<string>();
         while (result.HasMoreResults)
         {
@@ -1077,6 +1118,26 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
     {
         [JsonProperty("id")] public string Id { get; set; }
     }
+
+    /// <summary>
+    /// Server-side projection of the four fields that feed <see cref="BlockedMessageEvent"/>.
+    /// </summary>
+    private sealed class BlockedEventProjection
+    {
+        [JsonProperty("status")] public string Status { get; set; }
+        [JsonProperty("eventId")] public string EventId { get; set; }
+        [JsonProperty("originatingMessageId")] public string OriginatingMessageId { get; set; }
+        [JsonProperty("lastMessageId")] public string LastMessageId { get; set; }
+    }
+
+    private static BlockedMessageEvent ToBlockedMessageEvent(BlockedEventProjection projection) => new()
+    {
+        EventId = projection.EventId,
+        OriginatingId = projection.OriginatingMessageId.Equals("self", StringComparison.OrdinalIgnoreCase)
+            ? projection.LastMessageId
+            : projection.OriginatingMessageId,
+        Status = projection.Status,
+    };
 
     private async Task<ICosmosContainerAdapter> GetEndpointContainer(string endpointId)
     {
@@ -1229,7 +1290,7 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         }
         catch (CosmosException e)
         {
-            _logger?.Error(e, $"COSMOS STORE-MESSAGE-ERROR: EventId: {message.EventId}, MessageId: {message.MessageId}");
+            _logger?.LogError(e, "COSMOS STORE-MESSAGE-ERROR: EventId: {EventId}, MessageId: {MessageId}", message.EventId, message.MessageId);
 
             if (e.StatusCode == HttpStatusCode.TooManyRequests)
             {
@@ -1373,7 +1434,7 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         }
         catch (CosmosException e)
         {
-            _logger?.Error(e, $"COSMOS STORE-AUDIT-ERROR: EventId: {eventId}");
+            _logger?.LogError(e, "COSMOS STORE-AUDIT-ERROR: EventId: {EventId}", eventId);
 
             if (e.StatusCode == HttpStatusCode.TooManyRequests)
             {
@@ -1514,7 +1575,7 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         }
         catch (CosmosException e) when (e.StatusCode == HttpStatusCode.NotFound)
         {
-            _logger?.Verbose($"COSMOS ARCHIVE-FAILED: Event not found. EventId: {eventId}, SessionId: {sessionId}, EndpointId: {endpointId}");
+            _logger?.LogTrace("COSMOS ARCHIVE-FAILED: Event not found. EventId: {EventId}, SessionId: {SessionId}, EndpointId: {EndpointId}", eventId, sessionId, endpointId);
         }
     }
 
@@ -1537,14 +1598,14 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         try
         {
             var response = await container.UpsertItemAsync(eventDbo, new PartitionKey(eventDbo.Id));
-            _logger?.Verbose(
-                $"COSMOS UPSERT-RESPONSE: EventId: {eventId}, SessionId: {sessionId}, HttpStatusCode: {response.StatusCode}, Status : {status}");
+            _logger?.LogTrace(
+                "COSMOS UPSERT-RESPONSE: EventId: {EventId}, SessionId: {SessionId}, HttpStatusCode: {StatusCode}, Status: {Status}", eventId, sessionId, response.StatusCode, status);
             return true;
         }
         catch (CosmosException e)
         {
-            _logger?.Error(e,
-                $"COSMOS UPSERT-ERROR: EventId: {eventId}, SessionId: {sessionId}, Status : {status}, HttpStatusCode: {e.StatusCode}");
+            _logger?.LogError(e,
+                "COSMOS UPSERT-ERROR: EventId: {EventId}, SessionId: {SessionId}, Status: {Status}, HttpStatusCode: {StatusCode}", eventId, sessionId, status, e.StatusCode);
 
             if (e.StatusCode == HttpStatusCode.TooManyRequests)
             {
@@ -1590,19 +1651,19 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         }
         catch (CosmosException e) when (e.StatusCode == HttpStatusCode.NotFound)
         {
-            _logger?.Information($"COSMOS METADATAS: Some endpoints not found in metadata container");
+            _logger?.LogInformation("COSMOS METADATAS: Some endpoints not found in metadata container");
             return null;
         }
         catch (Exception e)
         {
-            _logger?.Error(e, $"COSMOS METADATAS-ERROR: Failed to get metadatas for endpoints");
+            _logger?.LogError(e, "COSMOS METADATAS-ERROR: Failed to get metadatas for endpoints");
             throw;
         }
     }
 
     public async Task<List<EndpointMetadata>> GetMetadatas()
     {
-        var sqlQuery = $"SELECT * FROM c";
+        var sqlQuery = "SELECT * FROM c";
         var metadatas = await GetMetadatasByFilter(sqlQuery);
 
         return metadatas;
@@ -1633,14 +1694,14 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         {
             var response =
                 await container.UpsertItemAsync(endpointMetadata, new PartitionKey(endpointMetadata.EndpointId));
-            _logger?.Verbose(
-                $"COSMOS UPSERT-RESPONSE: Metadata upsert. Id: {endpointMetadata.EndpointId}, HttpStatusCode: {response.StatusCode}");
+            _logger?.LogTrace(
+                "COSMOS UPSERT-RESPONSE: Metadata upsert. Id: {EndpointId}, HttpStatusCode: {StatusCode}", endpointMetadata.EndpointId, response.StatusCode);
             return true;
         }
         catch (CosmosException e)
         {
-            _logger?.Error(e,
-                $"COSMOS UPSERT-ERROR: Metadata upsert. Id: {endpointMetadata.EndpointId}, HttpStatusCode: {e.StatusCode}");
+            _logger?.LogError(e,
+                "COSMOS UPSERT-ERROR: Metadata upsert. Id: {EndpointId}, HttpStatusCode: {StatusCode}", endpointMetadata.EndpointId, e.StatusCode);
 
             if (e.StatusCode == HttpStatusCode.TooManyRequests)
             {

--- a/src/NimBus.MessageStore.CosmosDb/CosmosDbMessageStoreBuilderExtensions.cs
+++ b/src/NimBus.MessageStore.CosmosDb/CosmosDbMessageStoreBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Azure.Identity;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NimBus.Core.Diagnostics;
 using NimBus.Core.Extensions;
@@ -38,7 +39,7 @@ public static class CosmosDbMessageStoreBuilderExtensions
         services.AddSingleton<ICosmosDbClient>(sp =>
         {
             var cosmosClient = sp.GetRequiredService<CosmosClient>();
-            return new CosmosDbClient(cosmosClient);
+            return new CosmosDbClient(cosmosClient, sp.GetService<ILogger<CosmosDbClient>>());
         });
 
         RegisterContracts(services);
@@ -53,7 +54,8 @@ public static class CosmosDbMessageStoreBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(cosmosClient);
         builder.Services.AddSingleton(cosmosClient);
-        builder.Services.AddSingleton<ICosmosDbClient>(sp => new CosmosDbClient(cosmosClient));
+        builder.Services.AddSingleton<ICosmosDbClient>(sp =>
+            new CosmosDbClient(cosmosClient, sp.GetService<ILogger<CosmosDbClient>>()));
         RegisterContracts(builder.Services);
         return builder;
     }

--- a/src/NimBus.MessageStore.CosmosDb/NimBus.MessageStore.CosmosDb.csproj
+++ b/src/NimBus.MessageStore.CosmosDb/NimBus.MessageStore.CosmosDb.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0-preview.1.25120.3" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
 	<PackageReference Include="Microsoft.Identity.Client" Version="4.81.0" />

--- a/src/NimBus.Testing/Conformance/MessageTrackingStoreConformanceTests.cs
+++ b/src/NimBus.Testing/Conformance/MessageTrackingStoreConformanceTests.cs
@@ -398,6 +398,29 @@ public abstract class MessageTrackingStoreConformanceTests
     }
 
     [TestMethod]
+    public async Task PurgeMessages_removes_only_the_target_session()
+    {
+        var store = CreateStore();
+        var endpointId = Id("ep-purge");
+        var purgedPendingId = Id("purge-pending");
+        var purgedDeferredId = Id("purge-deferred");
+        var keptId = Id("purge-kept");
+        await store.UploadPendingMessage(purgedPendingId, "session-purged", endpointId, SampleEvent(endpointId, purgedPendingId, "session-purged"));
+        await store.UploadDeferredMessage(purgedDeferredId, "session-purged", endpointId, SampleEvent(endpointId, purgedDeferredId, "session-purged"));
+        await store.UploadPendingMessage(keptId, "session-kept", endpointId, SampleEvent(endpointId, keptId, "session-kept"));
+
+        var purged = await store.PurgeMessages(endpointId, "session-purged");
+
+        Assert.IsTrue(purged);
+        var purgedPage = await store.GetBlockedEventsOnSession(endpointId, "session-purged", 0, 100);
+        Assert.AreEqual(0, purgedPage.Total);
+        Assert.AreEqual(0, purgedPage.Items.Count);
+        var keptPage = await store.GetBlockedEventsOnSession(endpointId, "session-kept", 0, 100);
+        Assert.AreEqual(1, keptPage.Total);
+        Assert.IsTrue(keptPage.Items.Any(e => e.EventId == keptId));
+    }
+
+    [TestMethod]
     public async Task GetBlockedEventsOnSession_pages_results_and_reports_total()
     {
         var store = CreateStore();

--- a/src/NimBus.WebApp/EnumMemberModelBinder.cs
+++ b/src/NimBus.WebApp/EnumMemberModelBinder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -23,8 +24,26 @@ public class EnumMemberModelBinderProvider : IModelBinderProvider
 public class EnumMemberModelBinder : IModelBinder
 {
     private readonly Type _enumType;
+    private readonly Dictionary<string, object> _valueMap;
 
-    public EnumMemberModelBinder(Type enumType) => _enumType = enumType;
+    public EnumMemberModelBinder(Type enumType)
+    {
+        _enumType = enumType;
+
+        // The binder is cached per model type by MVC, so reflect once here instead
+        // of on every bind. Insertion order mirrors the original per-field scan
+        // (EnumMember value before field name, fields in declaration order), so
+        // first-match-wins semantics are preserved by TryAdd.
+        _valueMap = new Dictionary<string, object>(StringComparer.Ordinal);
+        foreach (var field in enumType.GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            var enumValue = field.GetValue(null);
+            var attr = field.GetCustomAttribute<EnumMemberAttribute>();
+            if (attr?.Value != null)
+                _valueMap.TryAdd(attr.Value, enumValue);
+            _valueMap.TryAdd(field.Name, enumValue);
+        }
+    }
 
     public Task BindModelAsync(ModelBindingContext bindingContext)
     {
@@ -32,14 +51,10 @@ public class EnumMemberModelBinder : IModelBinder
         if (string.IsNullOrEmpty(value))
             return Task.CompletedTask;
 
-        foreach (var field in _enumType.GetFields(BindingFlags.Public | BindingFlags.Static))
+        if (_valueMap.TryGetValue(value, out var mapped))
         {
-            var attr = field.GetCustomAttribute<EnumMemberAttribute>();
-            if (attr?.Value == value || field.Name == value)
-            {
-                bindingContext.Result = ModelBindingResult.Success(field.GetValue(null));
-                return Task.CompletedTask;
-            }
+            bindingContext.Result = ModelBindingResult.Success(mapped);
+            return Task.CompletedTask;
         }
 
         if (Enum.TryParse(_enumType, value, ignoreCase: true, out var parsed))

--- a/tests/NimBus.MessageStore.CosmosDb.Tests/CosmosDbClientPurgeTests.cs
+++ b/tests/NimBus.MessageStore.CosmosDb.Tests/CosmosDbClientPurgeTests.cs
@@ -1,0 +1,162 @@
+#pragma warning disable CA1707, CA2007
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace NimBus.MessageStore.CosmosDb.Tests;
+
+/// <summary>
+/// Fake-adapter tests for <see cref="CosmosDbClient.PurgeMessages(string, string)"/>:
+/// the lookup must project only the document id (not whole EventDbo documents with
+/// their EventJson payloads), and the per-document deletes — each its own partition
+/// on a /id-partitioned container — must run concurrently rather than one-by-one.
+/// </summary>
+[TestClass]
+public sealed class CosmosDbClientPurgeTests
+{
+    [TestMethod]
+    public async Task PurgeMessages_projects_ids_and_deletes_concurrently()
+    {
+        var container = new RecordingContainerAdapter(
+            Enumerable.Range(1, 8).Select(i => $"{{\"id\": \"event-{i}\"}}").ToList());
+        var client = new CosmosDbClient(new SingleContainerClientAdapter(container));
+
+        var purged = await client.PurgeMessages("endpoint-1", "session-1");
+
+        Assert.IsTrue(purged);
+        CollectionAssert.AreEquivalent(
+            Enumerable.Range(1, 8).Select(i => $"event-{i}").ToList(),
+            container.DeletedIds.ToList());
+        StringAssert.Contains(container.LastQueryText, "SELECT c.id",
+            "Purge only needs document ids — it must not fetch whole documents.");
+        Assert.IsTrue(container.MaxObservedDeleteConcurrency >= 2,
+            $"Expected deletes to overlap, but max observed concurrency was {container.MaxObservedDeleteConcurrency} (serial execution).");
+    }
+
+    private sealed class SingleContainerClientAdapter : ICosmosClientAdapter, ICosmosDatabaseAdapter
+    {
+        private readonly ICosmosContainerAdapter _container;
+
+        public SingleContainerClientAdapter(ICosmosContainerAdapter container) => _container = container;
+
+        public ICosmosDatabaseAdapter GetDatabase(string id) => this;
+
+        public ICosmosContainerAdapter GetContainer(string id) => _container;
+
+        public Task<ICosmosContainerAdapter> CreateContainerIfNotExistsAsync(string id, string partitionKeyPath)
+            => Task.FromResult(_container);
+    }
+
+    private sealed class RecordingContainerAdapter : ICosmosContainerAdapter
+    {
+        private readonly IReadOnlyList<string> _documentJson;
+        private int _inFlightDeletes;
+        private int _maxObservedDeleteConcurrency;
+
+        public RecordingContainerAdapter(IReadOnlyList<string> documentJson) => _documentJson = documentJson;
+
+        public string LastQueryText { get; private set; }
+
+        public ConcurrentBag<string> DeletedIds { get; } = new();
+
+        public int MaxObservedDeleteConcurrency => Volatile.Read(ref _maxObservedDeleteConcurrency);
+
+        public FeedIterator<T> GetItemQueryIterator<T>(QueryDefinition queryDefinition)
+        {
+            LastQueryText = queryDefinition.QueryText;
+            return new SingleBatchFeedIterator<T>(
+                _documentJson.Select(JsonConvert.DeserializeObject<T>).ToList());
+        }
+
+        public FeedIterator<T> GetItemQueryIterator<T>(QueryDefinition queryDefinition, string? continuationToken = null, QueryRequestOptions? requestOptions = null)
+            => GetItemQueryIterator<T>(queryDefinition);
+
+        public FeedIterator<T> GetItemQueryIterator<T>(string queryText)
+            => throw new NotSupportedException();
+
+        public FeedIterator<T> GetItemQueryIterator<T>(string queryText, string? continuationToken = null, QueryRequestOptions? requestOptions = null)
+            => throw new NotSupportedException();
+
+        public IOrderedQueryable<T> GetItemLinqQueryable<T>(bool allowSynchronousQueryExecution = false, string? continuationToken = null, QueryRequestOptions? requestOptions = null)
+            => throw new NotSupportedException();
+
+        public Task<ItemResponse<T>> UpsertItemAsync<T>(T item, PartitionKey partitionKey = default)
+            => throw new NotSupportedException();
+
+        public async Task<ItemResponse<T>> DeleteItemAsync<T>(string id, PartitionKey partitionKey)
+        {
+            var inFlight = Interlocked.Increment(ref _inFlightDeletes);
+            try
+            {
+                int seen;
+                while (inFlight > (seen = Volatile.Read(ref _maxObservedDeleteConcurrency)) &&
+                       Interlocked.CompareExchange(ref _maxObservedDeleteConcurrency, inFlight, seen) != seen)
+                {
+                }
+
+                // Hold the call open long enough for overlapping deletes to be observable.
+                await Task.Delay(50);
+                DeletedIds.Add(id);
+                return null;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _inFlightDeletes);
+            }
+        }
+
+        public Task<ItemResponse<T>> ReadItemAsync<T>(string id, PartitionKey partitionKey)
+            => throw new NotSupportedException();
+
+        public Task<ItemResponse<T>> ReadItemAsync<T>(string id, PartitionKey partitionKey, ItemRequestOptions requestOptions)
+            => throw new NotSupportedException();
+
+        public Task<ItemResponse<T>> PatchItemAsync<T>(string id, PartitionKey partitionKey, IReadOnlyList<PatchOperation> patchOperations)
+            => throw new NotSupportedException();
+
+        public Task<ContainerResponse> DeleteContainerAsync()
+            => throw new NotSupportedException();
+
+        public Task<FeedResponse<T>> ReadManyItemsAsync<T>(IReadOnlyList<(string id, PartitionKey partitionKey)> items)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class SingleBatchFeedIterator<T> : FeedIterator<T>
+    {
+        private readonly IReadOnlyList<T> _items;
+        private bool _consumed;
+
+        public SingleBatchFeedIterator(IReadOnlyList<T> items) => _items = items;
+
+        public override bool HasMoreResults => !_consumed;
+
+        public override Task<FeedResponse<T>> ReadNextAsync(CancellationToken cancellationToken = default)
+        {
+            _consumed = true;
+            return Task.FromResult<FeedResponse<T>>(new ListFeedResponse<T>(_items));
+        }
+    }
+
+    private sealed class ListFeedResponse<T> : FeedResponse<T>
+    {
+        private readonly IReadOnlyList<T> _items;
+
+        public ListFeedResponse(IReadOnlyList<T> items) => _items = items;
+
+        public override string ContinuationToken => null;
+        public override int Count => _items.Count;
+        public override string IndexMetrics => null;
+        public override Headers Headers { get; } = new();
+        public override IEnumerable<T> Resource => _items;
+        public override HttpStatusCode StatusCode => HttpStatusCode.OK;
+        public override CosmosDiagnostics Diagnostics => null;
+        public override IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+    }
+}

--- a/tests/NimBus.MessageStore.CosmosDb.Tests/CosmosDbClientUnitTests.cs
+++ b/tests/NimBus.MessageStore.CosmosDb.Tests/CosmosDbClientUnitTests.cs
@@ -2,10 +2,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NimBus.MessageStore.States;
 
 namespace NimBus.MessageStore.CosmosDb.Tests;
 
@@ -29,21 +32,53 @@ public sealed class CosmosDbClientUnitTests
             $"EventTime {state.EventTime:O} should be within a minute of DateTime.UtcNow.");
     }
 
-    private sealed class FakeCosmosClientAdapter : ICosmosClientAdapter
+    [TestMethod]
+    public async Task SetEndpointMetadata_reports_throttled_upserts_through_logger()
     {
-        public ICosmosDatabaseAdapter GetDatabase(string id) => new FakeDatabaseAdapter();
+        var logger = new CapturingLogger();
+        var container = new FakeContainerAdapter
+        {
+            UpsertException = new CosmosException("throttled", HttpStatusCode.TooManyRequests, 0, "activity-1", 0),
+        };
+        var client = new CosmosDbClient(new FakeCosmosClientAdapter(container), logger);
+
+        await Assert.ThrowsExceptionAsync<RequestLimitException>(
+            () => client.SetEndpointMetadata(new EndpointMetadata { EndpointId = "ep-1" }));
+
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Error && e.Exception is CosmosException),
+            "Upsert failures must surface through the Microsoft.Extensions.Logging logger.");
     }
 
-    private sealed class FakeDatabaseAdapter : ICosmosDatabaseAdapter
+    private sealed class CapturingLogger : ILogger<CosmosDbClient>
     {
-        public ICosmosContainerAdapter GetContainer(string id) => new FakeContainerAdapter();
+        public List<(LogLevel Level, string Message, Exception Exception)> Entries { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception), exception));
+    }
+
+    private sealed class FakeCosmosClientAdapter : ICosmosClientAdapter, ICosmosDatabaseAdapter
+    {
+        private readonly FakeContainerAdapter _container;
+
+        public FakeCosmosClientAdapter(FakeContainerAdapter container = null) => _container = container ?? new FakeContainerAdapter();
+
+        public ICosmosDatabaseAdapter GetDatabase(string id) => this;
+
+        public ICosmosContainerAdapter GetContainer(string id) => _container;
 
         public Task<ICosmosContainerAdapter> CreateContainerIfNotExistsAsync(string id, string partitionKeyPath)
-            => Task.FromResult<ICosmosContainerAdapter>(new FakeContainerAdapter());
+            => Task.FromResult<ICosmosContainerAdapter>(_container);
     }
 
     private sealed class FakeContainerAdapter : ICosmosContainerAdapter
     {
+        public Exception UpsertException { get; set; }
+
         public FeedIterator<T> GetItemQueryIterator<T>(QueryDefinition queryDefinition)
             => new EmptyFeedIterator<T>();
 
@@ -60,7 +95,7 @@ public sealed class CosmosDbClientUnitTests
             => throw new NotSupportedException();
 
         public Task<ItemResponse<T>> UpsertItemAsync<T>(T item, PartitionKey partitionKey = default)
-            => throw new NotSupportedException();
+            => throw UpsertException ?? new NotSupportedException();
 
         public Task<ItemResponse<T>> DeleteItemAsync<T>(string id, PartitionKey partitionKey)
             => throw new NotSupportedException();

--- a/tests/NimBus.MessageStore.CosmosDb.Tests/CosmosDbStoreTestHarness.cs
+++ b/tests/NimBus.MessageStore.CosmosDb.Tests/CosmosDbStoreTestHarness.cs
@@ -11,6 +11,7 @@ internal static class CosmosDbStoreTestHarness
     private const string ConnectionStringEnvironmentVariable = "NIMBUS_COSMOS_TEST_CONNECTION";
     private const string EndpointEnvironmentVariable = "NIMBUS_COSMOS_TEST_ENDPOINT";
     private const string KeyEnvironmentVariable = "NIMBUS_COSMOS_TEST_KEY";
+    private const string GatewayModeEnvironmentVariable = "NIMBUS_COSMOS_TEST_GATEWAY";
 
     private static readonly Lazy<CosmosClient> Client = new(CreateClient);
 
@@ -23,10 +24,21 @@ internal static class CosmosDbStoreTestHarness
         var endpoint = Environment.GetEnvironmentVariable(EndpointEnvironmentVariable);
         var key = Environment.GetEnvironmentVariable(KeyEnvironmentVariable);
 
+        // The Cosmos emulator (Docker, vNext) only speaks Gateway mode; the SDK
+        // default of Direct mode tries to reach partition addresses that aren't
+        // exposed by the container. Opt in via NIMBUS_COSMOS_TEST_GATEWAY=1.
+        var options = new CosmosClientOptions();
+        var gateway = Environment.GetEnvironmentVariable(GatewayModeEnvironmentVariable);
+        if (gateway is "1" or "true")
+        {
+            options.ConnectionMode = ConnectionMode.Gateway;
+            options.LimitToEndpoint = true;
+        }
+
         var client = !string.IsNullOrWhiteSpace(connectionString)
-            ? new CosmosClient(connectionString)
+            ? new CosmosClient(connectionString, options)
             : !string.IsNullOrWhiteSpace(endpoint) && !string.IsNullOrWhiteSpace(key)
-                ? new CosmosClient(endpoint, key)
+                ? new CosmosClient(endpoint, key, options)
                 : null;
 
         if (client == null)

--- a/tests/NimBus.WebApp.Tests/EnumMemberModelBinderTests.cs
+++ b/tests/NimBus.WebApp.Tests/EnumMemberModelBinderTests.cs
@@ -1,0 +1,118 @@
+#pragma warning disable CA1707, CA2007
+using System;
+using System.Globalization;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.Extensions.Primitives;
+
+namespace NimBus.WebApp.Tests;
+
+/// <summary>
+/// Pins the binding semantics of <see cref="EnumMemberModelBinder"/>:
+/// EnumMember values and field names resolve exactly, anything else falls
+/// back to case-insensitive <see cref="Enum.TryParse(Type, string, bool, out object)"/>,
+/// and unknown values produce a model error.
+/// </summary>
+[TestClass]
+public sealed class EnumMemberModelBinderTests
+{
+    private enum SampleStatus
+    {
+        [EnumMember(Value = "in-progress")]
+        InProgress,
+
+        [EnumMember(Value = "dead-lettered")]
+        DeadLettered,
+
+        Done,
+    }
+
+    [TestMethod]
+    public async Task Binds_enum_member_value()
+    {
+        var result = await BindAsync("in-progress");
+
+        Assert.IsTrue(result.IsModelSet);
+        Assert.AreEqual(SampleStatus.InProgress, result.Model);
+    }
+
+    [TestMethod]
+    public async Task Binds_field_name()
+    {
+        var result = await BindAsync("Done");
+
+        Assert.IsTrue(result.IsModelSet);
+        Assert.AreEqual(SampleStatus.Done, result.Model);
+    }
+
+    [TestMethod]
+    public async Task Falls_back_to_case_insensitive_parse()
+    {
+        var result = await BindAsync("deadlettered");
+
+        Assert.IsTrue(result.IsModelSet);
+        Assert.AreEqual(SampleStatus.DeadLettered, result.Model);
+    }
+
+    [TestMethod]
+    public async Task Rejects_unknown_value_with_model_error()
+    {
+        var context = MakeContext("no-such-status");
+
+        await new EnumMemberModelBinder(typeof(SampleStatus)).BindModelAsync(context);
+
+        Assert.IsFalse(context.Result.IsModelSet);
+        Assert.AreEqual(1, context.ModelState.ErrorCount);
+    }
+
+    [TestMethod]
+    public async Task Leaves_result_unset_for_empty_value()
+    {
+        var context = MakeContext(string.Empty);
+
+        await new EnumMemberModelBinder(typeof(SampleStatus)).BindModelAsync(context);
+
+        Assert.IsFalse(context.Result.IsModelSet);
+        Assert.AreEqual(0, context.ModelState.ErrorCount);
+    }
+
+    private static async Task<ModelBindingResult> BindAsync(string value)
+    {
+        var context = MakeContext(value);
+        await new EnumMemberModelBinder(typeof(SampleStatus)).BindModelAsync(context);
+        return context.Result;
+    }
+
+    private static DefaultModelBindingContext MakeContext(string value)
+    {
+        return new DefaultModelBindingContext
+        {
+            ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(SampleStatus)),
+            ModelName = "status",
+            ModelState = new ModelStateDictionary(),
+            ValueProvider = new SingleValueProvider("status", value),
+        };
+    }
+
+    private sealed class SingleValueProvider : IValueProvider
+    {
+        private readonly string _key;
+        private readonly string _value;
+
+        public SingleValueProvider(string key, string value)
+        {
+            _key = key;
+            _value = value;
+        }
+
+        public bool ContainsPrefix(string prefix) => prefix == _key;
+
+        public ValueProviderResult GetValue(string key)
+            => key == _key
+                ? new ValueProviderResult(new StringValues(_value), CultureInfo.InvariantCulture)
+                : ValueProviderResult.None;
+    }
+}


### PR DESCRIPTION
## Summary

Second batch from the codebase analysis (everything except the `CosmosDbClient` split):

- **`PurgeMessages(endpointId, sessionId)`** now projects `SELECT c.id` instead of fetching whole documents (the `EventJson` payload dominated each page), and runs the per-document deletes with bounded concurrency. The `/id`-partitioned containers put every document in its own logical partition, so `TransactionalBatch` cannot apply — concurrent independent deletes are the right tool.
- **`GetBlockedEventsOnSession` / `GetInvalidEventsOnSession`** project the four fields that feed `BlockedMessageEvent` server-side instead of reading full documents.
- **`GetCompletedEventsOnEndpoint`, `GetInvalidEventsOnSession`, `GetEndpointErrorList`** use parameterized `QueryDefinition`s instead of interpolated constants, so the SDK caches query plans.
- **`EnumMemberModelBinder`** builds its name→value map once in the constructor instead of reflecting over enum fields on every bind.
- **Serilog → `Microsoft.Extensions.Logging`** in `CosmosDbClient` (ADR-006): structured templates throughout, `ILogger<CosmosDbClient>` wired through DI — no caller ever passed the old Serilog logger, so this turns Cosmos logging on for the first time. `[Obsolete]` bridge constructors keep source compatibility per repo convention.

## Verification

- **Live emulator run**: the Cosmos conformance suite was executed against the Cosmos emulator (Docker, vNext) before and after the changes — 40/44 pass after (37/41 before; +3 new tests), with the *same* 4 pre-existing failures in both runs (emulator quirks, untouched code paths).
- TDD: the purge unit test failed red (`SELECT *` + serial deletes observed), the MEL test failed red at compile time, binder behavior was pinned green before refactoring.
- New conformance test `PurgeMessages_removes_only_the_target_session` runs across in-memory, Cosmos, and SQL Server providers.
- Full solution suite: 0 failures.

## Running the live Cosmos suite locally

```
docker run -d -p 8081:8081 mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview --protocol https
$env:NIMBUS_COSMOS_TEST_CONNECTION = "AccountEndpoint=https://localhost:8081/;AccountKey=<emulator-key>;DisableServerCertificateValidation=true"
$env:NIMBUS_COSMOS_TEST_GATEWAY = "1"   # new: emulator only speaks Gateway mode
dotnet test tests/NimBus.MessageStore.CosmosDb.Tests
```