### PR TITLE
feat(webapp): routing lineage on event details; plain resubmit replays original request

### DIFF
--- a/src/NimBus.WebApp/ClientApp/src/components/data-table/data-table-new.test.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/data-table/data-table-new.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import DataTable from "./data-table-new";
 import type { ITableHeadCell, ITableRow } from "./types";
@@ -10,6 +10,14 @@ import type { ITableHeadCell, ITableRow } from "./types";
 vi.mock("components/ui/toast", () => ({
   useToast: () => ({ addToast: () => {} }),
 }));
+
+// Spy on useNavigate so row-click navigation is observable; everything else
+// (MemoryRouter included) stays real.
+const navigateSpy = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => navigateSpy };
+});
 
 const headCells: ITableHeadCell[] = [
   { id: "name", label: "Name", numeric: false },
@@ -54,5 +62,96 @@ describe("DataTable (smoke)", () => {
     // Header still renders; body is empty — the noDataMessage default is
     // "No data" but the exact wording isn't part of this smoke contract.
     expect(screen.getByText("Name")).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Row navigation (ported from DIS 5adc92b7) — plain click navigates in place;
+// Ctrl/Cmd-click and middle-click open the row's route in a new tab.
+// ---------------------------------------------------------------------------
+describe("DataTable row navigation", () => {
+  const ROUTE = "/Message/Index/Bob/event-1/0";
+
+  const routedRows: ITableRow[] = [
+    {
+      id: "row-1",
+      route: ROUTE,
+      data: new Map([
+        ["name", { value: "AliceSaidHello", searchValue: "AliceSaidHello" }],
+        ["count", { value: 1, searchValue: 1 }],
+      ]),
+    },
+  ];
+
+  let openedTab: { opener: unknown };
+
+  beforeEach(() => {
+    navigateSpy.mockReset();
+    openedTab = { opener: {} };
+    vi.stubGlobal("open", vi.fn(() => openedTab));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function getRow(): HTMLElement {
+    renderTable(
+      <DataTable headCells={headCells} rows={routedRows} withToolbar={false} />,
+    );
+    return screen.getByText("AliceSaidHello").closest("tr") as HTMLElement;
+  }
+
+  function auxClick(row: HTMLElement, button: number) {
+    fireEvent(
+      row,
+      new MouseEvent("auxclick", { bubbles: true, cancelable: true, button }),
+    );
+  }
+
+  it("navigates in the same tab on a plain click", () => {
+    const row = getRow();
+
+    fireEvent.click(row);
+
+    expect(navigateSpy).toHaveBeenCalledWith(ROUTE);
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it("opens a new tab on Ctrl+click and nulls the opener", () => {
+    const row = getRow();
+
+    fireEvent.click(row, { ctrlKey: true });
+
+    expect(window.open).toHaveBeenCalledWith(ROUTE, "_blank");
+    expect(openedTab.opener).toBeNull();
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("opens a new tab on Cmd+click (metaKey)", () => {
+    const row = getRow();
+
+    fireEvent.click(row, { metaKey: true });
+
+    expect(window.open).toHaveBeenCalledWith(ROUTE, "_blank");
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("opens a new tab on middle-click", () => {
+    const row = getRow();
+
+    auxClick(row, 1);
+
+    expect(window.open).toHaveBeenCalledWith(ROUTE, "_blank");
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores a right-button auxclick (button 2)", () => {
+    const row = getRow();
+
+    auxClick(row, 2);
+
+    expect(window.open).not.toHaveBeenCalled();
+    expect(navigateSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/NimBus.WebApp/ClientApp/src/components/data-table/data-table-new.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/data-table/data-table-new.tsx
@@ -449,9 +449,45 @@ function SortIcon({ direction }: { direction: false | "asc" | "desc" }) {
   );
 }
 
+// Open a row's route in a new browser tab. No window-features string -> the
+// browser opens a tab (a features string would force a popup window instead).
+// Null out `opener` to avoid reverse-tabnabbing.
+function openRowInNewTab(route: string) {
+  const opened = window.open(route, "_blank");
+  if (opened) opened.opener = null;
+}
+
+// True when the click landed on an interactive element inside the row —
+// row-level navigation must not hijack those.
+function isInteractiveTarget(e: React.MouseEvent): boolean {
+  const target = e.target as HTMLElement;
+  return !!target.closest(
+    'input, button, a, [role="button"], [role="checkbox"]',
+  );
+}
+
 // Table row component with proper navigation handling
 function TableRow({ row, rowData }: { row: any; rowData: ITableRow }) {
   const navigate = useNavigate();
+
+  const handleRowClick = (e: React.MouseEvent) => {
+    if (!rowData.route || isInteractiveTarget(e)) return;
+    // Ctrl (Win/Linux) or Cmd (macOS) click -> open in a new tab, like a
+    // real link.
+    if (e.ctrlKey || e.metaKey) {
+      openRowInNewTab(rowData.route);
+      return;
+    }
+    navigate(rowData.route);
+  };
+
+  // Middle-click never fires onClick; handle it here. Guard button === 1 so a
+  // right-click (context menu) is left alone.
+  const handleRowAuxClick = (e: React.MouseEvent) => {
+    if (!rowData.route || e.button !== 1 || isInteractiveTarget(e)) return;
+    e.preventDefault();
+    openRowInNewTab(rowData.route);
+  };
 
   return (
     <tr
@@ -460,22 +496,8 @@ function TableRow({ row, rowData }: { row: any; rowData: ITableRow }) {
         row.getIsSelected() && "bg-primary-50 dark:bg-primary/10",
         rowData.route && "cursor-pointer",
       )}
-      onClick={
-        rowData.route
-          ? (e: React.MouseEvent) => {
-              // Don't navigate if clicking interactive elements
-              const target = e.target as HTMLElement;
-              if (
-                target.closest(
-                  'input, button, a, [role="button"], [role="checkbox"]',
-                )
-              ) {
-                return;
-              }
-              navigate(rowData.route!);
-            }
-          : undefined
-      }
+      onClick={rowData.route ? handleRowClick : undefined}
+      onAuxClick={rowData.route ? handleRowAuxClick : undefined}
       title={rowData.hoverText}
     >
       {row.getVisibleCells().map((cell: any) => (

--- a/src/NimBus.WebApp/ClientApp/src/components/endpoint-details/events-panel.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/endpoint-details/events-panel.tsx
@@ -245,8 +245,14 @@ const EventsPanel = (props: EventsPanelProps) => {
   const params = useParams();
   const endpointId = props.endpointId || params.id!;
 
-  const { applied, applyFilters, resetFilters, setFiltersWithoutHistory } =
-    useUrlFilters<EndpointFilterParams>(DEFAULT_ENDPOINT_FILTER_PARAMS);
+  // Filters live in the URL (shareable, Back/forward-safe) and are mirrored to
+  // sessionStorage per endpoint, so navigating away and back through the
+  // sidebar restores the operator's last-used filters. URL params always win
+  // over the stored copy.
+  const { applied, applyFilters, resetFilters } =
+    useUrlFilters<EndpointFilterParams>(DEFAULT_ENDPOINT_FILTER_PARAMS, {
+      persistKey: `endpoint-events-filter:${endpointId}`,
+    });
 
   // Bumped on every explicit Search click. The fetch effect is keyed on the URL
   // filter (`applied`), which does not change when Search is clicked without
@@ -294,17 +300,11 @@ const EventsPanel = (props: EventsPanelProps) => {
     setProjectContext: setEventFilter,
   };
 
-  // Materialise the default failed-message statuses into the URL on
-  // first mount when the URL has no status param. This makes the operator's
-  // default landing state explicit in the URL — essential for browser Back from
-  // a message-detail page to land back on the *same* filter the user saw.
-  React.useEffect(() => {
-    const url = new URL(window.location.href);
-    if (!url.searchParams.has("status")) {
-      setFiltersWithoutHistory(applied);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // NOTE: the defaults are no longer materialised into the URL on first mount.
+  // A clean URL re-derives the same default filter deterministically, and the
+  // hook's sessionStorage hydration (persistKey above) now owns the "restore
+  // last-used filters on a clean URL" concern — an explicit default write here
+  // would clobber it.
 
   // Re-fetch whenever the applied (URL) filter changes. Covers initial mount,
   // Search, Reset, browser Back/forward, and direct bookmark loads.

--- a/src/NimBus.WebApp/ClientApp/src/components/event-details/message-listing.test.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/event-details/message-listing.test.tsx
@@ -8,6 +8,7 @@ import MessageListing, {
   getHandoffResult,
   getHistoryQueueTimeMs,
   getResubmitPayload,
+  getRoutingFromTo,
 } from "./message-listing";
 
 // MessageListing internally constructs an api.Client and queries `getMe()` on
@@ -444,6 +445,189 @@ describe("getHandoffResult", () => {
   it("returns undefined without history", () => {
     expect(getHandoffResult(undefined)).toBeUndefined();
     expect(getHandoffResult([])).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Routing lineage (ported from DIS 5adc92b7) — response messages render
+// From = originating publisher, To = handling endpoint, dropping the internal
+// Resolver hop.
+// ---------------------------------------------------------------------------
+describe("getRoutingFromTo", () => {
+  function lineageEvent(props: Partial<api.IEvent>): api.Event {
+    return api.Event.fromJS(props);
+  }
+
+  function lineageMsg(props: Partial<api.IMessage>): api.Message {
+    return api.Message.fromJS(props);
+  }
+
+  it("shows publisher → handling endpoint for a response, dropping the Resolver", () => {
+    // Response handled by Bob; the originating EventRequest was published by
+    // Alice (carried on the request's originatingFrom). The response's own
+    // `from`/`originatingFrom` only know about the handling endpoint (Bob).
+    const result = getRoutingFromTo(
+      lineageEvent({
+        messageType: "ResolutionResponse",
+        from: "Bob",
+        to: "Resolver",
+        originatingFrom: "Bob",
+        originatingMessageId: "AliceSaidHello-1",
+      }),
+      [
+        lineageMsg({
+          messageId: "AliceSaidHello-1",
+          messageType: "EventRequest",
+          from: "Bob",
+          to: "Bob",
+          originatingFrom: "Alice",
+        }),
+      ],
+    );
+
+    expect(result).toEqual({ from: "Alice", to: "Bob" });
+  });
+
+  it("uses the originating request's literal from when it has no originatingFrom", () => {
+    const result = getRoutingFromTo(
+      lineageEvent({
+        messageType: "ResolutionResponse",
+        from: "Bob",
+        to: "Resolver",
+        originatingMessageId: "AliceSaidHello-1",
+      }),
+      [
+        lineageMsg({
+          messageId: "AliceSaidHello-1",
+          messageType: "EventRequest",
+          from: "Alice",
+          to: "Bob",
+        }),
+      ],
+    );
+
+    expect(result).toEqual({ from: "Alice", to: "Bob" });
+  });
+
+  it('falls through an empty-string originatingFrom (SQL Server null→"") to from', () => {
+    // SQL Server stores a missing originatingFrom as "", which `??` would keep
+    // (rendering a blank From). It must fall through to the request's `from`.
+    const result = getRoutingFromTo(
+      lineageEvent({
+        messageType: "ResolutionResponse",
+        from: "Bob",
+        to: "Resolver",
+        originatingFrom: "",
+        originatingMessageId: "AliceSaidHello-1",
+      }),
+      [
+        lineageMsg({
+          messageId: "AliceSaidHello-1",
+          messageType: "EventRequest",
+          from: "Alice",
+          to: "Bob",
+          originatingFrom: "",
+        }),
+      ],
+    );
+
+    expect(result).toEqual({ from: "Alice", to: "Bob" });
+  });
+
+  it("treats the 'self' sentinel as no publisher and falls through to from", () => {
+    const result = getRoutingFromTo(
+      lineageEvent({
+        messageType: "ResolutionResponse",
+        from: "Bob",
+        to: "Resolver",
+        originatingMessageId: "AliceSaidHello-1",
+      }),
+      [
+        lineageMsg({
+          messageId: "AliceSaidHello-1",
+          messageType: "EventRequest",
+          from: "Alice",
+          to: "Bob",
+          originatingFrom: "self",
+        }),
+      ],
+    );
+
+    expect(result).toEqual({ from: "Alice", to: "Bob" });
+  });
+
+  it("applies to every response message type", () => {
+    const messages = [
+      lineageMsg({
+        messageId: "AliceSaidHello-1",
+        messageType: "EventRequest",
+        from: "Bob",
+        originatingFrom: "Alice",
+      }),
+    ];
+    for (const messageType of [
+      "ErrorResponse",
+      "SkipResponse",
+      "DeferralResponse",
+      "UnsupportedResponse",
+      "PendingHandoffResponse",
+    ]) {
+      expect(
+        getRoutingFromTo(
+          lineageEvent({
+            messageType,
+            from: "Bob",
+            to: "Resolver",
+            originatingMessageId: "AliceSaidHello-1",
+          }),
+          messages,
+        ),
+      ).toEqual({ from: "Alice", to: "Bob" });
+    }
+  });
+
+  it("falls back to the event's own fields when the originating message is missing", () => {
+    const result = getRoutingFromTo(
+      lineageEvent({
+        messageType: "ResolutionResponse",
+        from: "Bob",
+        to: "Resolver",
+        originatingFrom: "Alice",
+        originatingMessageId: "AliceSaidHello-1",
+      }),
+      [],
+    );
+
+    expect(result).toEqual({ from: "Alice", to: "Bob" });
+  });
+
+  it("falls back to the handling endpoint when nothing else is known", () => {
+    const result = getRoutingFromTo(
+      lineageEvent({
+        messageType: "ResolutionResponse",
+        from: "Bob",
+        to: "Resolver",
+      }),
+    );
+
+    expect(result).toEqual({ from: "Bob", to: "Bob" });
+  });
+
+  it("leaves non-response messages untouched", () => {
+    const result = getRoutingFromTo(
+      lineageEvent({
+        messageType: "EventRequest",
+        from: "Alice",
+        to: "Bob",
+        originatingFrom: "Alice",
+      }),
+    );
+
+    expect(result).toEqual({ from: "Alice", to: "Bob" });
+  });
+
+  it("handles an undefined event", () => {
+    expect(getRoutingFromTo(undefined)).toEqual({ from: "", to: "" });
   });
 });
 

--- a/src/NimBus.WebApp/ClientApp/src/components/event-details/message-listing.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/event-details/message-listing.tsx
@@ -154,6 +154,62 @@ function normalizeMessageType(rawType: unknown): string {
   return typeof rawType === "string" ? rawType.toLowerCase() : "";
 }
 
+function isResponseMessageType(messageType: unknown): boolean {
+  return normalizeMessageType(messageType).endsWith("response");
+}
+
+// Stores persist an absent `originatingFrom` inconsistently — Cosmos leaves it
+// null, SQL Server normalises it to "" — and the wire default is the literal
+// "self" sentinel. None of those is a usable publisher name, so collapse them
+// all to empty.
+function cleanSender(value: string | undefined): string {
+  const trimmed = (value ?? "").trim();
+  return trimmed.toLowerCase() === "self" ? "" : trimmed;
+}
+
+// A message's sender: prefer `originatingFrom` (the original publisher when
+// stamped), fall back to the literal `from`. Uses truthy `||` (not `??`) so an
+// empty/"self" originatingFrom falls through to `from` instead of rendering
+// blank.
+function senderOf(message: api.Message | undefined): string {
+  return cleanSender(message?.originatingFrom) || cleanSender(message?.from);
+}
+
+// Response messages (ResolutionResponse, ErrorResponse, SkipResponse, …) are
+// addressed `To` the platform Resolver — an internal auditing hop, not a
+// meaningful routing leg. The operator-relevant lineage is "where the event
+// came from → which endpoint handled it". The publisher lives on the
+// originating EventRequest message in the history; the response's own `from`
+// is the handling endpoint. So for responses we render From = <publisher> and
+// To = <handling endpoint>, and never surface the Resolver. Non-response
+// messages keep their literal from/to.
+export function getRoutingFromTo(
+  event:
+    | Pick<
+        api.Event,
+        "from" | "to" | "originatingFrom" | "originatingMessageId" | "messageType"
+      >
+    | undefined,
+  messages?: api.Message[],
+): { from: string; to: string } {
+  const from = event?.from ?? "";
+  const to = event?.to ?? "";
+  if (!isResponseMessageType(event?.messageType)) {
+    return { from, to };
+  }
+
+  const originatingMessage = event?.originatingMessageId
+    ? messages?.find((m) => m.messageId === event.originatingMessageId)
+    : undefined;
+  // Prefer the originating EventRequest's sender (the true publisher); fall
+  // back to the event's own originatingFrom, then to its from, so partial
+  // histories still render something meaningful. `||` so empty/"self" values
+  // fall through rather than rendering a blank From.
+  const publisher =
+    senderOf(originatingMessage) || cleanSender(event?.originatingFrom) || from;
+  return { from: publisher, to: from };
+}
+
 // Request message types that carry the original event payload — mirrors the
 // backend's resubmit source selection
 // (EventImplementation.LatestRequestMessageWithPayload). Handoff control
@@ -331,6 +387,10 @@ export default function MessageListing(props: IMessageListingProps) {
   // A completed hand-off's optional external result details (separate from
   // the original payload), shown in its own block when present.
   const handoffResult = getHandoffResult(props.messages);
+  // Routing lineage: for response messages, From = the originating publisher
+  // (resolved from the EventRequest in the history) and To = the handling
+  // endpoint — never the internal Resolver hop.
+  const routing = getRoutingFromTo(props.eventDetails, props.messages);
   const [textAreaValue, setTextAreaValue] = useState(resubmitPayload);
   const [eventTypeIdValue, setEventTypeIdValue] = useState(
     props.eventDetails?.eventTypeId,
@@ -808,17 +868,32 @@ export default function MessageListing(props: IMessageListingProps) {
             }
           />
           <PropertyRow
-            label="Source Endpoint"
+            label="From"
             value={
-              (props.eventDetails?.originatingFrom ||
-                props.eventDetails?.from) && (
+              routing.from ? (
                 <Link
-                  to={`/Endpoints/Details/${props.eventDetails?.originatingFrom || props.eventDetails?.from}`}
+                  to={`/Endpoints/Details/${routing.from}`}
                   className="text-status-info font-semibold no-underline hover:underline"
                 >
-                  {props.eventDetails?.originatingFrom ||
-                    props.eventDetails?.from}
+                  {routing.from}
                 </Link>
+              ) : (
+                "—"
+              )
+            }
+          />
+          <PropertyRow
+            label="To"
+            value={
+              routing.to ? (
+                <Link
+                  to={`/Endpoints/Details/${routing.to}`}
+                  className="text-status-info font-semibold no-underline hover:underline"
+                >
+                  {routing.to}
+                </Link>
+              ) : (
+                "—"
               )
             }
           />

--- a/src/NimBus.WebApp/ClientApp/src/hooks/use-url-filters.test.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/hooks/use-url-filters.test.tsx
@@ -1,0 +1,78 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useUrlFilters } from "./use-url-filters";
+
+type Params = { status: string[]; q: string };
+const defaults: Params = { status: ["A"], q: "" };
+
+function wrapperAt(entry: string) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter initialEntries={[entry]}>{children}</MemoryRouter>
+  );
+}
+
+describe("useUrlFilters sessionStorage persistence", () => {
+  beforeEach(() => sessionStorage.clear());
+  afterEach(() => sessionStorage.clear());
+
+  it("mirrors applied filters into sessionStorage on change", () => {
+    const { result } = renderHook(
+      () => useUrlFilters(defaults, { persistKey: "k" }),
+      { wrapper: wrapperAt("/") },
+    );
+
+    act(() => result.current.applyFilters({ status: ["B"], q: "x" }));
+
+    const saved = JSON.parse(sessionStorage.getItem("k")!);
+    expect(saved).toMatchObject({ status: ["B"], q: "x" });
+  });
+
+  it("restores from sessionStorage when the URL has no owned params", async () => {
+    sessionStorage.setItem("k", JSON.stringify({ status: ["B"], q: "x" }));
+
+    const { result } = renderHook(
+      () => useUrlFilters(defaults, { persistKey: "k" }),
+      { wrapper: wrapperAt("/") },
+    );
+
+    await waitFor(() => expect(result.current.applied.status).toEqual(["B"]));
+    expect(result.current.applied.q).toBe("x");
+  });
+
+  it("lets the URL win over sessionStorage", async () => {
+    sessionStorage.setItem("k", JSON.stringify({ status: ["B"] }));
+
+    const { result } = renderHook(
+      () => useUrlFilters(defaults, { persistKey: "k" }),
+      { wrapper: wrapperAt("/?status=C") },
+    );
+
+    // Give any (suppressed) hydrate effect a tick; URL must remain authoritative.
+    await Promise.resolve();
+    expect(result.current.applied.status).toEqual(["C"]);
+  });
+
+  it("clears sessionStorage on reset", () => {
+    sessionStorage.setItem("k", JSON.stringify({ status: ["B"] }));
+
+    const { result } = renderHook(
+      () => useUrlFilters(defaults, { persistKey: "k" }),
+      { wrapper: wrapperAt("/?status=B") },
+    );
+
+    act(() => result.current.resetFilters());
+
+    expect(sessionStorage.getItem("k")).toBeNull();
+  });
+
+  it("does not touch sessionStorage when no persistKey is given", () => {
+    const { result } = renderHook(() => useUrlFilters(defaults), {
+      wrapper: wrapperAt("/"),
+    });
+
+    act(() => result.current.applyFilters({ status: ["B"] }));
+
+    expect(sessionStorage.length).toBe(0);
+  });
+});

--- a/src/NimBus.WebApp/ClientApp/src/hooks/use-url-filters.ts
+++ b/src/NimBus.WebApp/ClientApp/src/hooks/use-url-filters.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 
 /**
@@ -26,6 +26,20 @@ interface UseUrlFiltersResult<T extends FilterValues> {
 }
 
 /**
+ * Options for {@link useUrlFilters}.
+ */
+export interface UseUrlFiltersOptions {
+  /**
+   * When set, the applied filters are mirrored to `sessionStorage[persistKey]`
+   * on every change, and restored on first mount IF the URL carries none of the
+   * owned filter params. The URL always wins when present (so reload / Back /
+   * shared links behave normally); sessionStorage only fills the gap when the
+   * page is re-entered with a clean URL (e.g. via the sidebar).
+   */
+  persistKey?: string;
+}
+
+/**
  * Source-of-truth for filter state via the URL query string.
  *
  * Browser Back works for free — when the URL is restored, `applied` re-derives from the URL.
@@ -34,8 +48,10 @@ interface UseUrlFiltersResult<T extends FilterValues> {
  */
 export function useUrlFilters<T extends FilterValues>(
   defaults: T,
+  options?: UseUrlFiltersOptions,
 ): UseUrlFiltersResult<T> {
   const [params, setParams] = useSearchParams();
+  const persistKey = options?.persistKey;
 
   const applied = useMemo<T>(() => {
     const result = { ...defaults } as T;
@@ -117,8 +133,81 @@ export function useUrlFilters<T extends FilterValues>(
         out.append(k, v);
       }
     }
+    if (persistKey) {
+      try {
+        sessionStorage.removeItem(persistKey);
+      } catch {
+        /* storage unavailable — ignore */
+      }
+    }
     setParams(out);
-  }, [params, defaults, setParams]);
+  }, [params, defaults, setParams, persistKey]);
+
+  // Snapshot the persisted filters ONCE during the first render, before the
+  // mirror effect below can overwrite sessionStorage with the (default) initial
+  // `applied`. `null` = not yet captured; `{}` = captured but absent/invalid.
+  const savedSnapshotRef = useRef<Partial<T> | null>(null);
+  if (persistKey && savedSnapshotRef.current === null) {
+    try {
+      const raw = sessionStorage.getItem(persistKey);
+      savedSnapshotRef.current = raw ? (JSON.parse(raw) as Partial<T>) : {};
+    } catch {
+      savedSnapshotRef.current = {};
+    }
+  }
+
+  const isAllDefault = useCallback(
+    (vals: T): boolean =>
+      (Object.keys(defaults) as (keyof T & string)[]).every((key) => {
+        const def = defaults[key];
+        const val = vals[key];
+        if (Array.isArray(def)) {
+          const arr = (Array.isArray(val) ? val : def) as string[];
+          return (
+            arr.length === def.length &&
+            arr.every((v, i) => v === (def as string[])[i])
+          );
+        }
+        return (
+          ((val as string | undefined) ?? "") ===
+          ((def as string | undefined) ?? "")
+        );
+      }),
+    [defaults],
+  );
+
+  // Mirror NON-default applied filters to sessionStorage so they survive a full
+  // navigation away and back (the URL only survives reload / Back). Defaults are
+  // never stored — they are the fallback anyway, so a reset cleanly forgets.
+  useEffect(() => {
+    if (!persistKey) return;
+    try {
+      if (isAllDefault(applied)) {
+        sessionStorage.removeItem(persistKey);
+      } else {
+        sessionStorage.setItem(persistKey, JSON.stringify(applied));
+      }
+    } catch {
+      /* quota / private mode — ignore */
+    }
+  }, [persistKey, applied, isAllDefault]);
+
+  // On first mount, if the URL has none of our owned params, rehydrate the
+  // last-used filters (from the render-time snapshot) by writing them to the
+  // URL (no history entry). The URL takes precedence whenever it carries a param.
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (!persistKey || hydratedRef.current) return;
+    hydratedRef.current = true;
+    const saved = savedSnapshotRef.current;
+    if (!saved || Object.keys(saved).length === 0) return;
+    const hasOwnedParam = (Object.keys(defaults) as string[]).some((k) =>
+      params.has(k),
+    );
+    if (hasOwnedParam) return;
+    setParams(buildNextParams(saved), { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return { applied, applyFilters, resetFilters, setFiltersWithoutHistory };
 }

--- a/src/NimBus.WebApp/Controllers/ApiContract/EventImplementation.cs
+++ b/src/NimBus.WebApp/Controllers/ApiContract/EventImplementation.cs
@@ -150,11 +150,28 @@ namespace NimBus.WebApp.Controllers.ApiContract
                 return new BadRequestResult();
             }
 
+            // Resubmit must replay the original event payload. For a failed
+            // hand-off the lastMessageId points at the terminal ErrorResponse,
+            // whose MessageContent carries no usable event JSON — so source the
+            // payload (and, when missing, the event type) from the latest REQUEST
+            // message that actually carries it (the original EventRequest, or a
+            // later Resubmission/Retry/Continuation/ProcessDeferredRequest). Falls
+            // back to the resolved message so non-hand-off resubmits are
+            // unchanged. Same source as the frontend's resubmit prefill and the
+            // resubmit-with-changes event-type resolution below.
+            var history = await cosmosClient.GetEventHistory(eventId);
+            MessageEntity? latestRequest = LatestRequestMessageWithPayload(history);
+            MessageEntity requestMessage = latestRequest ?? errorResponse;
+
             eventTypeId = errorResponse.EventTypeId;
             if (string.IsNullOrEmpty(eventTypeId))
             {
-                MessageEntity origMessage = await GetMessageWithFallback(eventId, errorResponse.OriginatingMessageId);
-                eventTypeId = origMessage.EventTypeId;
+                MessageEntity typeSource = latestRequest
+                    ?? await GetMessageWithFallback(eventId, errorResponse.OriginatingMessageId)
+                    ?? errorResponse;
+                eventTypeId = !string.IsNullOrWhiteSpace(typeSource.EventTypeId)
+                    ? typeSource.EventTypeId
+                    : typeSource.MessageContent?.EventContent?.EventTypeId!;
             }
 
             if (errorResponse.OriginatingMessageId.Equals("self", StringComparison.Ordinal))
@@ -166,7 +183,7 @@ namespace NimBus.WebApp.Controllers.ApiContract
                 endpoint = errorResponse.From;
             }
 
-            var eventJson = errorResponse.MessageContent.EventContent.EventJson;
+            var eventJson = requestMessage.MessageContent?.EventContent?.EventJson!;
 
             if (!authorizationService.IsManagerOfEndpoint(endpoint))
             {

--- a/tests/NimBus.WebApp.Tests/EventImplementationPlainResubmitTests.cs
+++ b/tests/NimBus.WebApp.Tests/EventImplementationPlainResubmitTests.cs
@@ -1,0 +1,216 @@
+#pragma warning disable CA1707, CA2007
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NimBus.Core.Messages;
+using NimBus.Manager;
+using NimBus.MessageStore;
+using NimBus.Testing.Conformance;
+using NimBus.WebApp.Controllers.ApiContract;
+using NimBus.WebApp.Services;
+
+namespace NimBus.WebApp.Tests;
+
+/// <summary>
+/// Behavior of <see cref="EventImplementation.PostResubmitEventIdsAsync"/>:
+/// plain Resubmit must replay the latest payload-carrying REQUEST message
+/// (the original EventRequest, or a later Resubmission/Retry request) rather
+/// than the terminal ErrorResponse — which, for a failed hand-off, carries no
+/// usable event JSON. Complements
+/// <see cref="EventImplementationResubmitPayloadTests"/>, which covers the
+/// shared <c>LatestRequestMessageWithPayload</c> selection helper.
+/// </summary>
+[TestClass]
+public sealed class EventImplementationPlainResubmitTests
+{
+    private const string EventId = "evt-1";
+    private const string TerminalMessageId = "term-1";
+
+    [TestMethod]
+    public async Task Resubmit_replays_the_original_EventRequest_payload_for_a_failed_handoff()
+    {
+        // Failed hand-off history: the terminal ErrorResponse (which lastMessageId
+        // points at) carries no event JSON — the original EventRequest must win.
+        var store = new InMemoryMessageStore();
+        await store.StoreMessage(Entity(
+            "req-1", MessageType.EventRequest, "2026-06-01T23:36:50Z",
+            eventJson: "{\"Fail\":true}", eventTypeId: "Demo.Type",
+            from: "PublisherEp", to: "SubscriberEp"));
+        await store.StoreMessage(Entity(
+            "pending-1", MessageType.PendingHandoffResponse, "2026-06-01T23:36:51Z",
+            from: "SubscriberEp", to: "Resolver", originatingMessageId: "req-1"));
+        await store.StoreMessage(Entity(
+            TerminalMessageId, MessageType.ErrorResponse, "2026-06-01T23:37:02Z",
+            eventTypeId: "Demo.Type",
+            from: "SubscriberEp", to: "Resolver", originatingMessageId: "req-1"));
+
+        var manager = new CapturingManagerClient();
+        var sut = CreateSut(store, manager);
+
+        var result = await sut.PostResubmitEventIdsAsync(EventId, TerminalMessageId);
+
+        Assert.IsInstanceOfType(result, typeof(OkResult));
+        Assert.AreEqual("{\"Fail\":true}", manager.EventJson);
+        Assert.AreEqual("Demo.Type", manager.EventTypeId);
+        Assert.AreEqual("SubscriberEp", manager.Endpoint);
+    }
+
+    [TestMethod]
+    public async Task Resubmit_prefers_the_latest_payload_carrying_request()
+    {
+        // A prior resubmission supersedes the original EventRequest as the
+        // payload to replay.
+        var store = new InMemoryMessageStore();
+        await store.StoreMessage(Entity(
+            "req-1", MessageType.EventRequest, "2026-06-01T10:00:00Z",
+            eventJson: "{\"v\":1}", eventTypeId: "Demo.Type",
+            from: "PublisherEp", to: "SubscriberEp"));
+        await store.StoreMessage(Entity(
+            "resub-1", MessageType.ResubmissionRequest, "2026-06-01T11:00:00Z",
+            eventJson: "{\"v\":2}", eventTypeId: "Demo.Type",
+            from: "Manager", to: "SubscriberEp"));
+        await store.StoreMessage(Entity(
+            TerminalMessageId, MessageType.ErrorResponse, "2026-06-01T11:00:05Z",
+            eventTypeId: "Demo.Type",
+            from: "SubscriberEp", to: "Resolver", originatingMessageId: "resub-1"));
+
+        var manager = new CapturingManagerClient();
+        var sut = CreateSut(store, manager);
+
+        var result = await sut.PostResubmitEventIdsAsync(EventId, TerminalMessageId);
+
+        Assert.IsInstanceOfType(result, typeof(OkResult));
+        Assert.AreEqual("{\"v\":2}", manager.EventJson);
+    }
+
+    [TestMethod]
+    public async Task Resubmit_falls_back_to_the_terminal_message_when_no_request_carries_a_payload()
+    {
+        // Non-hand-off shape with a partial history: the terminal ErrorResponse
+        // still carries the payload, and behavior is unchanged.
+        var store = new InMemoryMessageStore();
+        await store.StoreMessage(Entity(
+            TerminalMessageId, MessageType.ErrorResponse, "2026-06-01T10:00:05Z",
+            eventJson: "{\"orig\":1}", eventTypeId: "Demo.Type",
+            from: "SubscriberEp", to: "Resolver", originatingMessageId: "req-1"));
+
+        var manager = new CapturingManagerClient();
+        var sut = CreateSut(store, manager);
+
+        var result = await sut.PostResubmitEventIdsAsync(EventId, TerminalMessageId);
+
+        Assert.IsInstanceOfType(result, typeof(OkResult));
+        Assert.AreEqual("{\"orig\":1}", manager.EventJson);
+        Assert.AreEqual("SubscriberEp", manager.Endpoint);
+    }
+
+    [TestMethod]
+    public async Task Resubmit_resolves_the_event_type_from_the_request_history_when_the_terminal_lacks_it()
+    {
+        var store = new InMemoryMessageStore();
+        await store.StoreMessage(Entity(
+            "req-1", MessageType.EventRequest, "2026-06-01T10:00:00Z",
+            eventJson: "{\"v\":1}", eventTypeId: "Demo.Type",
+            from: "PublisherEp", to: "SubscriberEp"));
+        await store.StoreMessage(Entity(
+            TerminalMessageId, MessageType.ErrorResponse, "2026-06-01T10:00:05Z",
+            from: "SubscriberEp", to: "Resolver", originatingMessageId: "req-1"));
+
+        var manager = new CapturingManagerClient();
+        var sut = CreateSut(store, manager);
+
+        var result = await sut.PostResubmitEventIdsAsync(EventId, TerminalMessageId);
+
+        Assert.IsInstanceOfType(result, typeof(OkResult));
+        Assert.AreEqual("Demo.Type", manager.EventTypeId);
+        Assert.AreEqual("{\"v\":1}", manager.EventJson);
+    }
+
+    private static MessageEntity Entity(
+        string messageId,
+        MessageType type,
+        string enqueuedUtc,
+        string? eventJson = null,
+        string? eventTypeId = null,
+        string? from = null,
+        string? to = null,
+        string? originatingMessageId = null) =>
+        new()
+        {
+            EventId = EventId,
+            MessageId = messageId,
+            SessionId = "sess-1",
+            MessageType = type,
+            EnqueuedTimeUtc = DateTime.Parse(enqueuedUtc, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
+            EventTypeId = eventTypeId!,
+            From = from!,
+            To = to!,
+            OriginatingMessageId = originatingMessageId!,
+            MessageContent = eventJson == null
+                ? null!
+                : new MessageContent { EventContent = new EventContent { EventJson = eventJson, EventTypeId = eventTypeId! } },
+        };
+
+    private static EventImplementation CreateSut(InMemoryMessageStore store, IManagerClient managerClient) =>
+        new(
+            applicationInsightsService: null!,
+            platform: null!,
+            managerClient,
+            NullLogger<EventImplementation>.Instance,
+            store,
+            new AllowAllAuthorizationService(),
+            adminService: null!,
+            serviceBusClient: null!,
+            new NoOpAuditLogService(),
+            new HttpContextAccessor { HttpContext = new DefaultHttpContext() });
+
+    private sealed class CapturingManagerClient : IManagerClient
+    {
+        public string? Endpoint { get; private set; }
+        public string? EventTypeId { get; private set; }
+        public string? EventJson { get; private set; }
+
+        public Task Resubmit(MessageEntity errorResponse, string endpoint, string eventTypeId, string eventJson)
+        {
+            Endpoint = endpoint;
+            EventTypeId = eventTypeId;
+            EventJson = eventJson;
+            return Task.CompletedTask;
+        }
+
+        public Task Skip(MessageEntity errorResponse, string endpoint, string eventTypeId) => throw new NotSupportedException();
+
+        [Obsolete("Bridge member required by the interface; not used in these tests.")]
+        public Task CompleteHandoff(MessageEntity pendingEntry, string endpoint, string? detailsJson = null) => throw new NotSupportedException();
+
+        [Obsolete("Bridge member required by the interface; not used in these tests.")]
+        public Task FailHandoff(MessageEntity pendingEntry, string endpoint, string errorText, string? errorType = null) => throw new NotSupportedException();
+    }
+
+    private sealed class NoOpAuditLogService : IAuditLogService
+    {
+        public Task LogAuditAsync(
+            MessageAuditType type,
+            HttpContext context,
+            bool accessDenied = false,
+            string? data = null,
+            string? eventId = null,
+            string? endpointId = null,
+            string? eventTypeId = null,
+            System.Threading.CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class AllowAllAuthorizationService : IEndpointAuthorizationService
+    {
+        public bool IsManagerOfEndpoint(string endpointId) => true;
+
+        [Obsolete("Bridge member required by the interface; not used in these tests.")]
+        public MessageAuditEntity GetMessageAuditEntity(MessageAuditType type) => throw new NotSupportedException();
+
+        public string? GetCurrentUserName() => "test-user";
+    }
+}


### PR DESCRIPTION
## Summary
- **Routing lineage**: on Event Details, response messages now show From = the originating publisher (resolved from the EventRequest in message history) and To = the handling endpoint, instead of surfacing the Resolver hop. Falls back to the event's own originatingFrom/from when no request exists in history; empty-string and "self" sentinels collapse through the fallback chain instead of rendering blank. The single "Source Endpoint" row is replaced by linked From/To rows.
- **Plain Resubmit replays the original request payload (server-side)**: for a failed handoff, `lastMessageId` points at the terminal ErrorResponse whose content carries no usable event JSON — resubmit previously replayed that empty payload. `PostResubmitEventIdsAsync` now resolves the latest payload-carrying request message via the existing `LatestRequestMessageWithPayload()` helper (same source the resubmit-with-changes path and the frontend prefill already use), falling back to the terminal message so non-handoff resubmits are unchanged.
- **Ctrl/Cmd-click on table rows opens the row in a new tab** (shared DataTable).
- **Endpoint event filters persist in sessionStorage** (keyed per endpoint) and are restored when returning to the page without query params; URL params always win, and only non-default filters are stored.

## Testing
- 4 new backend tests (failed-handoff replay, latest-request preference, terminal fallback, type-from-history) — `NimBus.WebApp.Tests` 84/84 green.
- 19 new frontend tests (9 lineage resolution, 5 modifier-click navigation, 5 sessionStorage/URL precedence) — vitest 116 passed; only the known pre-existing `app.test.tsx` jsdom failure remains.
- `dotnet build -c Release` clean (zero new warnings); `npm run build` + `tsc --noEmit` clean.