### PR TITLE
feat(webapp): payload and resubmit-with-changes use the original request payload

### DIFF
--- a/src/NimBus.WebApp/ClientApp/src/components/event-details/message-listing.test.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/event-details/message-listing.test.tsx
@@ -5,7 +5,9 @@ import moment from "moment";
 import * as api from "api-client";
 import MessageListing, {
   diffMs,
+  getHandoffResult,
   getHistoryQueueTimeMs,
+  getResubmitPayload,
 } from "./message-listing";
 
 // MessageListing internally constructs an api.Client and queries `getMe()` on
@@ -292,5 +294,233 @@ describe("MessageListing — Blocked by row (spec 006)", () => {
   it("does not render 'Blocked by' for a non-deferred event even when blockedByEventId is provided", () => {
     spec006RenderListing(spec006BuildEvent({ resolutionStatus: "Completed" }), SPEC_006_BLOCKED_BY);
     expect(screen.queryByText("Blocked by")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Original-request payload resolution (ported from DIS 678f1cb3 / c555093d).
+// ---------------------------------------------------------------------------
+function historyMsg(props: {
+  messageType: api.MessageType | string;
+  enqueuedTimeUtc?: string;
+  eventContent?: string;
+}): api.Message {
+  return {
+    messageType: props.messageType as api.MessageType,
+    enqueuedTimeUtc: props.enqueuedTimeUtc
+      ? moment(props.enqueuedTimeUtc)
+      : undefined,
+    eventContent: props.eventContent,
+  } as api.Message;
+}
+
+describe("getResubmitPayload", () => {
+  it("returns the original EventRequest payload for a failed hand-off", () => {
+    // The terminal ErrorResponse/HandoffFailedRequest carry no event content;
+    // resubmit must replay the EventRequest's payload.
+    const result = getResubmitPayload([
+      historyMsg({
+        messageType: api.MessageType.EventRequest,
+        enqueuedTimeUtc: "2026-06-01T23:36:50.000Z",
+        eventContent: '{"Fail":true}',
+      }),
+      historyMsg({
+        messageType: api.MessageType.PendingHandoffResponse,
+        enqueuedTimeUtc: "2026-06-01T23:36:51.000Z",
+        eventContent: '{"Fail":true}',
+      }),
+      historyMsg({
+        messageType: api.MessageType.HandoffFailedRequest,
+        enqueuedTimeUtc: "2026-06-01T23:37:02.000Z",
+      }),
+      historyMsg({
+        messageType: api.MessageType.ErrorResponse,
+        enqueuedTimeUtc: "2026-06-01T23:37:02.000Z",
+      }),
+    ]);
+
+    expect(result).toBe('{"Fail":true}');
+  });
+
+  it("prefers the latest payload-carrying request (e.g. a prior resubmission)", () => {
+    const result = getResubmitPayload([
+      historyMsg({
+        messageType: api.MessageType.EventRequest,
+        enqueuedTimeUtc: "2026-06-01T10:00:00.000Z",
+        eventContent: '{"v":1}',
+      }),
+      historyMsg({
+        messageType: api.MessageType.ResubmissionRequest,
+        enqueuedTimeUtc: "2026-06-01T11:00:00.000Z",
+        eventContent: '{"v":2}',
+      }),
+    ]);
+
+    expect(result).toBe('{"v":2}');
+  });
+
+  it("ignores response messages even when they carry content", () => {
+    const result = getResubmitPayload([
+      historyMsg({
+        messageType: api.MessageType.EventRequest,
+        enqueuedTimeUtc: "2026-06-01T10:00:00.000Z",
+        eventContent: '{"req":true}',
+      }),
+      historyMsg({
+        messageType: api.MessageType.ErrorResponse,
+        enqueuedTimeUtc: "2026-06-01T10:00:01.000Z",
+        eventContent: '{"resp":true}',
+      }),
+    ]);
+
+    expect(result).toBe('{"req":true}');
+  });
+
+  it("skips payload-less requests and normalises messageType casing", () => {
+    const result = getResubmitPayload([
+      historyMsg({
+        messageType: "EVENTREQUEST",
+        enqueuedTimeUtc: "2026-06-01T10:00:00.000Z",
+        eventContent: '{"req":true}',
+      }),
+      historyMsg({
+        messageType: api.MessageType.RetryRequest,
+        enqueuedTimeUtc: "2026-06-01T10:05:00.000Z",
+        // No eventContent — must not shadow the earlier payload.
+      }),
+    ]);
+
+    expect(result).toBe('{"req":true}');
+  });
+
+  it("returns undefined without history (caller falls back to event payload)", () => {
+    expect(getResubmitPayload(undefined)).toBeUndefined();
+    expect(getResubmitPayload([])).toBeUndefined();
+  });
+});
+
+describe("getHandoffResult", () => {
+  it("returns the completed hand-off's external result details", () => {
+    const result = getHandoffResult([
+      historyMsg({
+        messageType: api.MessageType.EventRequest,
+        enqueuedTimeUtc: "2026-06-01T10:00:00.000Z",
+        eventContent: '{"Fail":false}',
+      }),
+      historyMsg({
+        messageType: api.MessageType.HandoffCompletedRequest,
+        enqueuedTimeUtc: "2026-06-01T10:05:00.000Z",
+        eventContent: '{"batchId":"abc","rows":42}',
+      }),
+    ]);
+
+    expect(result).toBe('{"batchId":"abc","rows":42}');
+  });
+
+  it("returns undefined when the completed hand-off carried no details", () => {
+    expect(
+      getHandoffResult([
+        historyMsg({
+          messageType: api.MessageType.HandoffCompletedRequest,
+          enqueuedTimeUtc: "2026-06-01T10:05:00.000Z",
+        }),
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for a failed hand-off (no result block)", () => {
+    expect(
+      getHandoffResult([
+        historyMsg({
+          messageType: api.MessageType.EventRequest,
+          eventContent: '{"x":1}',
+        }),
+        historyMsg({ messageType: api.MessageType.HandoffFailedRequest }),
+        historyMsg({ messageType: api.MessageType.ErrorResponse }),
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined without history", () => {
+    expect(getHandoffResult(undefined)).toBeUndefined();
+    expect(getHandoffResult([])).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Render integration — the Payload block shows the request payload and a
+// completed hand-off's details get their own "Handoff result" block.
+// ---------------------------------------------------------------------------
+describe("MessageListing payload blocks", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+  });
+
+  function renderWithHistory(messages: api.Message[]) {
+    stubMe();
+    const event = {
+      eventId: "evt-1",
+      sessionId: "sess-1",
+      lastMessageId: "msg-1",
+      endpointId: "ep-1",
+      eventTypeId: "Demo.Type",
+      resolutionStatus: "Completed",
+    } as unknown as api.Event;
+    return render(
+      <MemoryRouter>
+        <MessageListing
+          eventDetails={event}
+          messages={messages}
+          eventTypes={[]}
+          skipEvent={async () => {}}
+          resubmitEvent={async () => {}}
+          resubmitEventWithChanges={async () => {}}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders a 'Handoff result' block for a completed hand-off with details", () => {
+    renderWithHistory([
+      historyMsg({
+        messageType: api.MessageType.EventRequest,
+        enqueuedTimeUtc: "2026-06-01T10:00:00.000Z",
+        eventContent: '{"Fail":false}',
+      }),
+      historyMsg({
+        messageType: api.MessageType.HandoffCompletedRequest,
+        enqueuedTimeUtc: "2026-06-01T10:05:00.000Z",
+        eventContent: '{"batchId":"abc"}',
+      }),
+    ]);
+
+    expect(screen.getByText("Payload")).toBeTruthy();
+    expect(screen.getByText("Handoff result")).toBeTruthy();
+  });
+
+  it("renders the request payload without a result block when no hand-off completed", () => {
+    renderWithHistory([
+      historyMsg({
+        messageType: api.MessageType.EventRequest,
+        enqueuedTimeUtc: "2026-06-01T10:00:00.000Z",
+        eventContent: '{"Fail":true}',
+      }),
+      historyMsg({
+        messageType: api.MessageType.ErrorResponse,
+        enqueuedTimeUtc: "2026-06-01T10:00:01.000Z",
+      }),
+    ]);
+
+    expect(screen.getByText("Payload")).toBeTruthy();
+    expect(screen.queryByText("Handoff result")).toBeNull();
   });
 });

--- a/src/NimBus.WebApp/ClientApp/src/components/event-details/message-listing.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/event-details/message-listing.tsx
@@ -148,6 +148,73 @@ export function getHistoryQueueTimeMs(
   return span;
 }
 
+// Lowercase a messageType so comparisons tolerate transport casing (same
+// rule getHistoryQueueTimeMs applies inline).
+function normalizeMessageType(rawType: unknown): string {
+  return typeof rawType === "string" ? rawType.toLowerCase() : "";
+}
+
+// Request message types that carry the original event payload — mirrors the
+// backend's resubmit source selection
+// (EventImplementation.LatestRequestMessageWithPayload). Handoff control
+// requests (HandoffCompleted/FailedRequest) and SkipRequest carry no payload;
+// terminal *Response messages may carry a stale/empty payload (notably a
+// failed hand-off's ErrorResponse). "processdeferredrequest" exists in Core
+// but is folded to Unknown by the current API contract — kept here so the
+// filter stays correct if the contract ever surfaces it.
+const PAYLOAD_REQUEST_TYPES = new Set([
+  "eventrequest",
+  "resubmissionrequest",
+  "retryrequest",
+  "continuationrequest",
+  "processdeferredrequest",
+]);
+
+// The payload that Resubmit replays: the latest request message that actually
+// carries event content — the same rule the backend uses. For a failed
+// hand-off the event's own payload is the empty terminal ErrorResponse, so
+// both the Payload section and the "Resubmit with changes" modal must use the
+// original request payload instead. Returns undefined when no such message is
+// in the loaded history (caller falls back to the event payload).
+export function getResubmitPayload(
+  messages?: api.Message[],
+): string | undefined {
+  if (!messages?.length) return undefined;
+  return messages
+    .filter(
+      (m) =>
+        PAYLOAD_REQUEST_TYPES.has(normalizeMessageType(m.messageType)) &&
+        !!m.eventContent,
+    )
+    .sort(
+      (a, b) =>
+        (b.enqueuedTimeUtc?.valueOf() ?? 0) -
+        (a.enqueuedTimeUtc?.valueOf() ?? 0),
+    )[0]?.eventContent;
+}
+
+// A completed hand-off carries the external system's optional result details
+// on the HandoffCompletedRequest's event content (the original request
+// payload lives elsewhere). Surface it as a separate "Handoff result" block.
+// Returns undefined when there is no completed hand-off or it carried no
+// details.
+export function getHandoffResult(
+  messages?: api.Message[],
+): string | undefined {
+  if (!messages?.length) return undefined;
+  return messages
+    .filter(
+      (m) =>
+        normalizeMessageType(m.messageType) === "handoffcompletedrequest" &&
+        !!m.eventContent,
+    )
+    .sort(
+      (a, b) =>
+        (b.enqueuedTimeUtc?.valueOf() ?? 0) -
+        (a.enqueuedTimeUtc?.valueOf() ?? 0),
+    )[0]?.eventContent;
+}
+
 function statusToBadgeVariant(
   status: string | undefined,
 ):
@@ -253,9 +320,18 @@ export default function MessageListing(props: IMessageListingProps) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const deleteBtn: IButtonState = { isDisabled: false, text: "Delete" };
   const [deleteButton, setDeleteButton] = useState(deleteBtn);
-  const [textAreaValue, setTextAreaValue] = useState(
-    props.eventDetails?.messageContent?.eventContent?.eventJson,
-  );
+  // The original event payload: the latest payload-carrying request message
+  // in the loaded history, falling back to the event's own (server-resolved)
+  // payload. For a failed hand-off the event's own content is the empty
+  // terminal ErrorResponse, so the Payload section and the
+  // resubmit-with-changes modal must render/prefill the request payload.
+  const resubmitPayload =
+    getResubmitPayload(props.messages) ??
+    props.eventDetails?.messageContent?.eventContent?.eventJson;
+  // A completed hand-off's optional external result details (separate from
+  // the original payload), shown in its own block when present.
+  const handoffResult = getHandoffResult(props.messages);
+  const [textAreaValue, setTextAreaValue] = useState(resubmitPayload);
   const [eventTypeIdValue, setEventTypeIdValue] = useState(
     props.eventDetails?.eventTypeId,
   );
@@ -280,10 +356,14 @@ export default function MessageListing(props: IMessageListingProps) {
   const [operatorName, setOperatorName] = useState<string>("operator");
   const [piiRevealed, setPiiRevealed] = useState(false);
 
+  // The textarea prefill tracks the resolved request payload — `messages`
+  // loads asynchronously after `eventDetails`, so keying on the payload (not
+  // the event object) picks up the request payload once the history arrives.
   useEffect(() => {
-    setTextAreaValue(
-      props.eventDetails?.messageContent?.eventContent?.eventJson,
-    );
+    setTextAreaValue(resubmitPayload);
+  }, [resubmitPayload]);
+
+  useEffect(() => {
     setShowErrorDetails(false);
     // Reset handoff UI when navigating to a different event.
     setHeroOverride(null);
@@ -437,8 +517,10 @@ export default function MessageListing(props: IMessageListingProps) {
     }
   };
 
-  const payloadJson = props.eventDetails?.messageContent?.eventContent?.eventJson;
-  const hasPii = !!payloadJson && /\$piiMasked"\s*:\s*true/i.test(payloadJson);
+  // PII gate evaluates the payload actually rendered below (the resolved
+  // request payload), so a masked request payload stays blurred by default.
+  const hasPii =
+    !!resubmitPayload && /\$piiMasked"\s*:\s*true/i.test(resubmitPayload);
 
   const reprocessBtn: IButtonState = { isDisabled: false, text: "Reprocess" };
   const [reprocessButton, setReprocessButton] = useState(reprocessBtn);
@@ -871,7 +953,11 @@ export default function MessageListing(props: IMessageListingProps) {
         </>
       )}
 
-      {payloadJson && (
+      {/* Payload — the original event content (the latest request message's
+          payload, falling back to the event's own). For a hand-off this is
+          the EventRequest, not the terminal settlement message which carries
+          no original payload. */}
+      {resubmitPayload && (
         <div className="mt-4">
           {/* Masked payloads carry "$piiMasked": true. Keep the (already
               server-hashed) values blurred by default so PII tokens aren't
@@ -904,9 +990,20 @@ export default function MessageListing(props: IMessageListingProps) {
                 `/Messages?eventId=${_guid}`
               }
             >
-              {safeFormatJson(payloadJson)}
+              {safeFormatJson(resubmitPayload)}
             </CodeBlock>
           </div>
+        </div>
+      )}
+
+      {/* Handoff result — the external system's completion details, when the
+          handler supplied any on CompleteHandoff (a HandoffCompletedRequest's
+          eventContent). Distinct from the event payload above. */}
+      {handoffResult && (
+        <div className="mt-4">
+          <CodeBlock title="Handoff result" subtitle="application/json">
+            {safeFormatJson(handoffResult)}
+          </CodeBlock>
         </div>
       )}
 
@@ -918,11 +1015,7 @@ export default function MessageListing(props: IMessageListingProps) {
               Original event:
             </label>
             <pre className="bg-muted p-4 rounded text-sm overflow-x-auto max-h-96">
-              {props.eventDetails?.messageContent?.eventContent?.eventJson
-                ? safeFormatJson(
-                    props.eventDetails.messageContent.eventContent.eventJson,
-                  )
-                : ""}
+              {resubmitPayload ? safeFormatJson(resubmitPayload) : ""}
             </pre>
           </div>
           <div className="mb-4">

--- a/src/NimBus.WebApp/Controllers/ApiContract/EventImplementation.cs
+++ b/src/NimBus.WebApp/Controllers/ApiContract/EventImplementation.cs
@@ -23,6 +23,21 @@ namespace NimBus.WebApp.Controllers.ApiContract
 {
     public class EventImplementation : IEventApiController
     {
+        // Payload-carrying request message types — the ones that actually carry
+        // the original event JSON to be re-delivered on resubmit. Handoff control
+        // requests (HandoffCompleted/FailedRequest) and SkipRequest carry no
+        // payload; terminal *Response messages may carry a stale/empty payload
+        // (notably a failed hand-off's ErrorResponse). Mirrored by the frontend's
+        // PAYLOAD_REQUEST_TYPES in message-listing.tsx.
+        private static readonly Core.Messages.MessageType[] PayloadCarryingRequestTypes =
+        {
+            Core.Messages.MessageType.EventRequest,
+            Core.Messages.MessageType.ResubmissionRequest,
+            Core.Messages.MessageType.RetryRequest,
+            Core.Messages.MessageType.ContinuationRequest,
+            Core.Messages.MessageType.ProcessDeferredRequest,
+        };
+
         private readonly IPlatform platform;
         private readonly ILogger<EventImplementation> logger;
         private readonly INimBusMessageStore cosmosClient;
@@ -577,8 +592,21 @@ namespace NimBus.WebApp.Controllers.ApiContract
 
                 if (string.IsNullOrEmpty(eventTypeId))
                 {
-                    MessageEntity origMessage = await GetMessageWithFallback(eventId, errorResponse.OriginatingMessageId);
-                    eventTypeId = origMessage.EventTypeId;
+                    // Same source as the frontend's resubmit prefill: the latest
+                    // request message that carries the event payload (the original
+                    // EventRequest, or a later resubmission/retry). For a failed
+                    // hand-off the terminal ErrorResponse carries no event type,
+                    // so resolve it from the request history rather than the
+                    // originating message. Falls back to the originating-message
+                    // lookup when no request message carries a payload, and
+                    // finally to the terminal message itself.
+                    var history = await cosmosClient.GetEventHistory(eventId);
+                    MessageEntity requestMessage = LatestRequestMessageWithPayload(history)
+                        ?? await GetMessageWithFallback(eventId, errorResponse.OriginatingMessageId)
+                        ?? errorResponse;
+                    eventTypeId = !string.IsNullOrWhiteSpace(requestMessage.EventTypeId)
+                        ? requestMessage.EventTypeId
+                        : requestMessage.MessageContent?.EventContent?.EventTypeId!;
                 }
             }
 
@@ -796,6 +824,19 @@ namespace NimBus.WebApp.Controllers.ApiContract
                 return null;
             }
         }
+
+        // The latest request message that still carries the event payload — the
+        // "latest request message sent". Lets resubmit-with-changes resolve the
+        // event type from the original EventRequest (or a later Resubmission/
+        // Retry/Continuation/ProcessDeferredRequest) rather than the terminal
+        // ErrorResponse, which for a failed hand-off carries neither payload nor
+        // event type. Internal for unit tests (InternalsVisibleTo).
+        internal static MessageEntity? LatestRequestMessageWithPayload(IEnumerable<MessageEntity> history) =>
+            history
+                .Where(m => PayloadCarryingRequestTypes.Contains(m.MessageType)
+                         && !string.IsNullOrEmpty(m.MessageContent?.EventContent?.EventJson))
+                .OrderByDescending(m => m.EnqueuedTimeUtc)
+                .FirstOrDefault();
 
         private async Task<MessageEntity> GetMessageWithFallback(string eventId, string messageId)
         {

--- a/tests/NimBus.WebApp.Tests/EventImplementationResubmitPayloadTests.cs
+++ b/tests/NimBus.WebApp.Tests/EventImplementationResubmitPayloadTests.cs
@@ -1,0 +1,128 @@
+#pragma warning disable CA1707, CA2007
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NimBus.Core.Messages;
+using NimBus.MessageStore;
+using EventImplementation = NimBus.WebApp.Controllers.ApiContract.EventImplementation;
+
+namespace NimBus.WebApp.Tests;
+
+/// <summary>
+/// Coverage of <c>EventImplementation.LatestRequestMessageWithPayload</c> — the
+/// server-side selection of the "latest request message that carries the event
+/// payload" used by resubmit-with-changes to resolve the event type from the
+/// request history rather than the terminal ErrorResponse (which, for a failed
+/// hand-off, carries neither payload nor event type).
+/// </summary>
+[TestClass]
+public sealed class EventImplementationResubmitPayloadTests
+{
+    private static MessageEntity Entity(
+        MessageType type,
+        string enqueuedUtc,
+        string? eventJson = null,
+        string? eventTypeId = null) =>
+        new()
+        {
+            MessageType = type,
+            EnqueuedTimeUtc = DateTime.Parse(enqueuedUtc, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
+            EventTypeId = eventTypeId!,
+            MessageContent = eventJson == null
+                ? null!
+                : new MessageContent { EventContent = new EventContent { EventJson = eventJson, EventTypeId = eventTypeId! } },
+        };
+
+    [TestMethod]
+    public void Returns_original_EventRequest_for_a_failed_handoff()
+    {
+        // The terminal ErrorResponse / HandoffFailedRequest carry no event JSON;
+        // the original EventRequest must win.
+        var history = new List<MessageEntity>
+        {
+            Entity(MessageType.EventRequest, "2026-06-01T23:36:50Z", eventJson: "{\"Fail\":true}", eventTypeId: "Demo.Type"),
+            Entity(MessageType.PendingHandoffResponse, "2026-06-01T23:36:51Z", eventJson: "{\"Fail\":true}"),
+            Entity(MessageType.HandoffFailedRequest, "2026-06-01T23:37:02Z"),
+            Entity(MessageType.ErrorResponse, "2026-06-01T23:37:02Z"),
+        };
+
+        var result = EventImplementation.LatestRequestMessageWithPayload(history);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(MessageType.EventRequest, result!.MessageType);
+        Assert.AreEqual("Demo.Type", result.EventTypeId);
+    }
+
+    [TestMethod]
+    public void Prefers_the_latest_payload_carrying_request()
+    {
+        var history = new List<MessageEntity>
+        {
+            Entity(MessageType.EventRequest, "2026-06-01T10:00:00Z", eventJson: "{\"v\":1}"),
+            Entity(MessageType.ResubmissionRequest, "2026-06-01T11:00:00Z", eventJson: "{\"v\":2}"),
+        };
+
+        var result = EventImplementation.LatestRequestMessageWithPayload(history);
+
+        Assert.AreEqual(MessageType.ResubmissionRequest, result!.MessageType);
+        Assert.AreEqual("{\"v\":2}", result.MessageContent.EventContent.EventJson);
+    }
+
+    [TestMethod]
+    public void Ignores_responses_even_when_they_carry_content()
+    {
+        var history = new List<MessageEntity>
+        {
+            Entity(MessageType.EventRequest, "2026-06-01T10:00:00Z", eventJson: "{\"req\":true}"),
+            Entity(MessageType.ErrorResponse, "2026-06-01T10:00:01Z", eventJson: "{\"resp\":true}"),
+        };
+
+        var result = EventImplementation.LatestRequestMessageWithPayload(history);
+
+        Assert.AreEqual(MessageType.EventRequest, result!.MessageType);
+    }
+
+    [TestMethod]
+    public void Skips_payload_less_requests()
+    {
+        // A newer request without event JSON (e.g. a control retry) must not
+        // shadow the older request that actually carries the payload.
+        var history = new List<MessageEntity>
+        {
+            Entity(MessageType.EventRequest, "2026-06-01T10:00:00Z", eventJson: "{\"req\":true}"),
+            Entity(MessageType.RetryRequest, "2026-06-01T10:05:00Z"),
+        };
+
+        var result = EventImplementation.LatestRequestMessageWithPayload(history);
+
+        Assert.AreEqual(MessageType.EventRequest, result!.MessageType);
+    }
+
+    [TestMethod]
+    public void Counts_ProcessDeferredRequest_as_a_payload_source()
+    {
+        var history = new List<MessageEntity>
+        {
+            Entity(MessageType.EventRequest, "2026-06-01T10:00:00Z", eventJson: "{\"v\":1}"),
+            Entity(MessageType.ProcessDeferredRequest, "2026-06-01T10:10:00Z", eventJson: "{\"v\":2}"),
+        };
+
+        var result = EventImplementation.LatestRequestMessageWithPayload(history);
+
+        Assert.AreEqual(MessageType.ProcessDeferredRequest, result!.MessageType);
+    }
+
+    [TestMethod]
+    public void Returns_null_when_no_request_carries_a_payload()
+    {
+        var history = new List<MessageEntity>
+        {
+            Entity(MessageType.HandoffCompletedRequest, "2026-06-01T10:05:00Z", eventJson: "{\"batchId\":\"abc\"}"),
+            Entity(MessageType.ResolutionResponse, "2026-06-01T10:05:01Z"),
+        };
+
+        Assert.IsNull(EventImplementation.LatestRequestMessageWithPayload(history));
+        Assert.IsNull(EventImplementation.LatestRequestMessageWithPayload(new List<MessageEntity>()));
+    }
+}


### PR DESCRIPTION
## Summary
- The Payload section and the resubmit-with-changes prefill on Event Details previously used the terminal message's payload, which for failed handoffs and some response-terminated flows is empty or not what should be replayed. A new `getResubmitPayload()` walks the message history for the latest payload-carrying request (EventRequest, ResubmissionRequest, RetryRequest, ContinuationRequest, ProcessDeferredRequest) and falls back to the event content.
- For completed handoffs, a new "Handoff result" block renders the external completion details, which the payload substitution previously hid.
- Backend: `PostResubmitWithChangesEventIdsAsync` resolves the event type from request history when neither the request body nor the terminal message carries one, keeping the originating-message lookup as fallback.
- The `$piiMasked` reveal gate now evaluates the payload actually rendered, so masking behavior is preserved for history-sourced payloads.

## Testing
- 28 frontend tests green (payload resolution preference order, response/payload-less filtering, casing normalization, handoff-result rendering) + 6 new backend tests over `LatestRequestMessageWithPayload`; full WebApp test suite green.
- `dotnet build -c Release` clean (verified zero warning delta on the touched file); `npm run build` + `tsc --noEmit` clean.

## Note
Plain Resubmit (without changes) still replays the terminal response's payload server-side, so resubmitting a failed handoff that way can replay an empty payload — that fix belongs to the routing-lineage arc and is left as a follow-up.