### PR TITLE
perf(messagestore): cache Cosmos container handles instead of re-ensuring per call

### DIFF
--- a/src/NimBus.MessageStore.CosmosDb/CosmosDbClient.cs
+++ b/src/NimBus.MessageStore.CosmosDb/CosmosDbClient.cs
@@ -6,6 +6,7 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Linq;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -110,6 +111,17 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
 {
     private readonly ICosmosClientAdapter _cosmosClient;
     private readonly ILogger _logger;
+
+    // Cosmos container handles are lightweight client-side proxies the SDK
+    // recommends caching for the client's lifetime. Every data operation used to
+    // call CreateContainerIfNotExistsAsync, which issues a control-plane
+    // round-trip on each call even when the container already exists. Cache the
+    // resolved handle (running the one-time "ensure exists" once per container)
+    // so steady-state reads/writes skip that round-trip. Keyed by container id,
+    // which is unique per physical container in the database. Entries are evicted
+    // when a container is deleted (PurgeMessages) so the next access recreates it.
+    private readonly ConcurrentDictionary<string, Task<ICosmosContainerAdapter>> _containerCache = new();
+
     private const string DatabaseId = "MessageDatabase";
 
     private const string PendingStatus = "Pending";
@@ -478,6 +490,10 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
             var container = await GetEndpointContainer(endpointId);
 
             await container.DeleteContainerAsync();
+            // Drop the cached handle so the next access re-runs "ensure exists"
+            // and recreates the now-deleted container instead of reusing a stale
+            // handle that would only throw NotFound.
+            _containerCache.TryRemove(endpointId, out _);
             _logger?.Information($"COSMOS PURGE: Deleted all messages on endpoint {endpointId}");
 
             return true;
@@ -908,8 +924,7 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
     public async Task<IEnumerable<EndpointSubscription>> GetSubscriptionsOnEndpoint(string endpointId)
     {
         var subscriptions = new List<EndpointSubscription>();
-        var db = _cosmosClient.GetDatabase(DatabaseId);
-        var subscriptionContainer = await db.CreateContainerIfNotExistsAsync(SubscriptionsContainer, "/id");
+        var subscriptionContainer = await GetSubscriptionsContainer();
 
         var queryDefinition = new QueryDefinition("SELECT * FROM c WHERE c.endpointId = @endpointId")
             .WithParameter("@endpointId", endpointId);
@@ -931,8 +946,7 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         string eventType, string payload, string errorText)
     {
         var subscriptions = new List<EndpointSubscription>();
-        var db = _cosmosClient.GetDatabase(DatabaseId);
-        var subscriptionContainer = await db.CreateContainerIfNotExistsAsync(SubscriptionsContainer, "/id");
+        var subscriptionContainer = await GetSubscriptionsContainer();
 
         var sqlQuery = "SELECT * FROM c WHERE c.endpointId = @endpointId";
 
@@ -1078,27 +1092,48 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
         [JsonProperty("id")] public string Id { get; set; }
     }
 
-    private async Task<ICosmosContainerAdapter> GetEndpointContainer(string endpointId)
+    // Resolves a container handle through _containerCache, running "ensure
+    // exists" exactly once per container id and caching the resulting handle.
+    // A faulted creation is never left cached: the faulted entry is evicted
+    // (key + value match, so a newer good entry is never removed) and the
+    // next caller retries.
+    private async Task<ICosmosContainerAdapter> GetCachedContainerAsync(string containerId, string partitionKeyPath)
+    {
+        var containerTask = _containerCache.GetOrAdd(containerId, id => EnsureContainerExistsAsync(id, partitionKeyPath));
+        try
+        {
+            return await containerTask;
+        }
+        catch
+        {
+            _containerCache.TryRemove(new KeyValuePair<string, Task<ICosmosContainerAdapter>>(containerId, containerTask));
+            throw;
+        }
+    }
+
+    private async Task<ICosmosContainerAdapter> EnsureContainerExistsAsync(string containerId, string partitionKeyPath)
+    {
+        var db = _cosmosClient.GetDatabase(DatabaseId);
+        return await db.CreateContainerIfNotExistsAsync(containerId, partitionKeyPath);
+    }
+
+    private Task<ICosmosContainerAdapter> GetEndpointContainer(string endpointId)
     {
         if (string.IsNullOrEmpty(endpointId))
         {
             throw new ArgumentNullException(nameof(endpointId), "EndpointId cannot be null or empty");
         }
-        var db = _cosmosClient.GetDatabase(DatabaseId);
-        return await db.CreateContainerIfNotExistsAsync(endpointId, "/id");
+        return GetCachedContainerAsync(endpointId, "/id");
     }
 
-    private async Task<ICosmosContainerAdapter> GetMessagesContainer()
-    {
-        var db = _cosmosClient.GetDatabase(DatabaseId);
-        return await db.CreateContainerIfNotExistsAsync(MessagesContainer, "/eventId");
-    }
+    private Task<ICosmosContainerAdapter> GetSubscriptionsContainer() =>
+        GetCachedContainerAsync(SubscriptionsContainer, "/id");
 
-    private async Task<ICosmosContainerAdapter> GetAuditsContainer()
-    {
-        var db = _cosmosClient.GetDatabase(DatabaseId);
-        return await db.CreateContainerIfNotExistsAsync(AuditsContainer, "/eventId");
-    }
+    private Task<ICosmosContainerAdapter> GetMessagesContainer() =>
+        GetCachedContainerAsync(MessagesContainer, "/eventId");
+
+    private Task<ICosmosContainerAdapter> GetAuditsContainer() =>
+        GetCachedContainerAsync(AuditsContainer, "/eventId");
 
     public async Task<MessageSearchResult> SearchMessages(MessageFilter filter, string? continuationToken, int maxItemCount)
     {

--- a/tests/NimBus.MessageStore.CosmosDb.Tests/CosmosDbClientUnitTests.cs
+++ b/tests/NimBus.MessageStore.CosmosDb.Tests/CosmosDbClientUnitTests.cs
@@ -29,17 +29,91 @@ public sealed class CosmosDbClientUnitTests
             $"EventTime {state.EventTime:O} should be within a minute of DateTime.UtcNow.");
     }
 
