### PR TITLE
feat(webapp): reusable ErrorPatternNormalizer for failed-insight grouping

### DIFF
--- a/src/NimBus.WebApp/ClientApp/src/functions/error-normalization.ts
+++ b/src/NimBus.WebApp/ClientApp/src/functions/error-normalization.ts
@@ -15,11 +15,15 @@ export function extractErrorCategory(
   errorText: string | undefined | null,
 ): string {
   if (!errorText) return "Unknown";
-  if (errorText.startsWith("[")) {
-    const end = errorText.indexOf("]");
-    if (end > 0) return errorText.substring(0, end + 1);
+  // Strip GUIDs first so messages that differ only by an embedded id
+  // (e.g. "Job with JobID {GUID} not found") collapse into one category
+  // instead of one row per id.
+  const text = errorText.replace(GUID_PATTERN, "<id>");
+  if (text.startsWith("[")) {
+    const end = text.indexOf("]");
+    if (end > 0) return text.substring(0, end + 1);
   }
-  const colon = errorText.indexOf(":");
-  if (colon > 0 && colon < 100) return errorText.substring(0, colon);
-  return errorText.length > 100 ? errorText.substring(0, 100) : errorText;
+  const colon = text.indexOf(":");
+  if (colon > 0 && colon < 100) return text.substring(0, colon);
+  return text.length > 100 ? text.substring(0, 100) : text;
 }

--- a/src/NimBus.WebApp/Controllers/ApiContract/MetricsImplementation.cs
+++ b/src/NimBus.WebApp/Controllers/ApiContract/MetricsImplementation.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using NimBus.MessageStore;
 using NimBus.MessageStore.Abstractions;
 using NimBus.MessageStore.States;
 using NimBus.WebApp.ManagementApi;
+using NimBus.WebApp.Services;
 
 namespace NimBus.WebApp.Controllers.ApiContract;
 
@@ -158,34 +158,11 @@ public class MetricsImplementation : IMetricsApiController
         _ => (13, "hour")
     };
 
-    internal static string ExtractErrorCategory(string errorText)
-    {
-        if (string.IsNullOrEmpty(errorText)) return "Unknown";
-        if (errorText.StartsWith('['))
-        {
-            var end = errorText.IndexOf(']', StringComparison.Ordinal);
-            if (end > 0) return errorText[..(end + 1)];
-        }
-        var colon = errorText.IndexOf(':', StringComparison.Ordinal);
-        if (colon > 0 && colon < 100) return errorText[..colon];
-        return errorText.Length > 100 ? errorText[..100] : errorText;
-    }
+    internal static string ExtractErrorCategory(string errorText) =>
+        ErrorPatternNormalizer.ExtractCategory(errorText);
 
