### PR TITLE
fix(messagestore): match ILogger nullability in Serilog bridge and test logger

### DIFF
--- a/src/NimBus.MessageStore.CosmosDb/CosmosDbClient.cs
+++ b/src/NimBus.MessageStore.CosmosDb/CosmosDbClient.cs
@@ -161,11 +161,11 @@ public class CosmosDbClient : ICosmosDbClient, NimBus.MessageStore.Abstractions.
 
         public SerilogBridgeLogger(Serilog.ILogger serilog) => _serilog = serilog;
 
-        public IDisposable BeginScope<TState>(TState state) => null;
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
         public bool IsEnabled(LogLevel logLevel) => _serilog.IsEnabled(ToSerilogLevel(logLevel));
 
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
             => _serilog.Write(ToSerilogLevel(logLevel), exception, "{Message}", formatter(state, exception));
 
         private static Serilog.Events.LogEventLevel ToSerilogLevel(LogLevel level) => level switch

--- a/tests/NimBus.MessageStore.CosmosDb.Tests/CosmosDbClientUnitTests.cs
+++ b/tests/NimBus.MessageStore.CosmosDb.Tests/CosmosDbClientUnitTests.cs
@@ -51,13 +51,13 @@ public sealed class CosmosDbClientUnitTests
 
     private sealed class CapturingLogger : ILogger<CosmosDbClient>
     {
-        public List<(LogLevel Level, string Message, Exception Exception)> Entries { get; } = new();
+        public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = new();
 
-        public IDisposable BeginScope<TState>(TState state) where TState : notnull => null;
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
         public bool IsEnabled(LogLevel logLevel) => true;
 
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
             => Entries.Add((logLevel, formatter(state, exception), exception));
     }
 


### PR DESCRIPTION
## Summary
- Release builds of `NimBus.MessageStore.CosmosDb` (and its test project) have been failing since the Serilog-to-MEL migration: `SerilogBridgeLogger` and the test `CapturingLogger` implement `ILogger.Log`/`BeginScope` with non-nullable `Exception`/missing `notnull` constraint, which `TreatWarningsAsErrors` turns into CS8767/CS8633 errors. CI only builds Debug, so it slipped through.
- Aligns both implementations with the `ILogger` interface signatures (`Exception?`, `Func<TState, Exception?, string>`, `IDisposable? BeginScope<TState> where TState : notnull`).

## Testing
- `dotnet build -c Release` now clean for both projects (was 2 errors + 1 error).
- Cosmos unit/purge tests green.