### PR TITLE
fix(webapp): report inner handler exception type instead of SDK wrapper

### DIFF
--- a/src/NimBus.Core/Messages/ResponseService.cs
+++ b/src/NimBus.Core/Messages/ResponseService.cs
@@ -149,18 +149,28 @@ namespace NimBus.Core.Messages
             };
 
 
-        private static MessageContent CreateErrorContent(Exception exception, IMessageContext messageContext) =>
-            new MessageContent()
+        private static MessageContent CreateErrorContent(Exception exception, IMessageContext messageContext)
+        {
+            // For ErrorType the operator wants the actual handler exception
+            // (e.g. SampleApiException) — not the generic
+            // EventContextHandlerException wrapper the SDK puts around it.
+            // Simple Name (no namespace) keeps the field readable in the WebApp.
+            var reported = exception is EventContextHandlerException wrapper && wrapper.InnerException != null
+                ? wrapper.InnerException
+                : exception;
+
+            return new MessageContent()
             {
                 ErrorContent = new ErrorContent()
                 {
                     ErrorText = exception.Message,
-                    ErrorType = exception.GetType().FullName,
+                    ErrorType = reported.GetType().Name,
                     ExceptionStackTrace = null,
                     ExceptionSource = null,
                 },
                 EventContent = messageContext.MessageContent.EventContent
             };
+        }
 
         public async Task SendToDeferredSubscription(IMessageContext messageContext, int deferralSequence, CancellationToken cancellationToken = default)
         {

--- a/tests/NimBus.Core.Tests/ResponseServiceTests.cs
+++ b/tests/NimBus.Core.Tests/ResponseServiceTests.cs
@@ -74,7 +74,25 @@ public class ResponseServiceTests
         Assert.AreEqual(Constants.ResolverId, msg.To);
         Assert.AreEqual(MessageType.ErrorResponse, msg.MessageType);
         Assert.AreEqual("boom", msg.MessageContent.ErrorContent.ErrorText);
-        Assert.AreEqual(typeof(InvalidOperationException).FullName, msg.MessageContent.ErrorContent.ErrorType);
+        Assert.AreEqual(nameof(InvalidOperationException), msg.MessageContent.ErrorContent.ErrorType,
+            "ErrorType should be the simple type name (no namespace) for WebApp readability");
+    }
+
+    [TestMethod]
+    public async Task SendErrorResponse_WrappedHandlerException_ReportsInnerExceptionType()
+    {
+        var sender = new RecordingSender();
+        var sut = new ResponseService(sender);
+        // StrictMessageHandler wraps handler failures in EventContextHandlerException
+        // before calling SendErrorResponse. The operator wants the actual handler
+        // exception type in the WebApp's Error type field, not the SDK wrapper.
+        var ex = new EventContextHandlerException(new SomeCustomException("handler blew up"));
+
+        await sut.SendErrorResponse(CreateContext(), ex);
+
+        var msg = sender.SentMessages.Single();
+        Assert.AreEqual(nameof(SomeCustomException), msg.MessageContent.ErrorContent.ErrorType);
+        Assert.AreEqual("handler blew up", msg.MessageContent.ErrorContent.ErrorText);
     }
 
     // ── SendDeadLetterResponse ──────────────────────────────────────────
@@ -439,6 +457,13 @@ public class ResponseServiceTests
     }
 
     // ── Fakes ────────────────────────────────────────────────────────────
+
+    private sealed class SomeCustomException : Exception
+    {
+        public SomeCustomException(string message) : base(message)
+        {
+        }
+    }
 
     private sealed class RecordingSender : ISender
     {


### PR DESCRIPTION
## Summary
- When a handler throws, `StrictMessageHandler` wraps the exception in `EventContextHandlerException` before it reaches `ResponseService`, so the WebApp's Error type field showed the wrapper's full name instead of the exception the operator actually cares about.
- `ResponseService.CreateErrorContent` now unwraps the wrapper and records the inner exception's simple name (e.g. `SampleApiException`), keeping the field readable. `ErrorText` is unchanged.

## Testing
- New test: a handler-thrown custom exception wrapped in `EventContextHandlerException` records its own type name as `ErrorType`.
- Existing `ResponseServiceTests` updated from `FullName` to simple-name expectation; full `NimBus.Core.Tests` suite green (134 passed).
- `dotnet build -c Release` clean.