+    [TestMethod]
+    public async Task GetEndpointContainer_caches_handle_so_ensure_exists_runs_once_per_endpoint()
+    {
+        var adapter = new FakeCosmosClientAdapter();
+        var client = new CosmosDbClient(adapter);
+
+        // Repeated operations on the same endpoint should resolve the container
+        // once; the cached handle skips the control-plane round-trip after.
+        for (var i = 0; i < 3; i++)
+        {
+            await client.DownloadEndpointStateCount("endpoint-1");
+        }
+
+        Assert.AreEqual(1, adapter.Database.GetCreateContainerCallCount("endpoint-1"),
+            "CreateContainerIfNotExistsAsync must run once per container; subsequent accesses reuse the cached handle.");
+    }
+
+    [TestMethod]
+    public async Task PurgeMessages_evicts_cached_handle_so_next_access_recreates_container()
+    {
+        var adapter = new FakeCosmosClientAdapter();
+        var client = new CosmosDbClient(adapter);
+
+        await client.DownloadEndpointStateCount("endpoint-1");
+
+        // Purge deletes the container and must evict the cache, so the next
+        // access re-runs "ensure exists" instead of reusing a stale handle.
+        var purged = await client.PurgeMessages("endpoint-1");
+        await client.DownloadEndpointStateCount("endpoint-1");
+
+        Assert.IsTrue(purged, "PurgeMessages should succeed against the fake adapter.");
+        Assert.AreEqual(2, adapter.Database.GetCreateContainerCallCount("endpoint-1"),
+            "After a purge the cached handle is stale; the next access must re-ensure the container exists.");
+    }
+
+    [TestMethod]
+    public async Task GetEndpointContainer_does_not_cache_faulted_creation_so_next_access_retries()
+    {
+        var adapter = new FakeCosmosClientAdapter();
+        adapter.Database.CreateFailuresRemaining = 1;
+        var client = new CosmosDbClient(adapter);
+
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => client.DownloadEndpointStateCount("endpoint-1"));
+
+        // The faulted creation must not be cached — the retry should run
+        // "ensure exists" again and succeed.
+        await client.DownloadEndpointStateCount("endpoint-1");
+
+        Assert.AreEqual(2, adapter.Database.GetCreateContainerCallCount("endpoint-1"),
+            "A failed creation must be evicted so the next caller retries CreateContainerIfNotExistsAsync.");
+    }
+
     private sealed class FakeCosmosClientAdapter : ICosmosClientAdapter
     {
-        public ICosmosDatabaseAdapter GetDatabase(string id) => new FakeDatabaseAdapter();
+        public FakeDatabaseAdapter Database { get; } = new FakeDatabaseAdapter();
+
+        public ICosmosDatabaseAdapter GetDatabase(string id) => Database;
     }
 
     private sealed class FakeDatabaseAdapter : ICosmosDatabaseAdapter
     {
+        private readonly Dictionary<string, int> _createContainerCalls = new(StringComparer.Ordinal);
+
+        public int CreateFailuresRemaining { get; set; }
+
+        public int GetCreateContainerCallCount(string id) => _createContainerCalls.GetValueOrDefault(id);
+
         public ICosmosContainerAdapter GetContainer(string id) => new FakeContainerAdapter();
 
         public Task<ICosmosContainerAdapter> CreateContainerIfNotExistsAsync(string id, string partitionKeyPath)
-            => Task.FromResult<ICosmosContainerAdapter>(new FakeContainerAdapter());
+        {
+            _createContainerCalls[id] = _createContainerCalls.GetValueOrDefault(id) + 1;
+            if (CreateFailuresRemaining > 0)
+            {
+                CreateFailuresRemaining--;
+                throw new InvalidOperationException("Simulated container creation failure.");
+            }
+
+            return Task.FromResult<ICosmosContainerAdapter>(new FakeContainerAdapter());
+        }
+    }
+
+    private sealed class FakeContainerResponse : ContainerResponse
+    {
     }
 
     private sealed class FakeContainerAdapter : ICosmosContainerAdapter