-    private static readonly Regex GuidPattern = new(
-        @"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
-        RegexOptions.Compiled);
-
-    private static readonly Regex ActionSuffix = new(
-        @"\.?\s*Action:.*$",
-        RegexOptions.Compiled);
-
-    internal static string NormalizeErrorPattern(string errorText)
-    {
-        if (string.IsNullOrEmpty(errorText)) return "Unknown";
-        var normalized = GuidPattern.Replace(errorText, "<id>");
-        normalized = ActionSuffix.Replace(normalized, "");
-        return normalized.TrimEnd(' ', '.');
-    }
+    internal static string NormalizeErrorPattern(string errorText) =>
+        ErrorPatternNormalizer.Normalize(errorText);
 
     private static TimeSpan PeriodToTimeSpan(Period period) => period switch
     {

--- a/src/NimBus.WebApp/Services/ErrorPatternNormalizer.cs
+++ b/src/NimBus.WebApp/Services/ErrorPatternNormalizer.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace NimBus.WebApp.Services;
+
+/// <summary>
+/// Normalizes failed-message error texts so that messages differing only by
+/// volatile fragments (timestamps, GUIDs, dimension values, quoted identifiers,
+/// long numbers, trailing "Action:" advice) collapse into a single pattern for
+/// the failed-insights grouping on the metrics dashboard.
+/// </summary>
+public static class ErrorPatternNormalizer
+{
+    private static readonly Regex TimestampPattern = new(
+        @"\b\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b",
+        RegexOptions.Compiled);
+
+    private static readonly Regex GuidPattern = new(
+        @"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+        RegexOptions.Compiled);
+
+    private static readonly Regex DimensionValuePattern = new(
+        @"\bdimension value\s+['""]?[^'"",.;:\s]+['""]?",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex KeyValuePattern = new(
+        @"\bkey\s+['""][^'""]+['""]",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex JobIdPattern = new(
+        @"\bJobID\s+\[[^\]]+\]",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex QuotedIdentifierPattern = new(
+        @"(['""])[A-Za-z0-9][A-Za-z0-9_.:-]{5,}\1",
+        RegexOptions.Compiled);
+
+    private static readonly Regex LongNumberPattern = new(
+        @"\b\d{4,}\b",
+        RegexOptions.Compiled);
+
+    private static readonly Regex ActionSuffix = new(
+        @"\.?\s*Action:.*$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Extracts a short, stable category from an error text. The text is
+    /// normalized first so errors that differ only by an embedded id or value
+    /// (e.g. "Job with JobID {GUID} not found") collapse into one category
+    /// instead of one row per id.
+    /// </summary>
+    /// <param name="errorText">The raw error text; may be null or empty.</param>
+    /// <returns>A normalized category string, or "Unknown" when the input is null or empty.</returns>
+    public static string ExtractCategory(string errorText)
+    {
+        if (string.IsNullOrEmpty(errorText)) return "Unknown";
+        var normalized = Normalize(errorText);
+        const string timestampPrefix = "<timestamp>:";
+        if (normalized.StartsWith(timestampPrefix, StringComparison.Ordinal))
+        {
+            normalized = normalized[timestampPrefix.Length..].TrimStart();
+        }
+
+        if (normalized.StartsWith('['))
+        {
+            var end = normalized.IndexOf(']', StringComparison.Ordinal);
+            if (end > 0) return normalized[..(end + 1)];
+        }
+
+        var colon = normalized.IndexOf(':', StringComparison.Ordinal);
+        if (colon > 0 && colon < 100) return normalized[..colon];
+
+        return normalized.Length > 100 ? normalized[..100] : normalized;
+    }
+
+    /// <summary>
+    /// Replaces volatile fragments (timestamps, GUIDs, dimension values, quoted
+    /// identifiers, long numbers) with placeholders and strips any trailing
+    /// "Action:" advice so equivalent errors yield an identical pattern string.
+    /// </summary>
+    /// <param name="errorText">The raw error text; may be null or empty.</param>
+    /// <returns>The normalized pattern, or "Unknown" when the input is null or empty.</returns>
+    public static string Normalize(string errorText)
+    {
+        if (string.IsNullOrEmpty(errorText)) return "Unknown";
+        var normalized = TimestampPattern.Replace(errorText, "<timestamp>");
+        normalized = GuidPattern.Replace(normalized, "<id>");
+        normalized = DimensionValuePattern.Replace(normalized, "dimension value <value>");
+        normalized = KeyValuePattern.Replace(normalized, "key '<value>'");
+        normalized = JobIdPattern.Replace(normalized, "JobID [<id>]");
+        normalized = QuotedIdentifierPattern.Replace(normalized, "$1<value>$1");
+        normalized = LongNumberPattern.Replace(normalized, "<number>");
+        normalized = ActionSuffix.Replace(normalized, string.Empty);
+        return normalized.TrimEnd(' ', '.');
+    }
+}

--- a/tests/NimBus.WebApp.Tests/ErrorPatternNormalizerTests.cs
+++ b/tests/NimBus.WebApp.Tests/ErrorPatternNormalizerTests.cs
@@ -1,0 +1,84 @@
+#pragma warning disable CA1707, CA2007
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NimBus.WebApp.Services;
+
+namespace NimBus.WebApp.Tests;
+
+[TestClass]
+public class ErrorPatternNormalizerTests
+{
+    [TestMethod]
+    public void Normalize_GroupsDimensionValueErrorsWithDifferentValues()
+    {
+        var first = ErrorPatternNormalizer.Normalize(
+            "Mandatory fields must be filled in to proceed. The dimension value 55890030 does not exist for dimension Afdeling.");
+        var second = ErrorPatternNormalizer.Normalize(
+            "Mandatory fields must be filled in to proceed. The dimension value 60000038 does not exist for dimension Afdeling.");
+        var third = ErrorPatternNormalizer.Normalize(
+            "Mandatory fields must be filled in to proceed. The dimension value 302 does not exist for dimension Afdeling.");
+
+        Assert.AreEqual(first, second);
+        Assert.AreEqual(first, third);
+        Assert.AreEqual(
+            "Mandatory fields must be filled in to proceed. The dimension value <value> does not exist for dimension Afdeling",
+            first);
+    }
+
+    [TestMethod]
+    public void ExtractCategory_UsesNormalizedFallbackForErrorsWithoutShortCategory()
+    {
+        var first = ErrorPatternNormalizer.ExtractCategory(
+            "Mandatory fields must be filled in to proceed. The dimension value 55890030 does not exist for dimension Afdeling.");
+        var second = ErrorPatternNormalizer.ExtractCategory(
+            "Mandatory fields must be filled in to proceed. The dimension value 60000038 does not exist for dimension Afdeling.");
+
+        Assert.AreEqual(first, second);
+        StringAssert.Contains(first, "dimension value <value>");
+    }
+
+    [TestMethod]
+    public void ExtractCategory_NormalizesEarlyColonCategory()
+    {
+        var first = ErrorPatternNormalizer.ExtractCategory(
+            "Order 'ABC123' rejected: Mandatory fields must be filled in to proceed.");
+        var second = ErrorPatternNormalizer.ExtractCategory(
+            "Order 'XYZ789' rejected: Mandatory fields must be filled in to proceed.");
+
+        Assert.AreEqual("Order '<value>' rejected", first);
+        Assert.AreEqual(first, second);
+    }
+
+    [TestMethod]
+    public void ExtractCategory_NormalizesTimestampPrefixBeforeEarlyColon()
+    {
+        var first = ErrorPatternNormalizer.ExtractCategory(
+            "2025-06-14T21:33:43: dimension value 55890030 does not exist");
+        var second = ErrorPatternNormalizer.ExtractCategory(
+            "2026-01-02T03:04:05: dimension value 60000038 does not exist");
+
+        Assert.AreEqual("dimension value <value> does not exist", first);
+        Assert.AreEqual(first, second);
+    }
+
+    [TestMethod]
+    public void Normalize_GroupsGuidAndJobIdErrors()
+    {
+        Assert.AreEqual(
+            "Could not find functional location <id>",
+            ErrorPatternNormalizer.Normalize("Could not find functional location e19aee84-6a4a-4bf4-b75a-b0d8d0a825a9"));
+
+        Assert.AreEqual(
+            "Job with JobID [<id>] not found",
+            ErrorPatternNormalizer.Normalize("Job with JobID [06E53DA9-0FA8-495B-8DE3-9187FF5F83BF] not found"));
+    }
+
+    [TestMethod]
+    public void Normalize_StripsActionSuffix()
+    {
+        Assert.AreEqual(
+            "[TRANSIENT ERROR] Failed to handle AliceSaidHello '<value>': the downstream system was momentarily unavailable",
+            ErrorPatternNormalizer.Normalize(
+                "[TRANSIENT ERROR] Failed to handle AliceSaidHello 'hello-0': the downstream system was momentarily unavailable. Action: Wait a few minutes and resubmit"));
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts the failed-insight error normalization out of `MetricsImplementation` into a reusable `ErrorPatternNormalizer` and broadens it: besides GUIDs and `Action:` suffixes it now normalizes timestamps, dimension values, quoted IDs, and long numbers, so insights that differ only by an embedded identifier collapse into one category.
- `MetricsImplementation.ExtractErrorCategory` / `NormalizeErrorPattern` are thin delegates to the new class.
- Frontend `extractErrorCategory` strips GUIDs before bracket/colon extraction for parity with the backend, so the insights page groups "Job with JobID {GUID} not found"-style errors into a single row.

## Testing
- 6 new unit tests covering GUID/job-id grouping, dimension-value grouping, timestamp prefixes, early-colon categories, normalized fallbacks, and Action-suffix stripping.
- `dotnet build -c Release` clean; `tsc --noEmit` clean.