@@ -75,7 +149,7 @@ public sealed class CosmosDbClientUnitTests
             => throw new NotSupportedException();
 
         public Task<ContainerResponse> DeleteContainerAsync()
-            => throw new NotSupportedException();
+            => Task.FromResult<ContainerResponse>(new FakeContainerResponse());
 
         public Task<FeedResponse<T>> ReadManyItemsAsync<T>(IReadOnlyList<(string id, PartitionKey partitionKey)> items)
             => throw new NotSupportedException();


### PR DESCRIPTION
## Summary
- Every data operation called `CreateContainerIfNotExistsAsync`, issuing a control-plane round-trip even when the container already exists. Container handles are now resolved through a `ConcurrentDictionary` cache so the one-time ensure-exists runs once per container.
- `PurgeMessages` evicts the cached entry after deleting the container, so the next access recreates it instead of reusing a stale handle.
- Faulted creations are never left cached: eviction matches key **and** value (the faulted task), so a failed creation retries on the next call and a newer good entry can't be removed by a stale failure.
- Consolidated the two inline subscription-container creations into a shared `GetSubscriptionsContainer()`.

## Testing
- 3 new mock-based unit tests (no emulator needed): cache-hit (ensure-exists once per endpoint), purge-eviction (recreates after purge), faulted-creation retry.
- `dotnet build -c Release` clean (TreatWarningsAsErrors).