### PR TITLE
ive Flow monitor: real-time message-flow visualization (spec 020) + CRM/ERP demo drivers

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,8 +20,8 @@ dotnet run --project src/NimBus.CommandLine -- <command>
 
 | Option | Description |
 |---|---|
-| `-sbc`, `--sb-connection-string` | Azure Service Bus connection string (overrides `AzureServiceBus_ConnectionString` env var) |
-| `-dbc`, `--db-connection-string` | Cosmos DB connection string (overrides `CosmosDb_ConnectionString` env var) |
+| `-sbc`, `--sb-connection-string` | Azure Service Bus connection string, or a fully qualified namespace for Entra ID auth (overrides `AzureServiceBus_ConnectionString` env var) |
+| `-dbc`, `--db-connection-string` | Cosmos DB connection string, or an account endpoint URI for Entra ID auth (overrides `CosmosDb_ConnectionString` env var) |
 | `-h`, `--help` | Show help for any command |
 
 Connection strings can be set via environment variables instead of passing them on every call:
@@ -30,6 +30,21 @@ Connection strings can be set via environment variables instead of passing them 
 export AzureServiceBus_ConnectionString="Endpoint=sb://..."
 export CosmosDb_ConnectionString="AccountEndpoint=https://..."
 ```
+
+### Entra ID / managed identity
+
+Instead of a connection string, pass a fully qualified Service Bus namespace or a Cosmos DB
+account endpoint. The CLI then authenticates with `DefaultAzureCredential` (`az login`,
+managed identity, environment credentials, etc.) — the same heuristic the WebApp and
+Resolver use, so no keys need to be distributed:
+
+```bash
+export AzureServiceBus_ConnectionString="mybus.servicebus.windows.net"
+export CosmosDb_ConnectionString="https://myaccount.documents.azure.com/"
+```
+
+The signed-in identity needs `Azure Service Bus Data Owner` on the namespace and a Cosmos
+DB data-plane role (e.g. `Cosmos DB Built-in Data Contributor`) on the account.
 
 ---
 

--- a/docs/specs/020-live-flow-monitor/spec.md
+++ b/docs/specs/020-live-flow-monitor/spec.md
@@ -1,0 +1,227 @@
+# Feature Specification: Live Flow Monitor — Real-Time Data-Flow Visualization in the WebApp
+
+Feature Branch: `020-live-flow-monitor`
+Created: 2026-06-11
+Updated: 2026-06-11
+Status: Proposed
+Input: User description: "The site/demo/index.html would be a cool feature to have in NimBus, another real time monitoring tool (no replacing existing page). Make a solution design for having this capability in the NimBus web app."
+
+## Problem
+
+NimBus ships a marketing demo (`site/demo/index.html`, published on GitHub Pages) that visualizes the platform as an animated SVG diagram: business systems publish events, message dots travel along bezier edges through Service Bus topics into endpoints, outcomes flow to the Resolver, failures park in a deferred strip, and a sidebar shows live counters and an activity log. It is compelling — and entirely fake: 666 lines of self-contained vanilla JS with a hardcoded topology, a virtual-clock animation loop, and randomly generated traffic.
+
+The management WebApp has the real ingredients but no equivalent view:
+
+- The **Topology** page (`ClientApp/src/components/topology/`) renders the real platform shape (producers/consumers per event type from `/api/eventtypes`, traffic-weighted ribbons from `/api/metrics/overview`) but is static — a snapshot, not a live picture.
+- The **Monitor** page polls `/api/endpointstatus/all` every 5 s for wall displays — live-ish numbers, no spatial sense of *where* messages flow.
+- The **GridEventsHub** SignalR hub (authorized per spec 010) already broadcasts `endpointupdate` events carrying `EndpointStatusCount` (`EndpointId`, `EventTime`, `FailedCount`, `DeferredCount`, `PendingCount`, `UnsupportedCount`, `DeadletterCount`, `SubscriptionStatus`, `StorageStatus`) whenever an endpoint's projected counts change — from the Cosmos change-feed webhook or the Resolver write-path notifier (`IMessageStateChangeNotifier`).
+
+Operators watching an incident currently triangulate between Endpoints, Monitor, and Metrics. A live flow view answers at a glance: *which routes are moving, which endpoint is accumulating failures, where deferred messages are parking* — the demo's exact value, on real data.
+
+This spec designs that capability as a **new page** alongside the existing ones (explicitly: no existing page is replaced; the GitHub Pages demo stays untouched as marketing collateral).
+
+## Proposed Solution
+
+### Architecture overview
+
+```
+                       Phase 1 (existing signals only)
+┌─────────────┐   GET /api/eventtypes, /api/eventtypes/{id},
+│  Flow page   │◄── /api/metadatashort, /api/metrics/overview     (topology shape + seed counters)
+│  (/flow)     │
+│              │◄── SignalR endpointupdate (EndpointStatusCount)  (live deltas)
+│  ┌─────────┐ │
+│  │ layout   │ │   Phase 2 (server enrichment)
+│  │ engine   │ │◄── SignalR flowactivity ({endpointId, eventTypeId,
+│  ├─────────┤ │       status, eventId, occurredAtUtc})
+│  │ delta →  │ │        ▲
+│  │ events   │ │        │ broadcast by WebApp
+│  ├─────────┤ │   POST /api/storagehook/flow  (X-Webhook-Key)
+│  │ animator │ │        ▲
+│  └─────────┘ │        │ Resolver write path (it just stored the outcome,
+└─────────────┘          │ so it knows endpoint, event type, and status)
+```
+
+Three client-side modules, one optional server-side enrichment:
+
+1. **Layout engine** — builds the diagram from the real catalog: a layered, automatically positioned graph (no hand-placed coordinates). Columns: *producing endpoints grouped by system* → *endpoint topics* → *consuming endpoints* → *platform* (Resolver, Manager, storage provider). Reuses the bipartite convention already proven in `topology-flow.tsx` (an endpoint that both produces and consumes appears in both columns).
+2. **Delta-to-events derivation** — turns the real-time signals into renderable `FlowEvent`s. Phase 1 diffs consecutive `EndpointStatusCount` per endpoint; Phase 2 consumes per-outcome `flowactivity` directly.
+3. **Animator** — ports the demo's proven technique (rAF loop, `getPointAtLength` dot positioning, virtual clock with pause/speed) into a React-compatible imperative module. React declaratively renders the static SVG (nodes, chips, edges); a `FlowAnimator` class held in a `useRef` owns the transient dot layer via a single `<g ref>`, so per-frame updates never touch React reconciliation.
+
+### Phase 1 — ship on existing signals (no server changes)
+
+The only live signal today is aggregate: `endpointupdate` says "endpoint X's counts are now {…}". The derivation rules:
+
+| Observed delta (vs. previous snapshot) | Rendered as |
+|---|---|
+| `PendingCount` +N | N inbound dots, topic → endpoint (event-type color if the route has a single event type, neutral otherwise) |
+| `PendingCount` −N with `FailedCount`/`DeferredCount`/`DeadletterCount` unchanged | N completed dots endpoint → Resolver topic, green; `completed` counter +N |
+| `FailedCount` +N | N red dots endpoint → Resolver topic; `failed` counter +N; endpoint node enters `attention` state |
+| `DeferredCount` +N | N amber dots into the endpoint's parking strip; strip size = current `DeferredCount` |
+| `DeferredCount` −N | parked dots release back into the endpoint (resubmit/skip happened) |
+| `DeadletterCount` +N | purple dot endpoint → DLQ glyph; `deadlettered` counter +N |
+| `StorageStatus` ≠ "ok" / `SubscriptionStatus` degraded | node border state, no dots |
+
+Honest limitation, stated in the UI: Phase 1 animation is *derived from count deltas*, so individual dots are representative, not 1:1 messages, and event-type attribution is inferred from the route. This is the same fidelity the Monitor page offers, presented spatially.
+
+Counters seed from `/api/metrics/overview` for the selected period and advance with deltas. The activity log renders humanized delta lines ("BillingEndpoint: 3 failed (12:04:11)"). The deferred parking strip is fully real even in Phase 1 — `DeferredCount` is authoritative per endpoint.
+
+Resilience: if the hub connection drops, the hook falls back to polling `/api/endpointstatus/all` on the Monitor page's 5 s cadence and keeps diffing — same derivation path, lower latency guarantee, automatic re-upgrade when SignalR reconnects.
+
+### Phase 2 — per-outcome enrichment (server change, additive)
+
+The Resolver write path is the universal interception point: it stores every message outcome regardless of storage provider, and `IMessageStateChangeNotifier.NotifyEndpointStateChangedAsync(endpointId)` already fires there. Phase 2 widens that seam additively:
+
+- New notification carrying outcome metadata (no payloads): `FlowActivity { EndpointId, EventTypeId, Status, EventId, SessionId?, OccurredAtUtc }`.
+- Transport Resolver → WebApp: a new storage-hook route `POST /api/storagehook/flow` on the existing anonymous-but-key-gated webhook controller (reusing the `X-Webhook-Key` mechanism hardened in this release). Batched (the notifier buffers ~250 ms and posts arrays) to keep chatter bounded.
+- The WebApp broadcasts a new SignalR event `flowactivity` on `GridEventsHub` (additive; `endpointupdate` unchanged, all existing consumers unaffected).
+- The Flow page prefers `flowactivity` when present; the Phase 1 delta path remains as fallback so the page works against older Resolvers.
+
+This gives true per-message dots with correct event-type colors and enables the demo's session-blocking story (a `SessionId` on a failed outcome marks the session's subsequent deferred arrivals as "parked behind ORD-1234").
+
+### Phase 3 (optional, separate spec) — blocked-session drill-down
+
+Clicking a parked strip opens the real session view (the admin session preview API exists). Remediation actions (resubmit/skip) from within the flow view. Out of scope here.
+
+### What is deliberately NOT inherited from the demo
+
+- Hardcoded layout, fictional "AI agent" nodes, simulated traffic generator, `min-width:1280px` hard floor (the page gets horizontal scroll + filtering instead).
+- The demo file itself is not imported or iframed — the WebApp implementation is a fresh React/TypeScript port of the *technique* (layered SVG + dot animation), themed with the app's Tailwind tokens and dark mode.
+
+## Scope
+
+In scope:
+
+- New lazy-loaded page `Flow` at `/flow`, nav entry in the "Observe" sidebar group (alongside Topology and Monitor).
+- Automatic layered layout from `/api/eventtypes`, `/api/eventtypes/{id}`, `/api/metadatashort`.
+- SignalR `endpointupdate` subscription with reconnect + polling fallback; delta derivation per the table above.
+- Animator module (virtual clock, pause, speed 0.25–4×, dot pooling, `prefers-reduced-motion` and hidden-tab suspension).
+- Counters, activity log, deferred parking strips, endpoint attention states.
+- Endpoint/event-type filter; default view = top 12 busiest endpoints by the selected metrics period, "show all" toggle.
+- Phase 2 server enrichment as specified (new webhook route, `flowactivity` hub event, Resolver notifier extension) — may ship in a follow-up PR but is designed here so Phase 1 makes no decision that blocks it.
+- Vitest coverage for layout + delta derivation; MSTest coverage for the Phase 2 webhook → hub path.
+
+Out of scope:
+
+- Replacing or modifying the Topology, Monitor, or Metrics pages.
+- Modifying or removing `site/demo/index.html`.
+- Message payload display anywhere in the flow view (metadata only — consistent with hub payload policy).
+- Per-user endpoint filtering of hub broadcasts (spec 010 already records this as a known limitation; the flow page inherits it).
+- Remediation actions from the flow view (Phase 3).
+- Mobile layout below ~1024 px (matches Monitor's wall-display posture); the page remains usable with horizontal scroll.
+
+## User Scenarios & Testing
+
+### User Story 1 — Watch live traffic spatially (Priority: P1)
+
+As an operator, I want a live diagram of my actual platform showing messages moving from producers through topics into endpoints, so I can see at a glance which routes are active and healthy.
+
+Why this priority: this is the feature; everything else decorates it.
+
+Independent Test: open `/flow` on a platform with traffic (or use `/api/dev/seed` + manual `endpointupdate` triggers in Development); verify nodes match the real catalog and dots appear within 2 s of an `endpointupdate` broadcast.
+
+Acceptance Scenarios:
+
+1. Given an authenticated user and a platform with 3 endpoints, When they open `/flow`, Then the diagram shows exactly the catalog's endpoints, their topics, and the platform nodes, positioned by the layout engine without overlap.
+2. Given the page is open, When an `endpointupdate` arrives with `FailedCount` +2 for BillingEndpoint, Then two red dots animate from BillingEndpoint toward the Resolver topic, the failed counter increments by 2, and the activity log gains one line.
+3. Given the SignalR connection drops, When 5 s elapse, Then the page continues updating via polling and shows a "degraded — polling" indicator; when the hub reconnects, the indicator clears.
+
+### User Story 2 — Spot accumulating problems (Priority: P1)
+
+As an on-call engineer, I want failing and deferred messages to be visually loud (red dots, amber parking strips, endpoint attention state), so the flow view works as an incident radar, not just a pretty animation.
+
+Acceptance Scenarios:
+
+1. Given BillingEndpoint has `DeferredCount` 14, When the page loads, Then BillingEndpoint shows a parking strip sized/labeled 14 without any animation needing to occur first.
+2. Given an endpoint's `StorageStatus` is "unavailable", When rendered, Then the node shows a distinct degraded border state and a tooltip naming the condition.
+
+### User Story 3 — Control the animation (Priority: P2)
+
+As a user presenting or debugging, I want pause, speed control, and filtering, so the view stays legible under load and in demos.
+
+Acceptance Scenarios:
+
+1. Given heavy traffic, When the user pauses, Then dots freeze, counters stop advancing visually, and buffered deltas apply on resume without being lost.
+2. Given a platform with 40 endpoints, When the page loads, Then only the top 12 by traffic render by default, with a filter to add/remove endpoints and a "show all" toggle.
+3. Given the OS reports `prefers-reduced-motion`, When the page loads, Then dots are replaced by edge-pulse highlights (no traveling particles) while counters and log behave identically.
+
+### User Story 4 — Per-message fidelity (Phase 2) (Priority: P3)
+
+As an operator on a platform with the enriched Resolver, I want dots colored by actual event type and parked sessions labeled by real session IDs.
+
+Acceptance Scenario: Given the Resolver posts `FlowActivity` batches, When a `CustomerRegistered` outcome with status `failed` arrives, Then a dot in that event type's color travels the correct route and the log line names the event type and event ID (linking to the existing event-details page).
+
+## Edge Cases
+
+- **Burst deltas** (e.g., bulk resubmit changes counts by 500): render at most `MAX_DOTS_PER_DELTA` (default 8) representative dots with a "×500" badge; the log aggregates to one line.
+- **Concurrent dot ceiling**: hard cap (default 60 in-flight dots); beyond it, new events update counters/log only and edges pulse instead. No unbounded DOM growth.
+- **Counter drift** (Phase 1 derives from deltas; missed broadcasts drift): reconcile counters against `/api/endpointstatus/all` every 60 s; corrections apply silently.
+- **First snapshot**: the first `endpointupdate` per endpoint establishes a baseline — never animated (no diff exists), only recorded.
+- **Endpoint in update but not in catalog** (provisioned after page load): render a placeholder node and refetch the catalog once, debounced.
+- **Hidden tab**: rAF suspends, deltas buffer (bounded ring, latest-wins per endpoint); on visibility regained, counters jump-correct and animation resumes — no catch-up storm.
+- **Both-role endpoints**: appear in producer and consumer columns (existing topology-flow convention); dots route to the correct instance per direction.
+- **Phase 2 webhook unconfigured key**: identical fail-closed semantics to the existing storage-hook route (shared `ValidateWebhookKey`).
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: A new page at route `/flow`, lazy-loaded, with a sidebar entry "Flow" in the Observe group. No existing route, page, or nav entry changes.
+- **FR-002**: The layout engine MUST build nodes/edges exclusively from catalog APIs (no hardcoded topology) and MUST produce a deterministic layered layout: systems/producers → topics → consumers → platform.
+- **FR-003**: The page MUST subscribe to `endpointupdate` on the existing `GridEventsHub` connection (reusing the SPA's connection management, including auth cookie and reconnect policy) and MUST degrade to 5 s polling of `/api/endpointstatus/all` when the hub is unavailable, with a visible degraded indicator.
+- **FR-004**: Delta derivation MUST follow the mapping table in "Phase 1" above and MUST treat the first snapshot per endpoint as baseline-only.
+- **FR-005**: Counters (published/completed/failed/deferred/resubmitted/skipped/deadlettered) MUST seed from `/api/metrics/overview` and reconcile against `/api/endpointstatus/all` at most every 60 s.
+- **FR-006**: Deferred parking strips MUST reflect the authoritative `DeferredCount` per endpoint at all times (not only animated deltas).
+- **FR-007**: Controls MUST include pause/resume, speed (0.25×–4×), endpoint/event-type filter, and "show all"; defaults: running, 1×, top 12 endpoints by traffic.
+- **FR-008**: Animation MUST respect `prefers-reduced-motion` (edge pulses instead of dots) and MUST suspend the rAF loop when `document.visibilityState === "hidden"`.
+- **FR-009**: In-flight dots MUST be capped (default 60) and per-delta dots capped (default 8) with multiplier badges; caps are constants, not user settings, in v1.
+- **FR-010** (Phase 2): A new route `POST /api/storagehook/flow` on `StorageHookApiController` MUST accept batched `FlowActivity[]`, gated by the existing `X-Webhook-Key` validation, and broadcast each batch as a `flowactivity` hub event. The payload MUST contain metadata only — no message bodies.
+- **FR-011** (Phase 2): The Resolver MUST expose an additive notifier abstraction (extending or sibling to `IMessageStateChangeNotifier`) that buffers outcomes ~250 ms and posts batches to the configured WebApp hook URL; default implementation remains no-op, so existing deployments are unaffected.
+- **FR-012** (Phase 2): The Flow page MUST prefer `flowactivity` when received and silently fall back to FR-004 derivation otherwise; both paths share the same renderer.
+
+### Non-Functional Requirements
+
+- **NFR-001**: No new runtime frontend dependencies — the animator and layout are vanilla TypeScript + SVG, consistent with `topology-flow.tsx` (no d3 force layout, no animation library).
+- **NFR-002**: 60 fps target with ≤60 in-flight dots on a mid-range laptop; per-frame work touches only the imperative dot layer (zero React re-renders per frame; counter/log state updates throttled to ≥250 ms).
+- **NFR-003**: Page CPU near-zero when the tab is hidden.
+- **NFR-004**: Phase 1 makes zero server-side changes; Phase 2 changes are additive (new route, new hub event name in `Constants.EventSignalNames`, no changes to `endpointupdate` shape or consumers).
+- **NFR-005**: The page renders a 50-endpoint catalog in under 2 s on first load (catalog fetches already parallelized per event type in `use-topology-data.ts`; reuse that pattern, share its cache where practical).
+
+## Key Entities
+
+- **FlowNode**: `{ id, kind: "system" | "producer" | "topic" | "consumer" | "platform", title, column, row, health }` — computed by the layout engine.
+- **FlowRoute**: `{ id, fromNodeId, toNodeId, eventTypeIds, pathD, length }` — static per layout; `length` memoized from the rendered path for `getPointAtLength`.
+- **FlowEvent**: `{ routeId, status, color, multiplier, occurredAt }` — the renderer's unit of work, produced by either derivation path.
+- **EndpointStatusDelta**: `{ endpointId, pending, failed, deferred, deadlettered, …, baseline: bool }` — Phase 1 diff result.
+- **FlowActivity** (Phase 2 wire type): `{ endpointId, eventTypeId, status, eventId, sessionId?, occurredAtUtc }`.
+
+## Success Criteria
+
+- **SC-001**: An operator can identify the endpoint accumulating failures within 5 seconds of opening `/flow` during a fault injection (red dots + attention state + counter).
+- **SC-002**: Dots corresponding to an `endpointupdate` appear within 2 s of the broadcast on a connected client.
+- **SC-003**: Existing pages, hub consumers, and the GitHub Pages demo are byte-for-byte unaffected by Phase 1.
+- **SC-004**: The delta-derivation module reaches ≥90% branch coverage in vitest (it is pure: snapshot pairs in, `FlowEvent[]` out).
+- **SC-005**: With 40 endpoints and sustained updates, the page holds 60 fps and stays under the dot cap (verified with the dev seed + a scripted update burst).
+
+## Assumptions
+
+- The SPA already maintains (or can be refactored to share) a single `GridEventsHub` connection; the Flow page must not open a second connection.
+- `EndpointStatusCount` broadcasts fire for all storage providers in deployments that want live updates (Cosmos via change-feed webhook; SQL via the Resolver write-path notifier) — the flow page is only as live as that wiring, and the polling fallback covers the rest.
+- The catalog APIs expose enough shape (producers/consumers per event type, endpoint→system mapping via metadata) to attribute routes; where a route hosts multiple event types, Phase 1 colors dots neutrally.
+- Built-in platform endpoints (Resolver, Manager) are identifiable in the catalog (by well-known IDs) for placement in the platform column.
+
+## Out of Scope (explicit)
+
+- Replacing Topology/Monitor/Metrics; modifying the demo; payload display; per-user broadcast filtering; remediation actions; mobile-first layout; user-configurable caps; historical replay ("time travel") of past traffic.
+
+## Open Questions
+
+- **OQ-1**: Phase 2 transport — the spec proposes the storage-hook webhook (reuses existing key infrastructure); an Azure SignalR backplane shared by Resolver and WebApp is the alternative if a deployment already runs Azure SignalR. Decide at Phase 2 implementation time; FR-011's abstraction keeps both open.
+- **OQ-2**: Should the top-N default persist per user (localStorage, like existing hidden-column persistence) or reset per session? Default proposal: persist filter + speed in localStorage.
+- **OQ-3**: Whether `flowactivity` should also flow into the activity log on the existing Monitor page ticker. Cheap if yes, but scope says no page changes — revisit in Phase 2.
+
+## Resolved Questions
+
+- **RQ-1**: *Port the demo file or rewrite?* Rewrite in React/TS. The demo's imperative globals (closure-held `dots`, `timers`, direct DOM `prepend`) fight React reconciliation; only the technique (layered SVG, `getPointAtLength` dots, virtual clock) carries over. The hybrid React-static/imperative-overlay split confines non-declarative code to one ref-owned `<g>`.
+- **RQ-2**: *Real per-message animation in v1?* No. The only live signal is aggregate counts; pretending otherwise would be fabrication. Phase 1 is honest about derived dots; Phase 2 buys fidelity with an additive server change.
+- **RQ-3**: *New hub or existing?* Existing `GridEventsHub`. It is authorized, mapped, and consumed; a second hub adds connection overhead and another authorization surface for no benefit.

--- a/docs/superpowers/plans/020-live-flow-monitor-phase1.md
+++ b/docs/superpowers/plans/020-live-flow-monitor-phase1.md
@@ -1,0 +1,65 @@
+# Implementation Plan: Live Flow Monitor — Phase 1
+
+Spec: `docs/specs/020-live-flow-monitor/spec.md` (Phase 1 scope only: zero server changes)
+Branch: `020-live-flow-monitor`
+Created: 2026-06-11
+
+## Context discovered during planning
+
+- `@microsoft/signalr@^8` is already in `ClientApp/package.json` but **nothing in the SPA uses it today** — the hub broadcasts server-side with no client consumer. Phase 1 therefore introduces the first client-side hub connection, built as a shared module (`lib/grid-events-connection.ts`) so later pages can reuse it (satisfies the spec's "single connection" assumption via the refactor path).
+- `components/topology/types.ts` + `use-topology-data.ts` already compute `FlowEdge[]` (producer→consumer routes with event types and traffic) — the layout engine consumes `TopologyData` directly instead of re-fetching the catalog.
+- Hub path `/hubs/gridevents`, event name `endpointupdate`, payload `api.EndpointStatusCount` (`endpointId`, `failedCount`, `deferredCount`, `pendingCount`, `unsupportedCount`, `deadletterCount`, `storageStatus`, `subscriptionStatus`, `eventTime`).
+- Conventions: routes declared in `app.tsx` `navigation` array (lazy pages), sidebar nav in `sidebar.tsx` `NAV` groups, polling pattern in `hooks/use-monitor-data.ts` (5 s cadence, refs for per-tick state, localStorage persistence), vitest with `environment: 'jsdom'` in `vite.config.ts`, path aliases rooted at `src/` ("components/…", "hooks/…", "api-client").
+
+## Architecture (client-only)
+
+```
+use-topology-data ──► layout.ts ──► FlowLayout {nodes, routes, routesByEndpoint index}
+                                            │ (static SVG, React-rendered)
+grid-events-connection ─► use-flow-data ──► FlowActivityEvent[] ──► page resolves to routes ──► FlowAnimator (imperative <g> layer)
+        ▲ endpointupdate      │ derive-deltas.ts (pure)                                              │ dots, pulses, parking
+        └ polling fallback    └ counters / activity log / connection mode (React state, throttled)
+```
+
+Separation rule: **derivation is layout-agnostic** — it emits semantic `FlowActivityEvent`s keyed by endpoint; the page maps them onto concrete routes via the layout's `routesByEndpoint` index. This keeps the pure modules independently testable and lets Phase 2's `flowactivity` events feed the same renderer.
+
+## File map
+
+| # | File | Contents |
+|---|---|---|
+| 1 | `ClientApp/src/components/flow/types.ts` | Contracts (below) + constants + status palette |
+| 2 | `ClientApp/src/components/flow/derive-deltas.ts` (+ `.test.ts`) | Pure: snapshot diff → `FlowActivityEvent[]` per spec FR-004 table |
+| 3 | `ClientApp/src/components/flow/layout.ts` (+ `.test.ts`) | Pure: `TopologyData` → positioned layered layout + route paths |
+| 4 | `ClientApp/src/components/flow/animator.ts` | Imperative rAF dot engine (no React imports) |
+| 5 | `ClientApp/src/lib/grid-events-connection.ts` | Shared SignalR connection wrapper |
+| 6 | `ClientApp/src/hooks/use-flow-data.ts` | Orchestration hook (subscribe/poll/reconcile/log/counters) |
+| 7 | `ClientApp/src/pages/flow.tsx` | Page: canvas, controls, sidebar |
+| 8 | `app.tsx`, `components/sidebar.tsx` | Route `/Flow` + Observe nav entry |
+
+## Key contracts (authored first, in types.ts)
+
+- `StatusSnapshot` — numeric mirror of `EndpointStatusCount` (no moment.js in pure modules).
+- `EndpointDelta` / `FlowActivityEvent { endpointId, kind: "arrived"|"completed"|"failed"|"deferred"|"released"|"deadlettered", count, dots, multiplier, at }`.
+- `FlowNode { id, kind: "producer"|"topic"|"consumer"|"platform", x, y, w, h, title, endpointId?, health }`.
+- `FlowRoute { id, kind: "publish"|"deliver"|"outcome", fromNodeId, toNodeId, eventTypeIds, d }`.
+- `FlowLayout { nodes, routes, width, height, byEndpoint: Record<endpointId, { deliver: routeIds[], outcome: routeId, nodeId }> }`.
+- Constants: `MAX_INFLIGHT_DOTS = 60`, `MAX_DOTS_PER_DELTA = 8`, `POLL_MS = 5000`, `RECONCILE_MS = 60_000`, `LOG_MAX = 50`, `TOP_N_DEFAULT = 12`.
+
+## Honest-fidelity rules (from spec FR-004)
+
+First snapshot per endpoint = baseline (recorded, never animated). Counter advancement from deltas: `arrived→published`, `completed`, `failed`, `deferred`, `deadlettered`; `released` (deferred −N) appears in the log but does not guess resubmit-vs-skip for counters — reconciliation (60 s against `/api/endpointstatus/all`, period counters from `/api/metrics/overview`) corrects drift.
+
+## Task order
+
+1. Plan + types (this doc) — me.
+2. ⇉ In parallel (disjoint new files): derive-deltas (+tests), layout (+tests), animator — one subagent each, briefed on conventions below.
+3. Connection lib + hook + page + nav wiring (depends on 2).
+4. Verify: `npx vitest run`, `npm run build` (tsc + vite) in `src/NimBus.WebApp/ClientApp` (exact casing), existing tests stay green. Local commits only; no push.
+
+## Subagent brief (applies to all implementation tasks)
+
+- Working dir for npm/vitest: `c:\Git\NimBus-Master\NimBus\src\NimBus.WebApp\ClientApp` — exact case.
+- TypeScript strict; imports via `src/`-rooted aliases; **no new npm dependencies**.
+- Match the codebase's comment style: explanatory block comments stating *why* (see `use-monitor-data.ts`).
+- Tailwind semantic tokens (`bg-background`, theme-aware) — no hardcoded hex in JSX; SVG fills may use the status palette from `types.ts`.
+- Vitest, `environment: jsdom`; test files co-located (`*.test.ts`).

--- a/samples/AspirePubSub/AspirePubSub.AppHost/AspirePubSub.AppHost.csproj
+++ b/samples/AspirePubSub/AspirePubSub.AppHost/AspirePubSub.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.5">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.3">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.3" />
 
   </ItemGroup>
 

--- a/samples/AspirePubSub/AspirePubSub.Publisher/AspirePubSub.Publisher.csproj
+++ b/samples/AspirePubSub/AspirePubSub.Publisher/AspirePubSub.Publisher.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="13.3.5" />
+    <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="13.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/AspirePubSub/AspirePubSub.ResolverWorker/AspirePubSub.ResolverWorker.csproj
+++ b/samples/AspirePubSub/AspirePubSub.ResolverWorker/AspirePubSub.ResolverWorker.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="13.3.5" />
+    <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="13.4.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
   </ItemGroup>
 

--- a/samples/AspirePubSub/AspirePubSub.Subscriber/AspirePubSub.Subscriber.csproj
+++ b/samples/AspirePubSub/AspirePubSub.Subscriber/AspirePubSub.Subscriber.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="13.3.5" />
+    <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="13.4.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
   </ItemGroup>
 

--- a/samples/CrmErpDemo/Crm.Adapter/Crm.Adapter.csproj
+++ b/samples/CrmErpDemo/Crm.Adapter/Crm.Adapter.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="13.3.5" />
+    <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="13.4.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
   </ItemGroup>

--- a/samples/CrmErpDemo/Crm.Api/Crm.Api.csproj
+++ b/samples/CrmErpDemo/Crm.Api/Crm.Api.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="13.3.5" />
+    <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="13.4.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0-preview.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0-preview.*">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/CrmErpDemo/Crm.Web/src/App.tsx
+++ b/samples/CrmErpDemo/Crm.Web/src/App.tsx
@@ -3,6 +3,7 @@ import AccountsList from './pages/AccountsList';
 import AccountForm from './pages/AccountForm';
 import ContactsList from './pages/ContactsList';
 import ContactForm from './pages/ContactForm';
+import { simulator, useSimulator } from './simulator';
 
 const tabClass = ({ isActive }: { isActive: boolean }) =>
   `px-4 py-2 rounded-md text-sm font-medium ${
@@ -10,6 +11,7 @@ const tabClass = ({ isActive }: { isActive: boolean }) =>
   }`;
 
 export default function App() {
+  const sim = useSimulator();
   return (
     <div className="min-h-full">
       <header className="bg-white border-b border-slate-200">
@@ -19,7 +21,20 @@ export default function App() {
             <NavLink to="/accounts" className={tabClass}>Accounts</NavLink>
             <NavLink to="/contacts" className={tabClass}>Contacts</NavLink>
           </nav>
-          <span className="ml-auto text-xs text-slate-400">NimBus · CRM + ERP demo</span>
+          <button
+            type="button"
+            onClick={() => simulator.toggle()}
+            title="Auto-generate account & contact activity to drive Service Bus traffic"
+            className={`ml-auto inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              sim.running
+                ? 'bg-amber-100 text-amber-800 ring-1 ring-amber-300'
+                : 'bg-slate-100 text-slate-600 hover:bg-slate-200 border border-slate-200'
+            }`}
+          >
+            <span className={`h-2 w-2 rounded-full ${sim.running ? 'bg-amber-500 animate-pulse' : 'bg-slate-400'}`} />
+            {sim.running ? `Simulating · ${sim.actions}` : 'Simulate'}
+          </button>
+          <span className="text-xs text-slate-400">NimBus · CRM + ERP demo</span>
         </div>
       </header>
       <main className="max-w-5xl mx-auto px-6 py-8">

--- a/samples/CrmErpDemo/Crm.Web/src/simulator.ts
+++ b/samples/CrmErpDemo/Crm.Web/src/simulator.ts
@@ -1,0 +1,174 @@
+// Browser-side "Simulate mode" engine. When running, it mimics real users
+// working in the CRM by performing randomized create/update/delete activity on
+// accounts and contacts through the same /api calls the UI uses — which publish
+// CrmAccount*/CrmContact* events to the Service Bus. Up to MAX_WORKERS actions
+// run in parallel, with a random 500ms–2s gap between each worker's actions.
+
+import { useSyncExternalStore } from 'react';
+import { api } from './api';
+import { randomCompany, randomPerson, randomPick } from './fakeData';
+
+const MIN_DELAY = 500;
+const MAX_DELAY = 2000;
+const MAX_WORKERS = 2;
+
+export interface SimStats {
+  running: boolean;
+  actions: number;
+  lastAction: string | null;
+}
+
+type ActionKind =
+  | 'account.create'
+  | 'account.update'
+  | 'account.delete'
+  | 'contact.create'
+  | 'contact.update'
+  | 'contact.delete';
+
+// Biased toward creates so the dataset stays populated; deletes stay occasional.
+const WEIGHTS: ReadonlyArray<readonly [ActionKind, number]> = [
+  ['account.create', 25],
+  ['account.update', 20],
+  ['account.delete', 10],
+  ['contact.create', 25],
+  ['contact.update', 15],
+  ['contact.delete', 5],
+];
+
+/** Pure weighted pick — exported so the distribution is unit-testable. */
+export function pickWeighted(
+  weights: ReadonlyArray<readonly [ActionKind, number]>,
+  rnd: number = Math.random(),
+): ActionKind {
+  const total = weights.reduce((sum, [, w]) => sum + w, 0);
+  let r = rnd * total;
+  for (const [kind, w] of weights) {
+    if (r < w) return kind;
+    r -= w;
+  }
+  return weights[weights.length - 1][0];
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+class Simulator {
+  private running = false;
+  private actions = 0;
+  private lastAction: string | null = null;
+  // Bumped on every start() so workers from a previous run exit instead of
+  // doubling up if the toggle is flipped off then on again quickly.
+  private generation = 0;
+  private listeners = new Set<() => void>();
+  private snapshot: SimStats = { running: false, actions: 0, lastAction: null };
+
+  // Stable identities required by useSyncExternalStore.
+  subscribe = (cb: () => void): (() => void) => {
+    this.listeners.add(cb);
+    return () => {
+      this.listeners.delete(cb);
+    };
+  };
+
+  getSnapshot = (): SimStats => this.snapshot;
+
+  toggle(): void {
+    if (this.running) this.stop();
+    else this.start();
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.generation += 1;
+    const gen = this.generation;
+    this.emit();
+    for (let i = 0; i < MAX_WORKERS; i++) void this.worker(gen);
+  }
+
+  stop(): void {
+    if (!this.running) return;
+    this.running = false;
+    this.emit();
+  }
+
+  private emit(): void {
+    this.snapshot = { running: this.running, actions: this.actions, lastAction: this.lastAction };
+    this.listeners.forEach(l => l());
+  }
+
+  private async worker(gen: number): Promise<void> {
+    while (this.running && this.generation === gen) {
+      try {
+        this.lastAction = await this.act();
+        this.actions += 1;
+        this.emit();
+      } catch {
+        // Swallow transient failures (e.g. two workers racing to delete the
+        // same row → 404) so the loop keeps simulating.
+      }
+      await sleep(MIN_DELAY + Math.random() * (MAX_DELAY - MIN_DELAY));
+    }
+  }
+
+  private act(): Promise<string> {
+    switch (pickWeighted(WEIGHTS)) {
+      case 'account.create': return this.createAccount();
+      case 'account.update': return this.updateAccount();
+      case 'account.delete': return this.deleteAccount();
+      case 'contact.create': return this.createContact();
+      case 'contact.update': return this.updateContact();
+      case 'contact.delete': return this.deleteContact();
+    }
+  }
+
+  private async createAccount(): Promise<string> {
+    const a = await api.createAccount(randomCompany());
+    return `Created account ${a.legalName}`;
+  }
+
+  private async updateAccount(): Promise<string> {
+    const target = randomPick((await api.listAccounts()).filter(a => !a.isDeleted));
+    if (!target) return this.createAccount();
+    const a = await api.updateAccount(target.id, randomCompany());
+    return `Updated account ${a.legalName}`;
+  }
+
+  private async deleteAccount(): Promise<string> {
+    const target = randomPick((await api.listAccounts()).filter(a => !a.isDeleted));
+    if (!target) return this.createAccount();
+    await api.deleteAccount(target.id);
+    return `Deleted account ${target.legalName}`;
+  }
+
+  private async createContact(): Promise<string> {
+    const accounts = (await api.listAccounts()).filter(a => !a.isDeleted);
+    // ~70% of contacts belong to an existing account; the rest are unlinked.
+    const account = Math.random() < 0.7 ? randomPick(accounts) : undefined;
+    const c = await api.createContact({ ...randomPerson(), accountId: account?.id ?? null });
+    return `Created contact ${c.firstName} ${c.lastName}`;
+  }
+
+  private async updateContact(): Promise<string> {
+    const target = randomPick((await api.listContacts()).filter(c => !c.isDeleted));
+    if (!target) return this.createContact();
+    const c = await api.updateContact(target.id, { ...randomPerson(), accountId: target.accountId ?? null });
+    return `Updated contact ${c.firstName} ${c.lastName}`;
+  }
+
+  private async deleteContact(): Promise<string> {
+    const target = randomPick((await api.listContacts()).filter(c => !c.isDeleted));
+    if (!target) return this.createContact();
+    await api.deleteContact(target.id);
+    return `Deleted contact ${target.firstName} ${target.lastName}`;
+  }
+}
+
+export const simulator = new Simulator();
+
+/** React binding so the header button reflects sim state across route changes. */
+export function useSimulator(): SimStats {
+  return useSyncExternalStore(simulator.subscribe, simulator.getSnapshot);
+}

--- a/samples/CrmErpDemo/Crm.Web/vite.config.ts
+++ b/samples/CrmErpDemo/Crm.Web/vite.config.ts
@@ -23,6 +23,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: Number(env.PORT) || 5173,
+    // Aspire owns this port and proxies its front-door to it. Without strictPort,
+    // Vite silently falls back to the next free port when the assigned one is briefly
+    // held during a restart, leaving Aspire's proxy pointed at a dead port ("does not
+    // load"). Fail fast instead so Aspire restarts us cleanly on the right port.
+    strictPort: true,
     proxy: {
       '/api': { target: apiTarget, changeOrigin: true, secure: false },
     },

--- a/samples/CrmErpDemo/CrmErpDemo.AppHost/CrmErpDemo.AppHost.csproj
+++ b/samples/CrmErpDemo/CrmErpDemo.AppHost/CrmErpDemo.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.5">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.3">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.3.5" />
-    <PackageReference Include="Aspire.Hosting.Azure.Functions" Version="13.3.5" />
-    <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.5" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.3" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.4.3" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.3" />
+    <PackageReference Include="Aspire.Hosting.Azure.Functions" Version="13.4.3" />
+    <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.3" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.DbGate" Version="9.7.0" />
   </ItemGroup>
 

--- a/samples/CrmErpDemo/CrmErpDemo.AppHost/Program.cs
+++ b/samples/CrmErpDemo/CrmErpDemo.AppHost/Program.cs
@@ -163,6 +163,13 @@ else
     nimbusOps.WithEnvironment("EnableLocalDevAuthentication", "true");
 }
 
+// Live Flow / Monitor realtime push (spec 020). SQL storage has no Cosmos
+// Change Feed, so point the Resolver's write-path notifier at the WebApp's
+// storage-hook webhook; the WebApp downloads the counts and broadcasts the
+// endpointupdate that the Flow page animates. Best-effort — failures are
+// swallowed and the pages reconcile via polling.
+resolver.WithEnvironment("NimBus__Flow__WebAppUrl", nimbusOps.GetEndpoint("http"));
+
 // Provider-specific wiring. The WebApp/Resolver pick their backend off NimBus__StorageProvider;
 // we set it explicitly so the AppHost CLI flag wins over the runtime auto-detect fallback.
 if (storageProvider == "sqlserver")

--- a/samples/CrmErpDemo/Erp.Adapter.Functions/Clients/IProcessingDelayClient.cs
+++ b/samples/CrmErpDemo/Erp.Adapter.Functions/Clients/IProcessingDelayClient.cs
@@ -1,0 +1,10 @@
+namespace Erp.Adapter.Functions.Clients;
+
+public interface IProcessingDelayClient
+{
+    /// <summary>
+    /// The effective per-message processing delay in milliseconds, or 0 when the
+    /// setting is disabled or can't be read (so processing proceeds without delay).
+    /// </summary>
+    Task<int> GetProcessingDelayMsAsync(CancellationToken cancellationToken);
+}

--- a/samples/CrmErpDemo/Erp.Adapter.Functions/Clients/ProcessingDelayClient.cs
+++ b/samples/CrmErpDemo/Erp.Adapter.Functions/Clients/ProcessingDelayClient.cs
@@ -1,0 +1,25 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Erp.Adapter.Functions.Clients;
+
+public sealed class ProcessingDelayClient(HttpClient http, ILogger<ProcessingDelayClient> logger) : IProcessingDelayClient
+{
+    public async Task<int> GetProcessingDelayMsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await http.GetFromJsonAsync<DelayResponse>("/api/admin/processing-delay", cancellationToken);
+            return response is { Enabled: true } ? Math.Max(0, response.DelayMs) : 0;
+        }
+        catch (Exception ex)
+        {
+            // If the setting can't be read (e.g. erp-api unreachable), apply no delay —
+            // the message proceeds normally rather than stalling on a config lookup.
+            logger.LogDebug(ex, "Could not read processing-delay setting — applying no delay.");
+            return 0;
+        }
+    }
+
+    private sealed record DelayResponse(bool Enabled, int DelayMs, DateTimeOffset ChangedAt);
+}

--- a/samples/CrmErpDemo/Erp.Adapter.Functions/Pipeline/ProcessingDelayMiddleware.cs
+++ b/samples/CrmErpDemo/Erp.Adapter.Functions/Pipeline/ProcessingDelayMiddleware.cs
@@ -1,0 +1,30 @@
+using Erp.Adapter.Functions.Clients;
+using Microsoft.Extensions.Logging;
+using NimBus.Core.Extensions;
+using NimBus.Core.Messages;
+
+namespace Erp.Adapter.Functions.Pipeline;
+
+/// <summary>
+/// Demo-only knob: when processing-delay mode is on, hold each inbound message for the
+/// configured time before its handler runs — simulating a slow ERP consumer so message
+/// processing visibly takes time on the Flow monitor. The live setting is read from
+/// Erp.Api per message (same pull pattern as <see cref="ServiceModeMiddleware"/>).
+/// </summary>
+public sealed class ProcessingDelayMiddleware(IProcessingDelayClient client, ILogger<ProcessingDelayMiddleware> logger)
+    : IMessagePipelineBehavior
+{
+    public async Task Handle(IMessageContext context, MessagePipelineDelegate next, CancellationToken cancellationToken = default)
+    {
+        var delayMs = await client.GetProcessingDelayMsAsync(cancellationToken);
+        if (delayMs > 0)
+        {
+            logger.LogInformation(
+                "Delaying message {MessageId} ({EventTypeId}) by {DelayMs}ms — ERP processing-delay mode.",
+                context.MessageId, context.EventTypeId, delayMs);
+            await Task.Delay(delayMs, cancellationToken);
+        }
+
+        await next(context, cancellationToken);
+    }
+}

--- a/samples/CrmErpDemo/Erp.Adapter.Functions/Program.cs
+++ b/samples/CrmErpDemo/Erp.Adapter.Functions/Program.cs
@@ -51,6 +51,12 @@ builder.Services.AddHttpClient<IHandoffModeClient, HandoffModeClient>(c =>
     c.Timeout = TimeSpan.FromSeconds(2);
 });
 
+builder.Services.AddHttpClient<IProcessingDelayClient, ProcessingDelayClient>(c =>
+{
+    c.BaseAddress = new Uri(ResolveErpApiBaseUrl(builder.Configuration));
+    c.Timeout = TimeSpan.FromSeconds(2);
+});
+
 builder.Services.AddHttpClient<IHandoffJobRegistration, HandoffJobRegistration>(c =>
     c.BaseAddress = new Uri(ResolveErpApiBaseUrl(builder.Configuration)));
 
@@ -59,6 +65,9 @@ builder.Services.AddNimBus(n =>
     n.AddPipelineBehavior<LoggingMiddleware>();
     n.AddPipelineBehavior<ValidationMiddleware>();
     n.AddPipelineBehavior<ServiceModeMiddleware>();
+    // Runs after the service-mode gate: don't delay messages that are being rejected,
+    // but hold the rest for the configured time before their handler runs.
+    n.AddPipelineBehavior<ProcessingDelayMiddleware>();
 });
 
 // The deferred-processor BackgroundService is intentionally NOT registered here —

--- a/samples/CrmErpDemo/Erp.Api/Endpoints/AdminEndpoints.cs
+++ b/samples/CrmErpDemo/Erp.Api/Endpoints/AdminEndpoints.cs
@@ -29,6 +29,26 @@ public static class AdminEndpoints
             var (enabled, changedAt) = state.Set(request.Enabled);
             return Results.Ok(new ErrorModeResponse(enabled, changedAt));
         });
+
+        group.MapGet("/processing-delay", (ProcessingDelayState state) =>
+        {
+            var (enabled, delayMs, changedAt) = state.Snapshot();
+            return Results.Ok(new ProcessingDelayResponse(enabled, delayMs, changedAt));
+        });
+
+        group.MapPut("/processing-delay", (ProcessingDelayRequest request, ProcessingDelayState state) =>
+        {
+            if (request.DelayMs < ProcessingDelayState.MinDelayMs || request.DelayMs > ProcessingDelayState.MaxDelayMs)
+            {
+                return Results.BadRequest(new
+                {
+                    error = $"delayMs must be in [{ProcessingDelayState.MinDelayMs}, {ProcessingDelayState.MaxDelayMs}].",
+                });
+            }
+
+            var (enabled, delayMs, changedAt) = state.Set(request.Enabled, request.DelayMs);
+            return Results.Ok(new ProcessingDelayResponse(enabled, delayMs, changedAt));
+        });
     }
 }
 
@@ -36,3 +56,5 @@ public record ServiceModeRequest(bool Enabled);
 public record ServiceModeResponse(bool Enabled, DateTimeOffset ChangedAt);
 public record ErrorModeRequest(bool Enabled);
 public record ErrorModeResponse(bool Enabled, DateTimeOffset ChangedAt);
+public record ProcessingDelayRequest(bool Enabled, int DelayMs);
+public record ProcessingDelayResponse(bool Enabled, int DelayMs, DateTimeOffset ChangedAt);

--- a/samples/CrmErpDemo/Erp.Api/Erp.Api.csproj
+++ b/samples/CrmErpDemo/Erp.Api/Erp.Api.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="13.3.5" />
+    <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" Version="13.4.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0-preview.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0-preview.*">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/CrmErpDemo/Erp.Api/ProcessingDelayState.cs
+++ b/samples/CrmErpDemo/Erp.Api/ProcessingDelayState.cs
@@ -1,0 +1,43 @@
+namespace Erp.Api;
+
+/// <summary>
+/// Demo-only knob: an artificial per-message processing delay applied by the ERP
+/// adapter's pipeline. When enabled, every inbound message waits
+/// <c>DelayMilliseconds</c> before its handler runs, so message processing visibly
+/// takes time on the Flow monitor and slow-consumer behaviour can be exercised.
+/// Mirror of <see cref="ServiceModeState"/>; the value is clamped to
+/// [<see cref="MinDelayMs"/>, <see cref="MaxDelayMs"/>].
+/// </summary>
+public sealed class ProcessingDelayState
+{
+    public const int MinDelayMs = 100;
+    public const int MaxDelayMs = 100_000;
+
+    private readonly object _gate = new();
+    private bool _enabled;
+    private int _delayMilliseconds = 2_000;
+    private DateTimeOffset _changedAt = DateTimeOffset.UtcNow;
+
+    public (bool Enabled, int DelayMilliseconds, DateTimeOffset ChangedAt) Snapshot()
+    {
+        lock (_gate)
+        {
+            return (_enabled, _delayMilliseconds, _changedAt);
+        }
+    }
+
+    public (bool Enabled, int DelayMilliseconds, DateTimeOffset ChangedAt) Set(bool enabled, int delayMilliseconds)
+    {
+        var clamped = Math.Clamp(delayMilliseconds, MinDelayMs, MaxDelayMs);
+        lock (_gate)
+        {
+            if (_enabled != enabled || _delayMilliseconds != clamped)
+            {
+                _enabled = enabled;
+                _delayMilliseconds = clamped;
+                _changedAt = DateTimeOffset.UtcNow;
+            }
+            return (_enabled, _delayMilliseconds, _changedAt);
+        }
+    }
+}

--- a/samples/CrmErpDemo/Erp.Api/Program.cs
+++ b/samples/CrmErpDemo/Erp.Api/Program.cs
@@ -29,6 +29,7 @@ builder.Services.AddDbContext<ErpDbContext>(opt => opt.UseSqlServer(erpConnectio
 
 builder.Services.AddSingleton<ServiceModeState>();
 builder.Services.AddSingleton<ErrorModeState>();
+builder.Services.AddSingleton<ProcessingDelayState>();
 builder.Services.AddSingleton<HandoffModeState>();
 builder.Services.AddSingleton<HandoffJobTracker>();
 

--- a/samples/CrmErpDemo/Erp.Web/src/App.tsx
+++ b/samples/CrmErpDemo/Erp.Web/src/App.tsx
@@ -5,6 +5,7 @@ import CustomerForm from './pages/CustomerForm';
 import ContactsList from './pages/ContactsList';
 import ContactForm from './pages/ContactForm';
 import HandoffModePanel from './components/admin/handoff-mode-panel';
+import ProcessingDelayPanel from './components/admin/processing-delay-panel';
 import { api } from './api';
 
 const tabClass = ({ isActive }: { isActive: boolean }) =>
@@ -33,6 +34,7 @@ export default function App() {
       <ErrorModeBanner />
       <main className="max-w-5xl mx-auto px-6 py-8 space-y-6">
         <HandoffModePanel />
+        <ProcessingDelayPanel />
         <Routes>
           <Route path="/" element={<CustomersList />} />
           <Route path="/customers" element={<CustomersList />} />

--- a/samples/CrmErpDemo/Erp.Web/src/api.ts
+++ b/samples/CrmErpDemo/Erp.Web/src/api.ts
@@ -48,6 +48,12 @@ export interface HandoffMode {
   changedAt: string;
 }
 
+export interface ProcessingDelay {
+  enabled: boolean;
+  delayMs: number;
+  changedAt: string;
+}
+
 export interface HandoffJob {
   eventId: string;
   sessionId: string;
@@ -112,6 +118,14 @@ export const api = {
     }).then(json<HandoffMode>),
 
   getHandoffJobs: () => fetch('/api/internal/handoff-jobs').then(json<HandoffJob[]>),
+
+  getProcessingDelay: () => fetch('/api/admin/processing-delay').then(json<ProcessingDelay>),
+  setProcessingDelay: (m: { enabled: boolean; delayMs: number }) =>
+    fetch('/api/admin/processing-delay', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(m),
+    }).then(json<ProcessingDelay>),
 
   listContacts: () => fetch('/api/contacts').then(json<Contact[]>),
   getContact: (id: string) => fetch(`/api/contacts/${id}`).then(json<Contact>),

--- a/samples/CrmErpDemo/Erp.Web/src/components/admin/processing-delay-panel.tsx
+++ b/samples/CrmErpDemo/Erp.Web/src/components/admin/processing-delay-panel.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react';
+import { api } from '../../api';
+
+// Demo control for the ERP adapter's artificial per-message processing delay.
+// The adapter's ProcessingDelayMiddleware polls /api/admin/processing-delay and,
+// when enabled, holds each inbound message for `delayMs` before its handler runs —
+// so message processing visibly takes time on the Flow monitor.
+
+const DEBOUNCE_MS = 300;
+const MIN_MS = 100;
+const MAX_MS = 100_000;
+
+function formatDelay(ms: number): string {
+  return ms < 1000 ? `${ms} ms` : `${(ms / 1000).toFixed(ms % 1000 === 0 ? 0 : 1)} s`;
+}
+
+export default function ProcessingDelayPanel() {
+  const [enabled, setEnabled] = useState<boolean>(false);
+  const [delayMs, setDelayMs] = useState<number>(2000);
+  const [loaded, setLoaded] = useState<boolean>(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const skipNextSendRef = useRef<boolean>(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const m = await api.getProcessingDelay();
+        if (cancelled) return;
+        setEnabled(m.enabled);
+        setDelayMs(Math.max(MIN_MS, Math.min(MAX_MS, Math.round(m.delayMs))));
+        setLoaded(true);
+      } catch {
+        setLoaded(true);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (!loaded) return;
+    // First render after the GET seeds initial values; don't echo it back.
+    if (skipNextSendRef.current) {
+      skipNextSendRef.current = false;
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      api.setProcessingDelay({ enabled, delayMs })
+        .catch(() => { /* ignore — UI will reflect next refresh */ });
+    }, DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [enabled, delayMs, loaded]);
+
+  return (
+    <section className="bg-white border border-slate-200 rounded-md p-4 space-y-4">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-slate-700">Processing delay</h2>
+          <p className="text-xs text-slate-500">
+            When enabled, the ERP adapter holds each inbound message for the configured time
+            before handling it — simulating a slow consumer so processing takes visible time.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setEnabled((v) => !v)}
+          disabled={!loaded}
+          className={`px-3 py-1.5 rounded-md text-xs font-medium disabled:opacity-50 ${
+            enabled
+              ? 'bg-indigo-600 text-white hover:bg-indigo-700'
+              : 'bg-slate-200 text-slate-700 hover:bg-slate-300'
+          }`}
+          title="When ON, every inbound ERP message waits the configured delay before its handler runs."
+        >
+          {`Processing delay: ${enabled ? 'ON' : 'OFF'}`}
+        </button>
+      </header>
+
+      <div>
+        <div className="flex items-center justify-between text-xs text-slate-600">
+          <label htmlFor="processing-delay">Delay per message</label>
+          <span className="font-mono">{formatDelay(delayMs)}</span>
+        </div>
+        <input
+          id="processing-delay"
+          type="range"
+          min={MIN_MS}
+          max={MAX_MS}
+          step={100}
+          value={delayMs}
+          onChange={(e) => setDelayMs(Number(e.target.value))}
+          disabled={!loaded}
+          className="w-full accent-indigo-600"
+        />
+        <div className="flex justify-between text-[10px] text-slate-400 font-mono">
+          <span>100 ms</span>
+          <span>100 s</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/NimBus.AppHost/NimBus.AppHost.csproj
+++ b/src/NimBus.AppHost/NimBus.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.5">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.3">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.3" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.4.3" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.DbGate" Version="9.7.0" />
   </ItemGroup>
 

--- a/src/NimBus.AppHost/Program.cs
+++ b/src/NimBus.AppHost/Program.cs
@@ -70,6 +70,11 @@ var webapp = builder.AddProject<Projects.NimBus_WebApp>("webapp")
     .WithExternalHttpEndpoints()
     .WaitFor(provisioner);
 
+// Live Flow / Monitor realtime push (spec 020). Point the Resolver's
+// write-path notifier at the WebApp's storage-hook webhook so endpointupdate
+// broadcasts fire for storage providers without a Change Feed (e.g. SQL).
+resolver.WithEnvironment("NimBus__Flow__WebAppUrl", webapp.GetEndpoint("http"));
+
 // Bind the active storage provider to both runtime services. Each provider package
 // resolves its own connection string at runtime.
 if (storageProvider == "sqlserver")

--- a/src/NimBus.CommandLine/CommandRunner.cs
+++ b/src/NimBus.CommandLine/CommandRunner.cs
@@ -1,3 +1,4 @@
+using Azure.Identity;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using McMaster.Extensions.CommandLineUtils;
@@ -11,14 +12,75 @@ static class CommandRunner
     public const string SbConnectionStringEnvName = "AzureServiceBus_ConnectionString";
     public const string DbConnectionStringEnvName = "CosmosDb_ConnectionString";
 
+    /// <summary>
+    /// Builds a ServiceBusClient from either a connection string or a fully
+    /// qualified namespace (e.g. mybus.servicebus.windows.net). Values without
+    /// a shared access key are treated as a namespace and authenticate with
+    /// Entra ID via DefaultAzureCredential — the same heuristic the WebApp and
+    /// Resolver use, so operators can avoid distributing connection strings.
+    /// </summary>
+    internal static ServiceBusClient CreateServiceBusClient(string? value)
+    {
+        var resolved = RequireServiceBusValue(value);
+        return IsServiceBusConnectionString(resolved)
+            ? new ServiceBusClient(resolved)
+            : new ServiceBusClient(resolved, new DefaultAzureCredential());
+    }
+
+    /// <summary>
+    /// Same connection-string-or-namespace handling as <see cref="CreateServiceBusClient"/>.
+    /// </summary>
+    internal static ServiceBusAdministrationClient CreateServiceBusAdministrationClient(string? value)
+    {
+        var resolved = RequireServiceBusValue(value);
+        return IsServiceBusConnectionString(resolved)
+            ? new ServiceBusAdministrationClient(resolved)
+            : new ServiceBusAdministrationClient(resolved, new DefaultAzureCredential());
+    }
+
+    /// <summary>
+    /// Builds a CosmosClient from either a connection string or an account
+    /// endpoint URI (e.g. https://myaccount.documents.azure.com/). Values
+    /// without an AccountKey are treated as an endpoint and authenticate with
+    /// Entra ID via DefaultAzureCredential — mirrors the Cosmos message store
+    /// provider's heuristic.
+    /// </summary>
+    internal static CosmosClient CreateCosmosClient(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException(
+                $"Cosmos DB connection is required. Use -dbc or set environment variable '{DbConnectionStringEnvName}'. " +
+                "Pass a connection string, or an account endpoint URI (e.g. https://myaccount.documents.azure.com/) to authenticate with Entra ID (DefaultAzureCredential).");
+        }
+
+        return value.Contains("AccountKey=", StringComparison.OrdinalIgnoreCase)
+            ? new CosmosClient(value)
+            : new CosmosClient(value, new DefaultAzureCredential());
+    }
+
+    private static bool IsServiceBusConnectionString(string value) =>
+        value.Contains("SharedAccessKey=", StringComparison.OrdinalIgnoreCase) ||
+        value.Contains("SharedAccessSignature=", StringComparison.OrdinalIgnoreCase);
+
+    private static string RequireServiceBusValue(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? throw new InvalidOperationException(
+                $"Service Bus connection is required. Use -sbc or set environment variable '{SbConnectionStringEnvName}'. " +
+                "Pass a connection string, or a fully qualified namespace (e.g. mybus.servicebus.windows.net) to authenticate with Entra ID (DefaultAzureCredential).")
+            : value;
+
+    private static string? Resolve(CommandOption option, string envName) =>
+        option.HasValue() ? option.Value() : Environment.GetEnvironmentVariable(envName);
+
     public static async Task Run(CommandOption sbConnectionString, CommandOption dbConnectionString, Func<ServiceBusClient, CosmosDbClient, ServiceBusAdministrationClient, Task> func)
     {
-        var sbConnStr = sbConnectionString.HasValue() ? sbConnectionString.Value() : Environment.GetEnvironmentVariable(SbConnectionStringEnvName);
-        var dbConnStr = dbConnectionString.HasValue() ? dbConnectionString.Value() : Environment.GetEnvironmentVariable(DbConnectionStringEnvName);
+        var sbConnStr = Resolve(sbConnectionString, SbConnectionStringEnvName);
+        var dbConnStr = Resolve(dbConnectionString, DbConnectionStringEnvName);
 
-        var serviceBusClient = new ServiceBusClient(sbConnStr);
-        var serviceBusAdmin = new ServiceBusAdministrationClient(sbConnStr);
-        var cosmosClient = new CosmosClient(dbConnStr);
+        var serviceBusClient = CreateServiceBusClient(sbConnStr);
+        var serviceBusAdmin = CreateServiceBusAdministrationClient(sbConnStr);
+        var cosmosClient = CreateCosmosClient(dbConnStr);
         var cosmosDbClient = new CosmosDbClient(cosmosClient);
 
         await func(serviceBusClient, cosmosDbClient, serviceBusAdmin);
@@ -26,11 +88,11 @@ static class CommandRunner
 
     public static async Task Run(CommandOption sbConnectionString, CommandOption dbConnectionString, Func<ServiceBusClient, CosmosDbClient, Task> func)
     {
-        var sbConnStr = sbConnectionString.HasValue() ? sbConnectionString.Value() : Environment.GetEnvironmentVariable(SbConnectionStringEnvName);
-        var dbConnStr = dbConnectionString.HasValue() ? dbConnectionString.Value() : Environment.GetEnvironmentVariable(DbConnectionStringEnvName);
+        var sbConnStr = Resolve(sbConnectionString, SbConnectionStringEnvName);
+        var dbConnStr = Resolve(dbConnectionString, DbConnectionStringEnvName);
 
-        var serviceBusClient = new ServiceBusClient(sbConnStr);
-        var cosmosClient = new CosmosClient(dbConnStr);
+        var serviceBusClient = CreateServiceBusClient(sbConnStr);
+        var cosmosClient = CreateCosmosClient(dbConnStr);
         var cosmosDbClient = new CosmosDbClient(cosmosClient);
 
         await func(serviceBusClient, cosmosDbClient);
@@ -38,9 +100,9 @@ static class CommandRunner
 
     public static async Task Run(CommandOption dbConnectionString, Func<CosmosDbClient, Task> func)
     {
-        var dbConnStr = dbConnectionString.HasValue() ? dbConnectionString.Value() : Environment.GetEnvironmentVariable(DbConnectionStringEnvName);
+        var dbConnStr = Resolve(dbConnectionString, DbConnectionStringEnvName);
 
-        var cosmosClient = new CosmosClient(dbConnStr);
+        var cosmosClient = CreateCosmosClient(dbConnStr);
         var cosmosDbClient = new CosmosDbClient(cosmosClient);
 
         await func(cosmosDbClient);
@@ -48,25 +110,25 @@ static class CommandRunner
 
     public static async Task Run(CommandOption sbConnectionString, Func<ServiceBusAdministrationClient, Task> func)
     {
-        var sbConnStr = sbConnectionString.HasValue() ? sbConnectionString.Value() : Environment.GetEnvironmentVariable(SbConnectionStringEnvName);
+        var sbConnStr = Resolve(sbConnectionString, SbConnectionStringEnvName);
 
-        var serviceBusAdmin = new ServiceBusAdministrationClient(sbConnStr);
+        var serviceBusAdmin = CreateServiceBusAdministrationClient(sbConnStr);
 
         await func(serviceBusAdmin);
     }
 
     public static async Task Run(CommandOption sbConnectionString, Func<ServiceBusClient, Task> func)
     {
-        var sbConnStr = sbConnectionString.HasValue() ? sbConnectionString.Value() : Environment.GetEnvironmentVariable(SbConnectionStringEnvName);
+        var sbConnStr = Resolve(sbConnectionString, SbConnectionStringEnvName);
 
-        var serviceBusClient = new ServiceBusClient(sbConnStr);
+        var serviceBusClient = CreateServiceBusClient(sbConnStr);
 
         await func(serviceBusClient);
     }
 
     public static async Task Run(CommandOption sourceDbConnectionString, CommandOption targetDbConnectionString, Func<CosmosClient, CosmosClient, Task> func)
     {
-        var sourceConnStr = sourceDbConnectionString.HasValue() ? sourceDbConnectionString.Value() : Environment.GetEnvironmentVariable(DbConnectionStringEnvName);
+        var sourceConnStr = Resolve(sourceDbConnectionString, DbConnectionStringEnvName);
         var targetConnStr = targetDbConnectionString.HasValue() ? targetDbConnectionString.Value() : null;
 
         if (string.IsNullOrEmpty(sourceConnStr))
@@ -74,8 +136,8 @@ static class CommandRunner
         if (string.IsNullOrEmpty(targetConnStr))
             throw new InvalidOperationException("Target Cosmos DB connection string is required. Use --target-dbc.");
 
-        using var sourceClient = new CosmosClient(sourceConnStr);
-        using var targetClient = new CosmosClient(targetConnStr);
+        using var sourceClient = CreateCosmosClient(sourceConnStr);
+        using var targetClient = CreateCosmosClient(targetConnStr);
 
         await func(sourceClient, targetClient);
     }

--- a/src/NimBus.CommandLine/NimBus.CommandLine.csproj
+++ b/src/NimBus.CommandLine/NimBus.CommandLine.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />

--- a/src/NimBus.CommandLine/Program.cs
+++ b/src/NimBus.CommandLine/Program.cs
@@ -16,12 +16,14 @@ internal static class Program
 
         var sbConnectionString = new CommandOption("-sbc|--sb-connection-string", CommandOptionType.SingleValue)
         {
-            Description = $"Overrides environment variable '{CommandRunner.SbConnectionStringEnvName}'"
+            Description = "Service Bus connection string, or a fully qualified namespace (e.g. mybus.servicebus.windows.net) to authenticate with Entra ID (DefaultAzureCredential). " +
+                $"Overrides environment variable '{CommandRunner.SbConnectionStringEnvName}'"
         };
 
         var dbConnectionString = new CommandOption("-dbc|--db-connection-string", CommandOptionType.SingleValue)
         {
-            Description = $"Overrides environment variable '{CommandRunner.DbConnectionStringEnvName}'"
+            Description = "Cosmos DB connection string, or an account endpoint URI (e.g. https://myaccount.documents.azure.com/) to authenticate with Entra ID (DefaultAzureCredential). " +
+                $"Overrides environment variable '{CommandRunner.DbConnectionStringEnvName}'"
         };
 
         app.HelpOption(inherited: true);
@@ -498,7 +500,7 @@ internal static class Program
                             return 1;
                         }
 
-                        using var cosmosClient = new Microsoft.Azure.Cosmos.CosmosClient(connStr);
+                        using var cosmosClient = CommandRunner.CreateCosmosClient(connStr);
                         await Container.DeleteMessages(cosmosClient, toArg.Value!);
                         return 0;
                     });

--- a/src/NimBus.Resolver/HttpEndpointStateChangeNotifier.cs
+++ b/src/NimBus.Resolver/HttpEndpointStateChangeNotifier.cs
@@ -1,0 +1,88 @@
+#nullable enable
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NimBus.MessageStore.Abstractions;
+
+namespace NimBus.Resolver
+{
+    /// <summary>
+    /// Resolver write-path notifier (spec 020). After the Resolver persists a
+    /// state transition it calls <see cref="NotifyEndpointStateChangedAsync"/>;
+    /// this implementation POSTs the endpoint id to the management WebApp's
+    /// storage-hook webhook — the same route the Cosmos Change Feed → Event Grid
+    /// path uses (<c>api/storagehook/cosmos/{endpointId}</c>). The WebApp then
+    /// downloads the authoritative counts and broadcasts an <c>endpointupdate</c>
+    /// over GridEventsHub, so the live Flow / Monitor pages update for storage
+    /// providers that have no Change Feed (e.g. SQL Server).
+    ///
+    /// Best-effort by design: a failed push only delays a visual update (the
+    /// pages reconcile via polling) and never affects message processing, so all
+    /// transport errors are swallowed. Registered only when a WebApp hook URL is
+    /// configured; otherwise the Resolver keeps the no-op notifier and existing
+    /// deployments are unaffected (spec NFR-004).
+    /// </summary>
+    public sealed class HttpEndpointStateChangeNotifier : IMessageStateChangeNotifier, IDisposable
+    {
+        // Mirrors StorageHookImplementation.WebhookKeyHeaderName on the WebApp
+        // side. Kept as a literal so the Resolver host need not reference the
+        // WebApp project.
+        private const string WebhookKeyHeaderName = "X-Webhook-Key";
+
+        private readonly HttpClient _httpClient;
+        private readonly string? _webhookKey;
+        private readonly ILogger<HttpEndpointStateChangeNotifier>? _logger;
+
+        /// <param name="httpClient">
+        /// Client whose <see cref="HttpClient.BaseAddress"/> is the WebApp origin;
+        /// the notifier owns it and disposes it on shutdown.
+        /// </param>
+        /// <param name="webhookKey">
+        /// Shared <c>EventGrid:WebhookKey</c>. Sent as <c>X-Webhook-Key</c> when
+        /// non-empty; omitted otherwise (the WebApp allows anonymous storage-hook
+        /// calls in Development).
+        /// </param>
+        public HttpEndpointStateChangeNotifier(
+            HttpClient httpClient,
+            string? webhookKey = null,
+            ILogger<HttpEndpointStateChangeNotifier>? logger = null)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _webhookKey = string.IsNullOrEmpty(webhookKey) ? null : webhookKey;
+            _logger = logger;
+        }
+
+        public async Task NotifyEndpointStateChangedAsync(string endpointId, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(endpointId))
+                return;
+
+            // Relative path resolves against HttpClient.BaseAddress (the WebApp origin).
+            var requestUri = $"api/storagehook/cosmos/{Uri.EscapeDataString(endpointId)}";
+
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+                if (_webhookKey is not null)
+                    request.Headers.TryAddWithoutValidation(WebhookKeyHeaderName, _webhookKey);
+
+                using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger?.LogDebug(
+                        "Flow notifier: WebApp storage-hook returned {StatusCode} for endpoint {EndpointId}.",
+                        (int)response.StatusCode, endpointId);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+            {
+                // Non-fatal: realtime push is best-effort; the pages reconcile via polling.
+                _logger?.LogDebug(ex, "Flow notifier: failed to post endpoint update for {EndpointId}.", endpointId);
+            }
+        }
+
+        public void Dispose() => _httpClient.Dispose();
+    }
+}

--- a/src/NimBus.Resolver/ResolverBuilderExtensions.cs
+++ b/src/NimBus.Resolver/ResolverBuilderExtensions.cs
@@ -26,6 +26,7 @@ namespace NimBus.Resolver
             var services = builder.Services;
 
             services.AddSingleton<IMessageHandler, ResolverService>();
+            services.AddFlowStateChangeNotifier();
 
             services.AddSingleton(sp =>
             {

--- a/src/NimBus.Resolver/ServiceExtensions.cs
+++ b/src/NimBus.Resolver/ServiceExtensions.cs
@@ -1,11 +1,14 @@
 using System;
+using System.Net.Http;
 using Azure.Identity;
 using Azure.Messaging.ServiceBus;
 using NimBus.Broker.Services;
 using NimBus.Core.Messages;
+using NimBus.MessageStore.Abstractions;
 using NimBus.ServiceBus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Serilog;
 
 namespace NimBus.Resolver
@@ -22,6 +25,7 @@ namespace NimBus.Resolver
             services.AddSingleton<Serilog.ILogger>(Log.Logger);
 
             services.AddSingleton<IMessageHandler, ResolverService>();
+            services.AddFlowStateChangeNotifier();
 
             services.AddSingleton(sp =>
             {
@@ -50,5 +54,41 @@ namespace NimBus.Resolver
 
             return services;
         }
+
+        /// <summary>
+        /// Registers the Resolver write-path state-change notifier (spec 020).
+        /// When <c>NimBus:Flow:WebAppUrl</c> is configured the Resolver pushes
+        /// <c>endpointupdate</c> broadcasts to the management WebApp's storage-hook
+        /// webhook (driving the live Flow / Monitor pages for storage providers
+        /// without a Change Feed). Absent that config it registers the no-op
+        /// notifier, so existing deployments are unaffected (spec NFR-004).
+        /// </summary>
+        internal static IServiceCollection AddFlowStateChangeNotifier(this IServiceCollection services)
+        {
+            services.AddSingleton<IMessageStateChangeNotifier>(sp =>
+            {
+                var config = sp.GetRequiredService<IConfiguration>();
+                var webAppUrl = config.GetValue<string>("NimBus:Flow:WebAppUrl");
+                if (string.IsNullOrWhiteSpace(webAppUrl)
+                    || !Uri.TryCreate(EnsureTrailingSlash(webAppUrl), UriKind.Absolute, out var baseUri))
+                {
+                    return new NoopMessageStateChangeNotifier();
+                }
+
+                var webhookKey = config.GetValue<string>("EventGrid:WebhookKey");
+                var httpClient = new HttpClient
+                {
+                    BaseAddress = baseUri,
+                    Timeout = TimeSpan.FromSeconds(10),
+                };
+                var logger = sp.GetService<ILogger<HttpEndpointStateChangeNotifier>>();
+                return new HttpEndpointStateChangeNotifier(httpClient, webhookKey, logger);
+            });
+
+            return services;
+        }
+
+        private static string EnsureTrailingSlash(string url) =>
+            url.EndsWith('/') ? url : url + "/";
     }
 }

--- a/src/NimBus.WebApp/AllowAnonymousActionsConvention.cs
+++ b/src/NimBus.WebApp/AllowAnonymousActionsConvention.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using NimBus.WebApp.ManagementApi;
+
+namespace NimBus.WebApp;
+
+/// <summary>
+/// Grants anonymous access to individual NSwag-generated controller actions.
+/// The generated controllers (ApiContract.g.cs) cannot carry per-action
+/// attributes, and a class-level [AllowAnonymous] would silently exempt every
+/// action on the controller — including ones added later. This convention
+/// scopes the exemption to exactly the actions that must stay anonymous:
+/// /api/app/stats, which health probes and status monitors call without
+/// credentials and which only returns non-sensitive information (environment
+/// name, version, storage provider). /api/me on the same controller stays
+/// behind the global authorization filter.
+/// </summary>
+internal sealed class AllowAnonymousActionsConvention : IApplicationModelConvention
+{
+    public void Apply(ApplicationModel application)
+    {
+        foreach (var controller in application.Controllers)
+        {
+            if (controller.ControllerType != typeof(ApplicationApiController))
+            {
+                continue;
+            }
+
+            foreach (var action in controller.Actions)
+            {
+                if (action.ActionMethod.Name == nameof(ApplicationApiController.GetApiAppStats))
+                {
+                    action.Filters.Add(new AllowAnonymousFilter());
+                }
+            }
+        }
+    }
+}

--- a/src/NimBus.WebApp/ClientApp/src/app.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/app.tsx
@@ -22,6 +22,7 @@ const MessagesList = lazy(() => import("pages/messages-list"));
 const Admin = lazy(() => import("pages/admin"));
 const Metrics = lazy(() => import("pages/metrics"));
 const Topology = lazy(() => import("pages/topology"));
+const Flow = lazy(() => import("pages/flow"));
 const Insights = lazy(() => import("pages/insights"));
 const Monitor = lazy(() => import("pages/monitor"));
 const AuditsList = lazy(() => import("pages/audits-list"));
@@ -80,6 +81,12 @@ const navigation: Navigation = [
     path: "/Topology",
     header: true,
     render: () => <Topology />,
+  },
+  {
+    name: "Flow",
+    path: "/Flow",
+    header: true,
+    render: () => <Flow />,
   },
   {
     name: "Monitor",

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/animator.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/animator.ts
@@ -1,0 +1,367 @@
+// FlowAnimator — imperative SVG dot animation for the Live Flow page (spec 020).
+//
+// This is a TypeScript port of the animation technique in site/demo/index.html:
+// a single requestAnimationFrame loop advances a *virtual clock* (vt), and every
+// traveling dot derives its position from vt via path.getPointAtLength(). React
+// owns the static scene (nodes, route paths); this class owns exactly one <g>
+// element (the dot layer) and never triggers a React render — per NFR-002, all
+// per-frame work touches only this imperative layer.
+//
+// WHY a virtual clock instead of wall time or CSS animations:
+// - Pause must freeze dots mid-path; with vt, pausing is "stop accumulating dt"
+//   and every dot stays exactly where it was, no per-dot bookkeeping.
+// - Speed is a multiplier on the timeline (vt += dt * speed), so changing it
+//   mid-flight smoothly retimes every dot and pending pulse at once.
+// - Hiding the tab cancels the loop entirely (NFR-003 near-zero CPU); since vt
+//   only advances inside the loop, in-flight dots resume from the same spot.
+// - Scheduling (pulse expiry) rides the same clock as vt-deadline entries
+//   processed in the frame loop — no setTimeout, so pause/speed/hidden-tab all
+//   affect pending work consistently and dispose() has nothing extra to cancel.
+
+import { MAX_INFLIGHT_DOTS } from "./types";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+/** CSS class lit on a route path while it carries dots or an edge pulse. */
+const ROUTE_ON_CLASS = "flow-route-on";
+
+/** Virtual-ms an edge pulse stays lit (reduced-motion / overflow fallback). */
+const PULSE_MS = 600;
+
+/**
+ * Per-frame wall-clock delta clamp. Long gaps (debugger, jank, tab re-show
+ * races) would otherwise teleport dots; clamping turns them into a brief slowdown.
+ */
+const MAX_FRAME_DT = 64;
+
+const MIN_SPEED = 0.25;
+const MAX_SPEED = 4;
+
+/** Travel time: never under 420 ms, otherwise 2.2 ms per path unit (demo's tuning). */
+const MIN_TRAVEL_MS = 420;
+const TRAVEL_MS_PER_UNIT = 2.2;
+
+const DEFAULT_DOT_RADIUS = 5;
+
+/** smoothstep — gentle ease-in-out so dots launch and land softly. */
+function ease(t: number): number {
+  return t * t * (3 - 2 * t);
+}
+
+export interface FlowAnimatorOptions {
+  /** Imperative layer the page hands over via ref — the ONLY DOM the animator owns. */
+  dotLayer: SVGGElement;
+  /** Resolves a route id to its rendered <path>; null if filtered out/unmounted. */
+  getPathEl: (routeId: string) => SVGPathElement | null;
+  /** When true, spawn() pulses edges instead of creating traveling dots (prefers-reduced-motion). */
+  reducedMotion?: boolean;
+}
+
+/** One dot (and its optional ×N label) currently traveling along a path. */
+interface TravelingDot {
+  /** Captured at spawn; if the path unmounts mid-flight the dot finishes early. */
+  pathEl: SVGPathElement;
+  /** Total path length, captured at spawn so a cache invalidation can't retime it. */
+  len: number;
+  circle: SVGCircleElement;
+  label: SVGTextElement | null;
+  /** Label offset from the dot center (rides above/right of the dot). */
+  labelDx: number;
+  labelDy: number;
+  /** Virtual-clock spawn time. */
+  start: number;
+  /** Virtual-ms travel duration. */
+  dur: number;
+}
+
+export class FlowAnimator {
+  private readonly dotLayer: SVGGElement;
+  private readonly getPathEl: (routeId: string) => SVGPathElement | null;
+  private readonly reducedMotion: boolean;
+
+  /** Virtual clock (ms). Only advances inside the frame loop, scaled by speed. */
+  private vt = 0;
+  /** Wall-clock anchor for dt; re-anchored on tab re-show so hidden time is free. */
+  private last = 0;
+  private speed = 1;
+  private paused = false;
+
+  private rafId: number | null = null;
+  private started = false;
+  private disposed = false;
+
+  private readonly dots: TravelingDot[] = [];
+
+  /** getTotalLength() per routeId — invalidated by the page after layout/filter changes. */
+  private readonly pathLengths = new Map<string, number>();
+
+  /**
+   * Dots currently traveling per path element. The route stays lit
+   * (ROUTE_ON_CLASS) while any dot rides it; the class comes off when the
+   * LAST dot finishes — same per-edge `active` counter the demo uses.
+   */
+  private readonly activeCounts = new Map<SVGPathElement, number>();
+
+  /**
+   * Pending pulse-off deadlines (virtual time) per path. Overlapping pulses
+   * EXTEND the single deadline instead of stacking removals, so a burst of
+   * fallback pulses reads as one continuous glow.
+   */
+  private readonly pulseDeadlines = new Map<SVGPathElement, number>();
+
+  constructor(opts: FlowAnimatorOptions) {
+    this.dotLayer = opts.dotLayer;
+    this.getPathEl = opts.getPathEl;
+    this.reducedMotion = opts.reducedMotion ?? false;
+  }
+
+  /** Begins the frame loop and starts honoring tab visibility (FR-008/NFR-003). */
+  start(): void {
+    if (this.started || this.disposed) {
+      return;
+    }
+    this.started = true;
+    document.addEventListener("visibilitychange", this.onVisibilityChange);
+    this.last = performance.now();
+    if (document.visibilityState !== "hidden") {
+      this.scheduleFrame();
+    }
+  }
+
+  /** Cancels the loop, detaches the listener, removes all owned DOM. Idempotent. */
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.started = false;
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+    document.removeEventListener("visibilitychange", this.onVisibilityChange);
+    for (const dot of this.dots) {
+      dot.circle.remove();
+      dot.label?.remove();
+    }
+    this.dots.length = 0;
+    // We added ROUTE_ON_CLASS to these paths; leave the scene as we found it.
+    for (const path of this.activeCounts.keys()) {
+      path.classList.remove(ROUTE_ON_CLASS);
+    }
+    for (const path of this.pulseDeadlines.keys()) {
+      path.classList.remove(ROUTE_ON_CLASS);
+    }
+    this.activeCounts.clear();
+    this.pulseDeadlines.clear();
+    this.pathLengths.clear();
+  }
+
+  /** Timeline speed multiplier, clamped to 0.25–4 (FR-007 control range). */
+  setSpeed(multiplier: number): void {
+    this.speed = Math.min(MAX_SPEED, Math.max(MIN_SPEED, multiplier));
+  }
+
+  /** Freezes the virtual clock; dots hold position. The cheap loop keeps running. */
+  setPaused(paused: boolean): void {
+    this.paused = paused;
+  }
+
+  /** Number of dots currently traveling (drives the FR-009 cap and the gauge). */
+  get inFlight(): number {
+    return this.dots.length;
+  }
+
+  /**
+   * Drops memoized path lengths. The page calls this after layout or filter
+   * changes re-render the route paths; dots already in flight keep the length
+   * they were spawned with (their captured element defines their geometry).
+   */
+  invalidatePaths(): void {
+    this.pathLengths.clear();
+  }
+
+  /**
+   * Animates one event along a route. Falls back to an edge pulse when the
+   * in-flight cap is hit or reduced motion is requested (FR-008/FR-009); a
+   * spawn for a filtered-out/unmounted route is a no-op (nothing to draw on).
+   */
+  spawn(routeId: string, color: string, opts?: { multiplier?: number; radius?: number }): void {
+    if (this.disposed) {
+      return;
+    }
+    const path = this.getPathEl(routeId);
+    if (path === null) {
+      return;
+    }
+    if (this.reducedMotion || this.dots.length >= MAX_INFLIGHT_DOTS) {
+      this.pulse(path);
+      return;
+    }
+
+    const len = this.resolveLength(routeId, path);
+    if (len <= 0) {
+      // Degenerate path (zero-length d) — a pulse still signals activity.
+      this.pulse(path);
+      return;
+    }
+
+    const radius = opts?.radius ?? DEFAULT_DOT_RADIUS;
+    const startPoint = path.getPointAtLength(0);
+
+    const circle = document.createElementNS(SVG_NS, "circle");
+    circle.setAttribute("r", String(radius));
+    circle.setAttribute("fill", color);
+    circle.setAttribute("class", "flow-dot");
+    // Position immediately so the dot never flashes at (0,0) before frame one.
+    circle.setAttribute("cx", String(startPoint.x));
+    circle.setAttribute("cy", String(startPoint.y));
+    this.dotLayer.appendChild(circle);
+
+    const multiplier = opts?.multiplier ?? 1;
+    const labelDx = radius + 3;
+    const labelDy = -(radius + 2);
+    let label: SVGTextElement | null = null;
+    if (multiplier > 1) {
+      label = document.createElementNS(SVG_NS, "text");
+      label.setAttribute("class", "flow-dot-label");
+      label.textContent = `×${multiplier}`;
+      label.setAttribute("x", String(startPoint.x + labelDx));
+      label.setAttribute("y", String(startPoint.y + labelDy));
+      this.dotLayer.appendChild(label);
+    }
+
+    this.dots.push({
+      pathEl: path,
+      len,
+      circle,
+      label,
+      labelDx,
+      labelDy,
+      start: this.vt,
+      dur: Math.max(MIN_TRAVEL_MS, len * TRAVEL_MS_PER_UNIT),
+    });
+
+    // Light the route for the duration of the ride (demo's edge.active++).
+    this.activeCounts.set(path, (this.activeCounts.get(path) ?? 0) + 1);
+    path.classList.add(ROUTE_ON_CLASS);
+  }
+
+  // -------------------------------------------------------------------------
+  // Frame loop
+  // -------------------------------------------------------------------------
+
+  private scheduleFrame(): void {
+    this.rafId = requestAnimationFrame(this.onFrame);
+  }
+
+  private readonly onFrame = (now: number): void => {
+    this.rafId = null;
+    if (this.disposed) {
+      return;
+    }
+    const dt = Math.min(MAX_FRAME_DT, now - this.last);
+    this.last = now;
+    if (!this.paused) {
+      this.vt += dt * this.speed;
+      this.updateDots();
+      this.expirePulses();
+    }
+    this.scheduleFrame();
+  };
+
+  /**
+   * FR-008/NFR-003: hidden tab → cancel the loop outright (near-zero CPU).
+   * On re-show, re-anchor `last` so the hidden interval contributes no dt —
+   * the virtual clock never advanced, so dots resume exactly where they froze.
+   */
+  private readonly onVisibilityChange = (): void => {
+    if (this.disposed || !this.started) {
+      return;
+    }
+    if (document.visibilityState === "hidden") {
+      if (this.rafId !== null) {
+        cancelAnimationFrame(this.rafId);
+        this.rafId = null;
+      }
+    } else {
+      this.last = performance.now();
+      if (this.rafId === null) {
+        this.scheduleFrame();
+      }
+    }
+  };
+
+  private updateDots(): void {
+    // Backwards so splice() during iteration is safe.
+    for (let i = this.dots.length - 1; i >= 0; i--) {
+      const dot = this.dots[i];
+      const t = (this.vt - dot.start) / dot.dur;
+      // A layout/filter change can unmount the captured path mid-flight;
+      // finish such dots early instead of animating against a detached node.
+      if (t >= 1 || !dot.pathEl.isConnected) {
+        this.finishDot(i, dot);
+        continue;
+      }
+      const point = dot.pathEl.getPointAtLength(ease(Math.max(0, t)) * dot.len);
+      dot.circle.setAttribute("cx", String(point.x));
+      dot.circle.setAttribute("cy", String(point.y));
+      if (dot.label !== null) {
+        dot.label.setAttribute("x", String(point.x + dot.labelDx));
+        dot.label.setAttribute("y", String(point.y + dot.labelDy));
+      }
+    }
+  }
+
+  private finishDot(index: number, dot: TravelingDot): void {
+    dot.circle.remove();
+    dot.label?.remove();
+    this.dots.splice(index, 1);
+    const remaining = (this.activeCounts.get(dot.pathEl) ?? 1) - 1;
+    if (remaining > 0) {
+      this.activeCounts.set(dot.pathEl, remaining);
+      return;
+    }
+    this.activeCounts.delete(dot.pathEl);
+    // Last dot off this path — pulse it off, unless a pending edge pulse is
+    // still holding the glow (its deadline will release the class instead).
+    if (!this.pulseDeadlines.has(dot.pathEl)) {
+      dot.pathEl.classList.remove(ROUTE_ON_CLASS);
+    }
+  }
+
+  /** Edge pulse fallback: glow the path now, schedule the off on the virtual clock. */
+  private pulse(path: SVGPathElement): void {
+    path.classList.add(ROUTE_ON_CLASS);
+    const deadline = this.vt + PULSE_MS;
+    const existing = this.pulseDeadlines.get(path);
+    this.pulseDeadlines.set(path, existing !== undefined ? Math.max(existing, deadline) : deadline);
+  }
+
+  private expirePulses(): void {
+    if (this.pulseDeadlines.size === 0) {
+      return;
+    }
+    for (const [path, deadline] of this.pulseDeadlines) {
+      if (this.vt < deadline) {
+        continue;
+      }
+      this.pulseDeadlines.delete(path);
+      // Keep the glow if dots are still riding this path; the last dot's
+      // completion owns the class removal in that case.
+      if ((this.activeCounts.get(path) ?? 0) === 0) {
+        path.classList.remove(ROUTE_ON_CLASS);
+      }
+    }
+  }
+
+  private resolveLength(routeId: string, path: SVGPathElement): number {
+    const cached = this.pathLengths.get(routeId);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const len = path.getTotalLength();
+    this.pathLengths.set(routeId, len);
+    return len;
+  }
+}

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/animator.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/animator.ts
@@ -37,11 +37,16 @@ const MAX_FRAME_DT = 64;
 const MIN_SPEED = 0.25;
 const MAX_SPEED = 4;
 
-/** Travel time: never under 420 ms, otherwise 2.2 ms per path unit (demo's tuning). */
-const MIN_TRAVEL_MS = 420;
-const TRAVEL_MS_PER_UNIT = 2.2;
+/**
+ * Travel time: never under 650 ms, otherwise 2.8 ms per path unit. Slower than
+ * the demo's tuning (420 ms / 2.2) on purpose — real traffic is far sparser
+ * than the demo's simulated firehose, so each dot lingers longer to keep the
+ * canvas feeling alive between events.
+ */
+const MIN_TRAVEL_MS = 650;
+const TRAVEL_MS_PER_UNIT = 2.8;
 
-const DEFAULT_DOT_RADIUS = 5;
+const DEFAULT_DOT_RADIUS = 6;
 
 /** smoothstep — gentle ease-in-out so dots launch and land softly. */
 function ease(t: number): number {

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/animator.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/animator.ts
@@ -62,6 +62,27 @@ export interface FlowAnimatorOptions {
   reducedMotion?: boolean;
 }
 
+/**
+ * A queued follow-up spawn that a finished dot hands off to, so one logical
+ * message can ride several route segments back-to-back (producer → topic →
+ * consumer). Each link carries its own color/badge and an optional deeper link;
+ * the chain survives the pulse/cap/filtered fallbacks so later legs still show.
+ */
+export interface SpawnChain {
+  routeId: string;
+  color: string;
+  multiplier?: number;
+  radius?: number;
+  next?: SpawnChain;
+}
+
+/** Options for spawn(): the ×N badge, dot radius, and an optional continuation. */
+export interface SpawnOptions {
+  multiplier?: number;
+  radius?: number;
+  next?: SpawnChain;
+}
+
 /** One dot (and its optional ×N label) currently traveling along a path. */
 interface TravelingDot {
   /** Captured at spawn; if the path unmounts mid-flight the dot finishes early. */
@@ -77,6 +98,8 @@ interface TravelingDot {
   start: number;
   /** Virtual-ms travel duration. */
   dur: number;
+  /** Next segment to spawn when this dot lands — the journey's continuation. */
+  next?: SpawnChain;
 }
 
 export class FlowAnimator {
@@ -191,16 +214,20 @@ export class FlowAnimator {
    * in-flight cap is hit or reduced motion is requested (FR-008/FR-009); a
    * spawn for a filtered-out/unmounted route is a no-op (nothing to draw on).
    */
-  spawn(routeId: string, color: string, opts?: { multiplier?: number; radius?: number }): void {
+  spawn(routeId: string, color: string, opts?: SpawnOptions): void {
     if (this.disposed) {
       return;
     }
     const path = this.getPathEl(routeId);
     if (path === null) {
+      // Segment not currently rendered (filtered/unmounted) — skip it but hand
+      // off so later legs of the journey still animate.
+      this.continueChain(opts?.next);
       return;
     }
     if (this.reducedMotion || this.dots.length >= MAX_INFLIGHT_DOTS) {
       this.pulse(path);
+      this.continueChain(opts?.next);
       return;
     }
 
@@ -208,6 +235,7 @@ export class FlowAnimator {
     if (len <= 0) {
       // Degenerate path (zero-length d) — a pulse still signals activity.
       this.pulse(path);
+      this.continueChain(opts?.next);
       return;
     }
 
@@ -245,6 +273,7 @@ export class FlowAnimator {
       labelDy,
       start: this.vt,
       dur: Math.max(MIN_TRAVEL_MS, len * TRAVEL_MS_PER_UNIT),
+      next: opts?.next,
     });
 
     // Light the route for the duration of the ride (demo's edge.active++).
@@ -325,14 +354,30 @@ export class FlowAnimator {
     const remaining = (this.activeCounts.get(dot.pathEl) ?? 1) - 1;
     if (remaining > 0) {
       this.activeCounts.set(dot.pathEl, remaining);
+    } else {
+      this.activeCounts.delete(dot.pathEl);
+      // Last dot off this path — pulse it off, unless a pending edge pulse is
+      // still holding the glow (its deadline will release the class instead).
+      if (!this.pulseDeadlines.has(dot.pathEl)) {
+        dot.pathEl.classList.remove(ROUTE_ON_CLASS);
+      }
+    }
+    // Hand the journey to its next leg, so the dot reads as one message
+    // continuing producer → topic → consumer. Appending mid-frame is safe: the
+    // update loop iterates backwards, so the new dot animates from next frame.
+    this.continueChain(dot.next);
+  }
+
+  /** Spawns the next leg of a journey, if any. */
+  private continueChain(next: SpawnChain | undefined): void {
+    if (next === undefined) {
       return;
     }
-    this.activeCounts.delete(dot.pathEl);
-    // Last dot off this path — pulse it off, unless a pending edge pulse is
-    // still holding the glow (its deadline will release the class instead).
-    if (!this.pulseDeadlines.has(dot.pathEl)) {
-      dot.pathEl.classList.remove(ROUTE_ON_CLASS);
-    }
+    this.spawn(next.routeId, next.color, {
+      multiplier: next.multiplier,
+      radius: next.radius,
+      next: next.next,
+    });
   }
 
   /** Edge pulse fallback: glow the path now, schedule the off on the virtual clock. */

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/derive-deltas.test.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/derive-deltas.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect } from "vitest";
+import { deriveDelta, applyToCounters } from "./derive-deltas";
+import type {
+  FlowActivityEvent,
+  FlowActivityKind,
+  FlowCounters,
+  StatusSnapshot,
+} from "./types";
+import { MAX_DOTS_PER_DELTA } from "./types";
+
+// Spec 020 Phase 1 — snapshot-diff derivation unit tests. deriveDelta turns a
+// pair of consecutive EndpointStatusCount snapshots into semantic flow events;
+// applyToCounters folds those events into the gauge-strip counters. Both are
+// pure, so plain vitest with no jsdom is sufficient.
+
+/** Builds a healthy zero-count snapshot; override only what the test varies. */
+function snap(overrides: Partial<StatusSnapshot> = {}): StatusSnapshot {
+  return {
+    endpointId: "BillingEndpoint",
+    failed: 0,
+    deferred: 0,
+    pending: 0,
+    unsupported: 0,
+    deadlettered: 0,
+    storageOk: true,
+    at: 1_000,
+    ...overrides,
+  };
+}
+
+/** Builds a minimal activity event for applyToCounters tests. */
+function ev(kind: FlowActivityKind, count: number): FlowActivityEvent {
+  return {
+    endpointId: "BillingEndpoint",
+    kind,
+    count,
+    dots: Math.min(count, MAX_DOTS_PER_DELTA),
+    multiplier: count > MAX_DOTS_PER_DELTA ? count : 1,
+    at: 1_000,
+  };
+}
+
+function zeroCounters(): FlowCounters {
+  return { published: 0, completed: 0, failed: 0, deferred: 0, deadlettered: 0 };
+}
+
+describe("deriveDelta — baseline handling", () => {
+  it("treats the first-ever snapshot as baseline with no events", () => {
+    const next = snap({ failed: 7, pending: 3 });
+    const delta = deriveDelta(undefined, next);
+    expect(delta).toEqual({
+      endpointId: "BillingEndpoint",
+      events: [],
+      baseline: true,
+    });
+  });
+
+  it("emits no events while storage is unavailable (counts unreliable)", () => {
+    const prev = snap({ pending: 10 });
+    const next = snap({ pending: 0, storageOk: false, at: 2_000 });
+    const delta = deriveDelta(prev, next);
+    expect(delta.events).toEqual([]);
+    expect(delta.baseline).toBe(false);
+  });
+
+  it("re-baselines when storage recovers (no phantom mega-delta)", () => {
+    // While the container was down the counts read as zeros; when it comes
+    // back the jump from 0 → real counts must not animate as a burst.
+    const prev = snap({ pending: 0, failed: 0, storageOk: false });
+    const next = snap({ pending: 500, failed: 40, at: 2_000 });
+    const delta = deriveDelta(prev, next);
+    expect(delta.events).toEqual([]);
+    expect(delta.baseline).toBe(true);
+  });
+
+  it("returns no events and baseline:false when nothing changed", () => {
+    const prev = snap({ pending: 5, failed: 2, deferred: 1, deadlettered: 1 });
+    const next = snap({
+      pending: 5,
+      failed: 2,
+      deferred: 1,
+      deadlettered: 1,
+      at: 2_000,
+    });
+    const delta = deriveDelta(prev, next);
+    expect(delta.events).toEqual([]);
+    expect(delta.baseline).toBe(false);
+  });
+});
+
+describe("deriveDelta — single-kind deltas", () => {
+  it("pending rise → one 'arrived' event with the delta as count", () => {
+    const delta = deriveDelta(snap({ pending: 2 }), snap({ pending: 6, at: 2_000 }));
+    expect(delta.events).toEqual([
+      {
+        endpointId: "BillingEndpoint",
+        kind: "arrived",
+        count: 4,
+        dots: 4,
+        multiplier: 1,
+        at: 2_000,
+      },
+    ]);
+  });
+
+  it("pending fall alone → one 'completed' event", () => {
+    const delta = deriveDelta(snap({ pending: 6 }), snap({ pending: 1, at: 2_000 }));
+    expect(delta.events).toEqual([
+      {
+        endpointId: "BillingEndpoint",
+        kind: "completed",
+        count: 5,
+        dots: 5,
+        multiplier: 1,
+        at: 2_000,
+      },
+    ]);
+  });
+
+  it("failed rise → one 'failed' event", () => {
+    const delta = deriveDelta(snap({ failed: 1 }), snap({ failed: 3, at: 2_000 }));
+    expect(delta.events).toEqual([
+      {
+        endpointId: "BillingEndpoint",
+        kind: "failed",
+        count: 2,
+        dots: 2,
+        multiplier: 1,
+        at: 2_000,
+      },
+    ]);
+  });
+
+  it("deferred rise → one 'deferred' event", () => {
+    const delta = deriveDelta(snap({ deferred: 0 }), snap({ deferred: 4, at: 2_000 }));
+    expect(delta.events).toEqual([
+      {
+        endpointId: "BillingEndpoint",
+        kind: "deferred",
+        count: 4,
+        dots: 4,
+        multiplier: 1,
+        at: 2_000,
+      },
+    ]);
+  });
+
+  it("deferred fall → one 'released' event with absolute count", () => {
+    const delta = deriveDelta(snap({ deferred: 4 }), snap({ deferred: 1, at: 2_000 }));
+    expect(delta.events).toEqual([
+      {
+        endpointId: "BillingEndpoint",
+        kind: "released",
+        count: 3,
+        dots: 3,
+        multiplier: 1,
+        at: 2_000,
+      },
+    ]);
+  });
+
+  it("deadletter rise → one 'deadlettered' event", () => {
+    const delta = deriveDelta(
+      snap({ deadlettered: 0 }),
+      snap({ deadlettered: 2, at: 2_000 }),
+    );
+    expect(delta.events).toEqual([
+      {
+        endpointId: "BillingEndpoint",
+        kind: "deadlettered",
+        count: 2,
+        dots: 2,
+        multiplier: 1,
+        at: 2_000,
+      },
+    ]);
+  });
+});
+
+describe("deriveDelta — completed inference", () => {
+  it("emits no 'completed' when the pending fall is fully explained by failures", () => {
+    // 3 messages went pending → failed; they decrement pending AND increment
+    // failed, so counting them as completions would double-book them.
+    const delta = deriveDelta(
+      snap({ pending: 10, failed: 0 }),
+      snap({ pending: 7, failed: 3, at: 2_000 }),
+    );
+    expect(delta.events.map((e) => e.kind)).toEqual(["failed"]);
+    expect(delta.events[0].count).toBe(3);
+  });
+
+  it("clamps completed at 0 when failures exceed the pending fall", () => {
+    // failedΔ (5) > −pendingΔ (2): retried old failures can re-fail without
+    // touching pending, so the inferred completed must clamp, never go negative.
+    const delta = deriveDelta(
+      snap({ pending: 10, failed: 0 }),
+      snap({ pending: 8, failed: 5, at: 2_000 }),
+    );
+    expect(delta.events.map((e) => e.kind)).toEqual(["failed"]);
+    expect(delta.events[0].count).toBe(5);
+  });
+
+  it("infers completed as the unexplained remainder of the pending fall", () => {
+    // pending −10, of which 2 failed, 1 deadlettered → 7 genuinely completed.
+    // The concurrent released (deferred −1) must NOT inflate completions.
+    const delta = deriveDelta(
+      snap({ pending: 10, failed: 0, deferred: 1, deadlettered: 0 }),
+      snap({ pending: 0, failed: 2, deferred: 0, deadlettered: 1, at: 2_000 }),
+    );
+    const completed = delta.events.find((e) => e.kind === "completed");
+    expect(completed?.count).toBe(7);
+  });
+});
+
+describe("deriveDelta — mixed deltas and ordering", () => {
+  it("emits one event per kind when arrivals and failures co-occur", () => {
+    const delta = deriveDelta(
+      snap({ pending: 1, failed: 0 }),
+      snap({ pending: 3, failed: 4, at: 2_000 }),
+    );
+    expect(delta.events.map((e) => e.kind)).toEqual(["arrived", "failed"]);
+    expect(delta.events.map((e) => e.count)).toEqual([2, 4]);
+  });
+
+  it("orders co-occurring kinds: arrived, completed, failed, deferred, released, deadlettered", () => {
+    // pending −10 with failed +2, deferred −1, deadlettered +1 →
+    // completed 7, failed 2, released 1, deadlettered 1, in canonical order.
+    const delta = deriveDelta(
+      snap({ pending: 10, failed: 0, deferred: 1, deadlettered: 0 }),
+      snap({ pending: 0, failed: 2, deferred: 0, deadlettered: 1, at: 2_000 }),
+    );
+    expect(delta.events.map((e) => e.kind)).toEqual([
+      "completed",
+      "failed",
+      "released",
+      "deadlettered",
+    ]);
+  });
+
+  it("stamps every event with next.at and the endpoint id", () => {
+    const delta = deriveDelta(
+      snap({ pending: 0, deferred: 0 }),
+      snap({ pending: 3, deferred: 2, at: 4_242 }),
+    );
+    expect(delta.events.length).toBeGreaterThan(1);
+    for (const event of delta.events) {
+      expect(event.at).toBe(4_242);
+      expect(event.endpointId).toBe("BillingEndpoint");
+    }
+  });
+});
+
+describe("deriveDelta — dot capping", () => {
+  it("caps a burst at MAX_DOTS_PER_DELTA dots with the count as multiplier", () => {
+    const delta = deriveDelta(snap({ pending: 0 }), snap({ pending: 500, at: 2_000 }));
+    expect(delta.events).toEqual([
+      {
+        endpointId: "BillingEndpoint",
+        kind: "arrived",
+        count: 500,
+        dots: MAX_DOTS_PER_DELTA,
+        multiplier: 500,
+        at: 2_000,
+      },
+    ]);
+  });
+
+  it("renders small deltas 1:1 with multiplier 1", () => {
+    const delta = deriveDelta(snap({ failed: 0 }), snap({ failed: 3, at: 2_000 }));
+    expect(delta.events[0].dots).toBe(3);
+    expect(delta.events[0].multiplier).toBe(1);
+  });
+});
+
+describe("applyToCounters", () => {
+  it("maps each event kind onto its counter", () => {
+    const result = applyToCounters(zeroCounters(), [
+      ev("arrived", 5),
+      ev("completed", 4),
+      ev("failed", 3),
+      ev("deferred", 2),
+      ev("deadlettered", 1),
+    ]);
+    expect(result).toEqual({
+      published: 5,
+      completed: 4,
+      failed: 3,
+      deferred: 2,
+      deadlettered: 1,
+    });
+  });
+
+  it("accumulates on top of existing counter values", () => {
+    const seeded: FlowCounters = {
+      published: 100,
+      completed: 90,
+      failed: 5,
+      deferred: 2,
+      deadlettered: 1,
+    };
+    const result = applyToCounters(seeded, [ev("failed", 3), ev("arrived", 10)]);
+    expect(result.failed).toBe(8);
+    expect(result.published).toBe(110);
+  });
+
+  it("'released' advances no counter (resubmit vs skip is indistinguishable)", () => {
+    const before = zeroCounters();
+    const result = applyToCounters(before, [ev("released", 9)]);
+    expect(result).toEqual(zeroCounters());
+  });
+
+  it("does not mutate the input counters and returns a new object", () => {
+    const input = zeroCounters();
+    const result = applyToCounters(input, [ev("failed", 3)]);
+    expect(input).toEqual(zeroCounters());
+    expect(result).not.toBe(input);
+  });
+
+  it("returns an equal copy for an empty event list", () => {
+    const input: FlowCounters = {
+      published: 1,
+      completed: 2,
+      failed: 3,
+      deferred: 4,
+      deadlettered: 5,
+    };
+    const result = applyToCounters(input, []);
+    expect(result).toEqual(input);
+    expect(result).not.toBe(input);
+  });
+});

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/derive-deltas.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/derive-deltas.ts
@@ -1,0 +1,128 @@
+import type {
+  EndpointDelta,
+  FlowActivityEvent,
+  FlowActivityKind,
+  FlowCounters,
+  StatusSnapshot,
+} from "./types";
+import { MAX_DOTS_PER_DELTA } from "./types";
+
+// Spec 020 Phase 1 — delta-to-events derivation. The only live signal today is
+// aggregate ("endpoint X's counts are now {…}"), so this module diffs
+// consecutive snapshots per endpoint and emits semantic FlowActivityEvents for
+// the animator, the activity log, and the counters. Pure by design: no clock,
+// no randomness, no I/O — the `at` on every event comes from the snapshot
+// itself, which keeps the whole pipeline replayable in tests.
+
+export function deriveDelta(
+  prev: StatusSnapshot | undefined,
+  next: StatusSnapshot,
+): EndpointDelta {
+  // First snapshot for this endpoint: there is nothing to diff against, and
+  // animating absolute counts as if they "just happened" would be fabrication.
+  // The page uses `baseline: true` to seed silently (FR-004).
+  if (prev === undefined) {
+    return { endpointId: next.endpointId, events: [], baseline: true };
+  }
+
+  // While the storage provider is degraded the counts read as zeros (or
+  // stale) — diffing them would animate noise. Emit nothing; the node-border
+  // state machine handles the visual "storage down" treatment instead.
+  if (!next.storageOk) {
+    return { endpointId: next.endpointId, events: [], baseline: false };
+  }
+
+  // Storage just came back: the previous snapshot's counts were unreliable,
+  // so the jump from "zeros while down" to "real counts" must re-baseline
+  // rather than render as a phantom mega-burst of arrivals/failures.
+  if (!prev.storageOk) {
+    return { endpointId: next.endpointId, events: [], baseline: true };
+  }
+
+  const failedDelta = next.failed - prev.failed;
+  const deferredDelta = next.deferred - prev.deferred;
+  const pendingDelta = next.pending - prev.pending;
+  const deadletteredDelta = next.deadlettered - prev.deadlettered;
+
+  // Completed is the one outcome with no counter of its own — we infer it
+  // from the pending fall. A pending message that fails / defers /
+  // deadletters ALSO decrements pending, so those transitions must be
+  // subtracted out or they'd double-count as completions. Clamp at 0 because
+  // retried old failures can raise `failed` without touching `pending`,
+  // making the subtraction overshoot.
+  const completed =
+    pendingDelta < 0
+      ? Math.max(
+          0,
+          -pendingDelta -
+            Math.max(0, failedDelta) -
+            Math.max(0, deferredDelta) -
+            Math.max(0, deadletteredDelta),
+        )
+      : 0;
+
+  // Several kinds can legitimately co-occur in one 5 s diff (e.g. arrivals
+  // while older messages fail). Emit one event per kind in a fixed canonical
+  // order so the animator, log, and tests are deterministic across runs.
+  const byKind: ReadonlyArray<readonly [FlowActivityKind, number]> = [
+    ["arrived", Math.max(0, pendingDelta)],
+    ["completed", completed],
+    ["failed", Math.max(0, failedDelta)],
+    ["deferred", Math.max(0, deferredDelta)],
+    ["released", Math.max(0, -deferredDelta)],
+    ["deadlettered", Math.max(0, deadletteredDelta)],
+  ];
+
+  const events: FlowActivityEvent[] = [];
+  for (const [kind, count] of byKind) {
+    if (count <= 0) continue;
+    // FR-009: never flood the canvas — a burst renders at most
+    // MAX_DOTS_PER_DELTA dots and carries the real magnitude as a "×N"
+    // badge; counters and the log always use the true count.
+    const dots = Math.min(count, MAX_DOTS_PER_DELTA);
+    events.push({
+      endpointId: next.endpointId,
+      kind,
+      count,
+      dots,
+      multiplier: count > dots ? count : 1,
+      at: next.at,
+    });
+  }
+
+  return { endpointId: next.endpointId, events, baseline: false };
+}
+
+/**
+ * Which gauge-strip counter each event kind advances. "released" is
+ * deliberately absent: a deferred fall only tells us messages left the
+ * parking strip — Phase 1 cannot distinguish a resubmit (which should count
+ * as re-published work) from a skip (which should not), so it advances no
+ * counter and only appears in the activity log.
+ */
+const COUNTER_BY_KIND: Partial<Record<FlowActivityKind, keyof FlowCounters>> = {
+  arrived: "published",
+  completed: "completed",
+  failed: "failed",
+  deferred: "deferred",
+  deadlettered: "deadlettered",
+};
+
+/**
+ * Folds derived events into the counters. Pure: always returns a fresh
+ * object so React state updates (and the 60 s reconcile pass) can compare by
+ * reference without defensive copying at the call site.
+ */
+export function applyToCounters(
+  counters: FlowCounters,
+  events: FlowActivityEvent[],
+): FlowCounters {
+  const next: FlowCounters = { ...counters };
+  for (const event of events) {
+    const key = COUNTER_BY_KIND[event.kind];
+    if (key !== undefined) {
+      next[key] += event.count;
+    }
+  }
+  return next;
+}

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/layout.test.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/layout.test.ts
@@ -144,14 +144,12 @@ describe("buildFlowLayout", () => {
     // Consumers: crm (500 handled) above audit (200).
     expect(byId.get("consumer::crm")!.y).toBe(20);
     expect(byId.get("consumer::audit")!.y).toBe(100);
-    // Topics mirror producer order, then the two platform chips at the bottom.
+    // Topics mirror producer order — no platform chips anymore.
     expect(byId.get("topic::erp")!.y).toBe(20);
     expect(byId.get("topic::crm")!.y).toBe(76); // 20 + 40 + 16
-    expect(byId.get("topic::__resolver")!.y).toBe(132);
-    expect(byId.get("topic::__manager")!.y).toBe(188);
-    // Platform column: Resolver Worker above Message Store.
-    expect(byId.get("platform::resolver")!.y).toBe(20);
-    expect(byId.get("platform::store")!.y).toBe(108); // 20 + 72 + 16
+    // Platform column: the lone Resolver, centered against the consumer
+    // column (center 92, half-height 36 → y 56).
+    expect(byId.get("platform::resolver")!.y).toBe(56);
     // Canvas: fixed width; height clamps to the 600 minimum for small graphs.
     expect(layout.width).toBe(1240);
     expect(layout.height).toBe(600);
@@ -179,9 +177,9 @@ describe("buildFlowLayout", () => {
     const routeIds = layout.routes.map((r) => r.id);
     expect(routeIds).toContain("publish::producer::erp::topic::erp");
     expect(routeIds).toContain("deliver::topic::erp::consumer::audit");
-    expect(routeIds).toContain("outcome::consumer::audit::topic::__resolver");
-    expect(routeIds).toContain("outcome::topic::__resolver::platform::resolver");
-    expect(routeIds).toContain("outcome::platform::resolver::platform::store");
+    // Each consumer reports straight to the Resolver platform node.
+    expect(routeIds).toContain("outcome::consumer::audit::platform::resolver");
+    expect(routeIds).toContain("outcome::consumer::crm::platform::resolver");
   });
 
   it("unions + sorts publish-route event types from flow edges; deliver routes carry the edge's list verbatim", () => {
@@ -250,14 +248,8 @@ describe("buildFlowLayout", () => {
     expect(nodeIds.has("producer::crm")).toBe(false);
     expect(nodeIds.has("consumer::crm")).toBe(false);
     expect(nodeIds.has("topic::crm")).toBe(false);
-    for (const id of [
-      "topic::__resolver",
-      "topic::__manager",
-      "platform::resolver",
-      "platform::store",
-    ]) {
-      expect(nodeIds.has(id)).toBe(true);
-    }
+    // The Resolver platform fixture always survives filtering.
+    expect(nodeIds.has("platform::resolver")).toBe(true);
     const routeIds = layout.routes.map((r) => r.id);
     expect(routeIds).toContain("deliver::topic::erp::consumer::audit");
     // crm is hidden → its inbound (erp→crm) and outbound (crm→audit) deliver
@@ -278,49 +270,23 @@ describe("buildFlowLayout", () => {
     expect(layout.byEndpoint).toEqual({});
   });
 
-  it("renders a platform-only layout for empty topology data without throwing", () => {
+  it("renders a Resolver-only layout for empty topology data without throwing", () => {
     const layout = buildFlowLayout(topo([]));
-    expect(layout.nodes.map((n) => n.id).sort()).toEqual([
-      "platform::resolver",
-      "platform::store",
-      "topic::__manager",
-      "topic::__resolver",
-    ]);
-    expect(layout.routes.map((r) => r.id)).toEqual([
-      "outcome::topic::__resolver::platform::resolver",
-      "outcome::platform::resolver::platform::store",
-    ]);
+    expect(layout.nodes.map((n) => n.id)).toEqual(["platform::resolver"]);
+    expect(layout.routes).toEqual([]);
     expect(layout.byEndpoint).toEqual({});
     expect(layout.width).toBe(1240);
     expect(layout.height).toBe(600);
   });
 
-  it("labels platform chips and platform nodes per spec", () => {
+  it("labels the Resolver platform node per spec", () => {
     const layout = buildFlowLayout(topo([]));
     const byId = new Map(layout.nodes.map((n) => [n.id, n]));
-    expect(byId.get("topic::__resolver")).toMatchObject({
-      kind: "topic",
-      title: "Resolver",
-      subtitle: "outcome stream",
-      h: 40,
-      health: "good",
-    });
-    expect(byId.get("topic::__manager")).toMatchObject({
-      kind: "topic",
-      title: "Manager",
-      subtitle: "recovery commands",
-      h: 40,
-    });
     expect(byId.get("platform::resolver")).toMatchObject({
       kind: "platform",
-      title: "Resolver Worker",
+      title: "Resolver",
       h: 72,
       health: "good",
-    });
-    expect(byId.get("platform::store")).toMatchObject({
-      kind: "platform",
-      title: "Message Store",
-      h: 72,
     });
   });
 

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/layout.test.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/layout.test.ts
@@ -144,9 +144,10 @@ describe("buildFlowLayout", () => {
     // Consumers: crm (500 handled) above audit (200).
     expect(byId.get("consumer::crm")!.y).toBe(20);
     expect(byId.get("consumer::audit")!.y).toBe(100);
-    // Topics mirror producer order — no platform chips anymore.
-    expect(byId.get("topic::erp")!.y).toBe(20);
-    expect(byId.get("topic::crm")!.y).toBe(76); // 20 + 40 + 16
+    // Topics mirror producer order, shifted down by the Service Bus header
+    // band (20 margin + 40 header). No platform chips anymore.
+    expect(byId.get("topic::erp")!.y).toBe(60);
+    expect(byId.get("topic::crm")!.y).toBe(116); // 60 + 40 + 16
     // Platform column: the lone Resolver, centered against the consumer
     // column (center 92, half-height 36 → y 56).
     expect(byId.get("platform::resolver")!.y).toBe(56);
@@ -200,8 +201,9 @@ describe("buildFlowLayout", () => {
     );
     const publish = layout.routes.find((r) => r.kind === "publish");
     // producer::erp anchor (20+220, 20+32) = (240, 52); topic::erp anchor
-    // (330, 20+20) = (330, 40); dx = clamp((330−240)/2, 40, 120) = 45.
-    expect(publish!.d).toBe("M 240 52 C 285 52, 285 40, 330 40");
+    // (330, 60+20) = (330, 80) — topics sit below the SB header band;
+    // dx = clamp((330−240)/2, 40, 120) = 45.
+    expect(publish!.d).toBe("M 240 52 C 285 52, 285 80, 330 80");
   });
 
   it("produces only finite, non-negative geometry and NaN-free paths", () => {
@@ -288,6 +290,25 @@ describe("buildFlowLayout", () => {
       h: 72,
       health: "good",
     });
+  });
+
+  it("frames the topic column in a Service Bus container with header room", () => {
+    const layout = buildFlowLayout(canonical());
+    expect(layout.serviceBus).toBeDefined();
+    const sb = layout.serviceBus!;
+    const topics = layout.nodes.filter((n) => n.kind === "topic");
+    // Box brackets the topic column horizontally (padding on both sides)...
+    expect(sb.x).toBeLessThan(Math.min(...topics.map((t) => t.x)));
+    expect(sb.x + sb.w).toBeGreaterThan(
+      Math.max(...topics.map((t) => t.x + t.w)),
+    );
+    // ...and leaves a header band above the first chip for the title.
+    expect(sb.y).toBe(20);
+    expect(Math.min(...topics.map((t) => t.y))).toBeGreaterThan(sb.y);
+  });
+
+  it("omits the Service Bus box when there are no topics", () => {
+    expect(buildFlowLayout(topo([])).serviceBus).toBeUndefined();
   });
 
   it("describes endpoint roles in subtitles and titles topics by endpoint id", () => {

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/layout.test.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/layout.test.ts
@@ -311,6 +311,39 @@ describe("buildFlowLayout", () => {
     expect(buildFlowLayout(topo([])).serviceBus).toBeUndefined();
   });
 
+  it("narrows the whole diagram to one event type's flow", () => {
+    // CustomerRegistered rides only crm -> audit. erp (publisher of the other
+    // types) and crm-as-consumer drop out entirely.
+    const layout = buildFlowLayout(canonical(), {
+      eventType: "CustomerRegistered",
+    });
+    expect(layout.nodes.map((n) => n.id).sort()).toEqual([
+      "consumer::audit",
+      "platform::resolver",
+      "producer::crm",
+      "topic::crm",
+    ]);
+    const routeIds = layout.routes.map((r) => r.id);
+    expect(routeIds).toContain("publish::producer::crm::topic::crm");
+    expect(routeIds).toContain("deliver::topic::crm::consumer::audit");
+    expect(routeIds).toContain("outcome::consumer::audit::platform::resolver");
+    expect(routeIds).not.toContain("deliver::topic::erp::consumer::audit");
+    expect(Object.keys(layout.byEndpoint)).toEqual(["audit"]);
+  });
+
+  it("keeps the full catalog when the event type filter is empty", () => {
+    expect(buildFlowLayout(canonical(), { eventType: "" })).toEqual(
+      buildFlowLayout(canonical()),
+    );
+  });
+
+  it("renders only the Resolver for an event type nobody carries", () => {
+    const layout = buildFlowLayout(canonical(), { eventType: "Nope" });
+    expect(layout.nodes.map((n) => n.id)).toEqual(["platform::resolver"]);
+    expect(layout.serviceBus).toBeUndefined();
+    expect(layout.byEndpoint).toEqual({});
+  });
+
   it("describes endpoint roles in subtitles and titles topics by endpoint id", () => {
     const layout = buildFlowLayout(canonical());
     const byId = new Map(layout.nodes.map((n) => [n.id, n]));

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/layout.test.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/layout.test.ts
@@ -164,7 +164,12 @@ describe("buildFlowLayout", () => {
     const producers = buildFlowLayout(tied).nodes.filter(
       (n) => n.kind === "producer",
     );
-    expect(producers.map((n) => n.title)).toEqual(["Alpha", "Zeta"]);
+    // Producer titles read as adapters (the sending side); ordering still
+    // follows the name tiebreak.
+    expect(producers.map((n) => n.title)).toEqual([
+      "Alpha Adapter",
+      "Zeta Adapter",
+    ]);
   });
 
   it("emits routes that reference existing nodes and follow the kind::from::to id scheme", () => {
@@ -221,7 +226,7 @@ describe("buildFlowLayout", () => {
     expect(Number.isFinite(layout.height)).toBe(true);
   });
 
-  it("indexes every consumer in byEndpoint with sorted, existing route ids", () => {
+  it("indexes every consumer in byEndpoint with existing, deliver-sorted journeys", () => {
     const layout = buildFlowLayout(canonical());
     const nodeIds = new Set(layout.nodes.map((n) => n.id));
     const routeIds = new Set(layout.routes.map((r) => r.id));
@@ -230,15 +235,26 @@ describe("buildFlowLayout", () => {
       expect(index.nodeId).toBe(`consumer::${endpointId}`);
       expect(nodeIds.has(index.nodeId)).toBe(true);
       expect(routeIds.has(index.outcome)).toBe(true);
-      for (const id of index.deliver) {
-        expect(routeIds.has(id)).toBe(true);
+      // Every journey is [publish, deliver] and both segments exist.
+      for (const journey of index.journeys) {
+        expect(journey).toHaveLength(2);
+        for (const id of journey) expect(routeIds.has(id)).toBe(true);
       }
-      expect([...index.deliver].sort()).toEqual(index.deliver);
+      // Journeys are ordered by their deliver segment id.
+      const deliverIds = index.journeys.map((j) => j[j.length - 1]);
+      expect([...deliverIds].sort()).toEqual(deliverIds);
     }
-    // audit fans in from both producers; sorted ids put crm before erp.
-    expect(layout.byEndpoint["audit"].deliver).toEqual([
-      "deliver::topic::crm::consumer::audit",
-      "deliver::topic::erp::consumer::audit",
+    // audit fans in from both producers; each journey pairs the publish leg
+    // with its deliver leg, ordered by deliver id (crm before erp).
+    expect(layout.byEndpoint["audit"].journeys).toEqual([
+      [
+        "publish::producer::crm::topic::crm",
+        "deliver::topic::crm::consumer::audit",
+      ],
+      [
+        "publish::producer::erp::topic::erp",
+        "deliver::topic::erp::consumer::audit",
+      ],
     ]);
   });
 
@@ -347,7 +363,7 @@ describe("buildFlowLayout", () => {
   it("describes endpoint roles in subtitles and titles topics by endpoint id", () => {
     const layout = buildFlowLayout(canonical());
     const byId = new Map(layout.nodes.map((n) => [n.id, n]));
-    expect(byId.get("producer::erp")!.title).toBe("ERP");
+    expect(byId.get("producer::erp")!.title).toBe("ERP Adapter");
     expect(byId.get("producer::erp")!.subtitle).toBe("publishes 2 event type(s)");
     expect(byId.get("consumer::audit")!.subtitle).toBe("handles 2 event type(s)");
     // Topic chips carry the endpoint id (one topic per endpoint), not the

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/layout.test.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/layout.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it } from "vitest";
+import type {
+  FlowEdge,
+  TopologyData,
+  TopologyNode,
+} from "components/topology/types";
+import { buildFlowLayout, topEndpointIds } from "./layout";
+import { TOP_N_DEFAULT } from "./types";
+
+// Spec 020 — layout engine unit tests. buildFlowLayout is pure (no DOM, no
+// clock, no randomness), so every assertion here pins exact geometry / ids;
+// any drift in the layout contract should fail loudly rather than render
+// subtly wrong.
+
+/* Fixture builders — construct full minimal objects so strict mode stays
+   happy without `as` casts. Only the fields layout reads get meaningful
+   values; the rest are zeroed defaults. */
+
+function endpoint(
+  overrides: Partial<TopologyNode> & Pick<TopologyNode, "id">,
+): TopologyNode {
+  return {
+    name: overrides.id,
+    role: "Endpoint",
+    publishCount: 0,
+    subscribeCount: 0,
+    publishedMessages: 0,
+    handledMessages: 0,
+    failedMessages: 0,
+    health: "good",
+    ...overrides,
+  };
+}
+
+function flowEdge(from: string, to: string, eventTypeIds: string[]): FlowEdge {
+  return {
+    id: `${from}::${to}`,
+    from,
+    to,
+    eventTypeIds,
+    messages: 0,
+    failures: 0,
+    health: "live",
+    tooltip: "",
+  };
+}
+
+function topo(nodes: TopologyNode[], flowEdges: FlowEdge[] = []): TopologyData {
+  return {
+    nodes,
+    edges: [],
+    pills: [],
+    flowEdges,
+    summary: {
+      endpoints: nodes.length,
+      eventTypes: 0,
+      edges: 0,
+      edgesWithFailures: 0,
+      namespaces: 0,
+      producingEndpoints: 0,
+      consumingEndpoints: 0,
+    },
+  };
+}
+
+/**
+ * Canonical fixture:
+ *   erp   — producer only, loudest (900 published)
+ *   crm   — both roles (300 published / 500 handled)
+ *   audit — consumer only, quiet (200 handled)
+ * Routes: erp→crm (OrderPlaced), erp→audit (OrderPlaced, InvoiceRaised),
+ *         crm→audit (CustomerRegistered).
+ */
+function canonical(): TopologyData {
+  return topo(
+    [
+      endpoint({
+        id: "erp",
+        name: "ERP",
+        publishCount: 2,
+        publishedMessages: 900,
+        health: "good",
+      }),
+      endpoint({
+        id: "crm",
+        name: "CRM",
+        publishCount: 1,
+        subscribeCount: 1,
+        publishedMessages: 300,
+        handledMessages: 500,
+        health: "warn",
+      }),
+      endpoint({
+        id: "audit",
+        name: "Audit Log",
+        subscribeCount: 2,
+        handledMessages: 200,
+        health: "bad",
+      }),
+    ],
+    [
+      flowEdge("erp", "crm", ["OrderPlaced"]),
+      flowEdge("erp", "audit", ["OrderPlaced", "InvoiceRaised"]),
+      flowEdge("crm", "audit", ["CustomerRegistered"]),
+    ],
+  );
+}
+
+describe("buildFlowLayout", () => {
+  it("is deterministic: repeated and input-order-shuffled calls produce deep-equal layouts", () => {
+    const first = buildFlowLayout(canonical());
+    expect(buildFlowLayout(canonical())).toEqual(first);
+
+    // Reversing the input arrays must not change anything — ordering comes
+    // from traffic + name, never from incidental catalog order.
+    const shuffled = canonical();
+    shuffled.nodes.reverse();
+    shuffled.flowEdges.reverse();
+    expect(buildFlowLayout(shuffled)).toEqual(first);
+  });
+
+  it("places a both-role endpoint in both producer and consumer columns with distinct node ids", () => {
+    const layout = buildFlowLayout(canonical());
+    const producer = layout.nodes.find((n) => n.id === "producer::crm");
+    const consumer = layout.nodes.find((n) => n.id === "consumer::crm");
+    expect(producer).toBeDefined();
+    expect(consumer).toBeDefined();
+    expect(producer!.id).not.toBe(consumer!.id);
+    expect(producer!.x).toBe(20);
+    expect(consumer!.x).toBe(660);
+    expect(producer!.endpointId).toBe("crm");
+    expect(consumer!.endpointId).toBe("crm");
+    // Health is copied from the TopologyNode onto both column instances.
+    expect(producer!.health).toBe("warn");
+    expect(consumer!.health).toBe("warn");
+  });
+
+  it("stacks each column top-down by descending traffic with margin 20 / gap 16", () => {
+    const layout = buildFlowLayout(canonical());
+    const byId = new Map(layout.nodes.map((n) => [n.id, n]));
+    // Producers: erp (900) above crm (300).
+    expect(byId.get("producer::erp")!.y).toBe(20);
+    expect(byId.get("producer::crm")!.y).toBe(100); // 20 + 64 + 16
+    // Consumers: crm (500 handled) above audit (200).
+    expect(byId.get("consumer::crm")!.y).toBe(20);
+    expect(byId.get("consumer::audit")!.y).toBe(100);
+    // Topics mirror producer order, then the two platform chips at the bottom.
+    expect(byId.get("topic::erp")!.y).toBe(20);
+    expect(byId.get("topic::crm")!.y).toBe(76); // 20 + 40 + 16
+    expect(byId.get("topic::__resolver")!.y).toBe(132);
+    expect(byId.get("topic::__manager")!.y).toBe(188);
+    // Platform column: Resolver Worker above Message Store.
+    expect(byId.get("platform::resolver")!.y).toBe(20);
+    expect(byId.get("platform::store")!.y).toBe(108); // 20 + 72 + 16
+    // Canvas: fixed width; height clamps to the 600 minimum for small graphs.
+    expect(layout.width).toBe(1240);
+    expect(layout.height).toBe(600);
+  });
+
+  it("breaks equal-traffic ordering ties by name ascending", () => {
+    const tied = topo([
+      endpoint({ id: "z", name: "Zeta", publishCount: 1, publishedMessages: 100 }),
+      endpoint({ id: "a", name: "Alpha", publishCount: 1, publishedMessages: 100 }),
+    ]);
+    const producers = buildFlowLayout(tied).nodes.filter(
+      (n) => n.kind === "producer",
+    );
+    expect(producers.map((n) => n.title)).toEqual(["Alpha", "Zeta"]);
+  });
+
+  it("emits routes that reference existing nodes and follow the kind::from::to id scheme", () => {
+    const layout = buildFlowLayout(canonical());
+    const nodeIds = new Set(layout.nodes.map((n) => n.id));
+    for (const route of layout.routes) {
+      expect(nodeIds.has(route.fromNodeId)).toBe(true);
+      expect(nodeIds.has(route.toNodeId)).toBe(true);
+      expect(route.id).toBe(`${route.kind}::${route.fromNodeId}::${route.toNodeId}`);
+    }
+    const routeIds = layout.routes.map((r) => r.id);
+    expect(routeIds).toContain("publish::producer::erp::topic::erp");
+    expect(routeIds).toContain("deliver::topic::erp::consumer::audit");
+    expect(routeIds).toContain("outcome::consumer::audit::topic::__resolver");
+    expect(routeIds).toContain("outcome::topic::__resolver::platform::resolver");
+    expect(routeIds).toContain("outcome::platform::resolver::platform::store");
+  });
+
+  it("unions + sorts publish-route event types from flow edges; deliver routes carry the edge's list verbatim", () => {
+    const layout = buildFlowLayout(canonical());
+    const publish = layout.routes.find(
+      (r) => r.id === "publish::producer::erp::topic::erp",
+    );
+    expect(publish!.eventTypeIds).toEqual(["InvoiceRaised", "OrderPlaced"]);
+    const deliver = layout.routes.find(
+      (r) => r.id === "deliver::topic::erp::consumer::audit",
+    );
+    expect(deliver!.eventTypeIds).toEqual(["OrderPlaced", "InvoiceRaised"]);
+  });
+
+  it("renders cubic beziers between right-center and left-center anchors, rounded to one decimal", () => {
+    const layout = buildFlowLayout(
+      topo([endpoint({ id: "erp", name: "ERP", publishCount: 1, publishedMessages: 10 })]),
+    );
+    const publish = layout.routes.find((r) => r.kind === "publish");
+    // producer::erp anchor (20+220, 20+32) = (240, 52); topic::erp anchor
+    // (330, 20+20) = (330, 40); dx = clamp((330−240)/2, 40, 120) = 45.
+    expect(publish!.d).toBe("M 240 52 C 285 52, 285 40, 330 40");
+  });
+
+  it("produces only finite, non-negative geometry and NaN-free paths", () => {
+    const layout = buildFlowLayout(canonical());
+    for (const n of layout.nodes) {
+      for (const value of [n.x, n.y, n.w, n.h]) {
+        expect(Number.isFinite(value)).toBe(true);
+        expect(value).toBeGreaterThanOrEqual(0);
+      }
+    }
+    for (const route of layout.routes) {
+      expect(route.d).not.toMatch(/NaN/);
+    }
+    expect(Number.isFinite(layout.width)).toBe(true);
+    expect(Number.isFinite(layout.height)).toBe(true);
+  });
+
+  it("indexes every consumer in byEndpoint with sorted, existing route ids", () => {
+    const layout = buildFlowLayout(canonical());
+    const nodeIds = new Set(layout.nodes.map((n) => n.id));
+    const routeIds = new Set(layout.routes.map((r) => r.id));
+    expect(Object.keys(layout.byEndpoint).sort()).toEqual(["audit", "crm"]);
+    for (const [endpointId, index] of Object.entries(layout.byEndpoint)) {
+      expect(index.nodeId).toBe(`consumer::${endpointId}`);
+      expect(nodeIds.has(index.nodeId)).toBe(true);
+      expect(routeIds.has(index.outcome)).toBe(true);
+      for (const id of index.deliver) {
+        expect(routeIds.has(id)).toBe(true);
+      }
+      expect([...index.deliver].sort()).toEqual(index.deliver);
+    }
+    // audit fans in from both producers; sorted ids put crm before erp.
+    expect(layout.byEndpoint["audit"].deliver).toEqual([
+      "deliver::topic::crm::consumer::audit",
+      "deliver::topic::erp::consumer::audit",
+    ]);
+  });
+
+  it("filters hidden endpoints out of every column but always keeps platform fixtures", () => {
+    const layout = buildFlowLayout(canonical(), {
+      visibleEndpointIds: new Set(["erp", "audit"]),
+    });
+    const nodeIds = new Set(layout.nodes.map((n) => n.id));
+    expect(nodeIds.has("producer::crm")).toBe(false);
+    expect(nodeIds.has("consumer::crm")).toBe(false);
+    expect(nodeIds.has("topic::crm")).toBe(false);
+    for (const id of [
+      "topic::__resolver",
+      "topic::__manager",
+      "platform::resolver",
+      "platform::store",
+    ]) {
+      expect(nodeIds.has(id)).toBe(true);
+    }
+    const routeIds = layout.routes.map((r) => r.id);
+    expect(routeIds).toContain("deliver::topic::erp::consumer::audit");
+    // crm is hidden → its inbound (erp→crm) and outbound (crm→audit) deliver
+    // routes are dropped silently.
+    expect(routeIds).not.toContain("deliver::topic::erp::consumer::crm");
+    expect(routeIds).not.toContain("deliver::topic::crm::consumer::audit");
+    expect(Object.keys(layout.byEndpoint)).toEqual(["audit"]);
+  });
+
+  it("drops deliver routes when the consumer end is hidden but keeps the producer's publish route", () => {
+    const layout = buildFlowLayout(canonical(), {
+      visibleEndpointIds: new Set(["erp"]),
+    });
+    expect(layout.routes.filter((r) => r.kind === "deliver")).toHaveLength(0);
+    expect(
+      layout.routes.find((r) => r.id === "publish::producer::erp::topic::erp"),
+    ).toBeDefined();
+    expect(layout.byEndpoint).toEqual({});
+  });
+
+  it("renders a platform-only layout for empty topology data without throwing", () => {
+    const layout = buildFlowLayout(topo([]));
+    expect(layout.nodes.map((n) => n.id).sort()).toEqual([
+      "platform::resolver",
+      "platform::store",
+      "topic::__manager",
+      "topic::__resolver",
+    ]);
+    expect(layout.routes.map((r) => r.id)).toEqual([
+      "outcome::topic::__resolver::platform::resolver",
+      "outcome::platform::resolver::platform::store",
+    ]);
+    expect(layout.byEndpoint).toEqual({});
+    expect(layout.width).toBe(1240);
+    expect(layout.height).toBe(600);
+  });
+
+  it("labels platform chips and platform nodes per spec", () => {
+    const layout = buildFlowLayout(topo([]));
+    const byId = new Map(layout.nodes.map((n) => [n.id, n]));
+    expect(byId.get("topic::__resolver")).toMatchObject({
+      kind: "topic",
+      title: "Resolver",
+      subtitle: "outcome stream",
+      h: 40,
+      health: "good",
+    });
+    expect(byId.get("topic::__manager")).toMatchObject({
+      kind: "topic",
+      title: "Manager",
+      subtitle: "recovery commands",
+      h: 40,
+    });
+    expect(byId.get("platform::resolver")).toMatchObject({
+      kind: "platform",
+      title: "Resolver Worker",
+      h: 72,
+      health: "good",
+    });
+    expect(byId.get("platform::store")).toMatchObject({
+      kind: "platform",
+      title: "Message Store",
+      h: 72,
+    });
+  });
+
+  it("describes endpoint roles in subtitles and titles topics by endpoint id", () => {
+    const layout = buildFlowLayout(canonical());
+    const byId = new Map(layout.nodes.map((n) => [n.id, n]));
+    expect(byId.get("producer::erp")!.title).toBe("ERP");
+    expect(byId.get("producer::erp")!.subtitle).toBe("publishes 2 event type(s)");
+    expect(byId.get("consumer::audit")!.subtitle).toBe("handles 2 event type(s)");
+    // Topic chips carry the endpoint id (one topic per endpoint), not the
+    // display name.
+    expect(byId.get("topic::erp")!.title).toBe("erp");
+  });
+});
+
+describe("topEndpointIds", () => {
+  it("ranks by published + handled traffic, descending", () => {
+    const data = topo([
+      endpoint({ id: "low", name: "Low", publishedMessages: 5, handledMessages: 5 }),
+      endpoint({ id: "high", name: "High", publishedMessages: 100, handledMessages: 150 }),
+      endpoint({ id: "mid", name: "Mid", handledMessages: 60 }),
+    ]);
+    expect(topEndpointIds(data, 2)).toEqual(["high", "mid"]);
+    expect(topEndpointIds(data, 10)).toEqual(["high", "mid", "low"]);
+  });
+
+  it("breaks ties by name ascending", () => {
+    const data = topo([
+      endpoint({ id: "b", name: "Beta", publishedMessages: 50, handledMessages: 50 }),
+      endpoint({ id: "a", name: "Alpha", publishedMessages: 100 }),
+      endpoint({ id: "g", name: "Gamma", handledMessages: 100 }),
+    ]);
+    expect(topEndpointIds(data, 3)).toEqual(["a", "b", "g"]);
+  });
+
+  it("returns an empty list for n <= 0 and caps at the catalog size", () => {
+    const data = topo([endpoint({ id: "only" })]);
+    expect(topEndpointIds(data, 0)).toEqual([]);
+    expect(topEndpointIds(data, -3)).toEqual([]);
+    expect(topEndpointIds(data, TOP_N_DEFAULT)).toEqual(["only"]);
+  });
+});

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/layout.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/layout.ts
@@ -18,6 +18,12 @@ import type {
 export interface LayoutOptions {
   /** Endpoints to render; undefined = all. Both producer and consumer roles of a visible endpoint render. */
   visibleEndpointIds?: ReadonlySet<string>;
+  /**
+   * When set to a non-empty event type, narrows the WHOLE diagram to that
+   * event type's flow: only its publishers, their topics, its handlers, and the
+   * routes carrying it. Empty/undefined renders the full catalog.
+   */
+  eventType?: string;
 }
 
 // Fixed column geometry. The canvas is an SVG viewBox, so these absolute
@@ -57,18 +63,37 @@ export function buildFlowLayout(
   const isVisible = (id: string): boolean =>
     visible === undefined || visible.has(id);
 
+  // Event-type filter: restrict everything to one event type's flow. The
+  // carrying edges drive which endpoints participate — publishers are the
+  // edges' `from`, handlers their `to` — so non-participating nodes drop out
+  // entirely instead of lingering as orphaned boxes.
+  const eventType =
+    opts?.eventType !== undefined && opts.eventType !== ""
+      ? opts.eventType
+      : undefined;
+  const edges =
+    eventType === undefined
+      ? data.flowEdges
+      : data.flowEdges.filter((e) => e.eventTypeIds.includes(eventType));
+  const publishesType = new Set(edges.map((e) => e.from));
+  const handlesType = new Set(edges.map((e) => e.to));
+  const publishesInType = (id: string): boolean =>
+    eventType === undefined || publishesType.has(id);
+  const handlesInType = (id: string): boolean =>
+    eventType === undefined || handlesType.has(id);
+
   // An endpoint with both roles appears in BOTH columns (the convention
   // proven by topology-flow.tsx), so the two populations are derived
   // independently rather than partitioning the catalog. Sort by the
   // role-relevant traffic so the busiest endpoints surface at the top where
   // the operator's eye lands first; ties fall back to name for stability.
   const producers = data.nodes
-    .filter((n) => n.publishCount > 0 && isVisible(n.id))
+    .filter((n) => n.publishCount > 0 && isVisible(n.id) && publishesInType(n.id))
     .sort(
       (a, b) => b.publishedMessages - a.publishedMessages || compareByName(a, b),
     );
   const consumers = data.nodes
-    .filter((n) => n.subscribeCount > 0 && isVisible(n.id))
+    .filter((n) => n.subscribeCount > 0 && isVisible(n.id) && handlesInType(n.id))
     .sort(
       (a, b) => b.handledMessages - a.handledMessages || compareByName(a, b),
     );
@@ -137,7 +162,7 @@ export function buildFlowLayout(
   // concrete event-type ids to a producing endpoint; types nobody subscribes
   // to simply don't decorate the route.
   const eventTypesByProducer = new Map<string, Set<string>>();
-  for (const edge of data.flowEdges) {
+  for (const edge of edges) {
     let set = eventTypesByProducer.get(edge.from);
     if (!set) {
       set = new Set<string>();
@@ -163,7 +188,7 @@ export function buildFlowLayout(
   const producerIds = new Set(producers.map((n) => n.id));
   const consumerIds = new Set(consumers.map((n) => n.id));
   const deliverRoutes: FlowRoute[] = [];
-  for (const edge of data.flowEdges) {
+  for (const edge of edges) {
     if (!producerIds.has(edge.from) || !consumerIds.has(edge.to)) continue;
     deliverRoutes.push(
       makeRoute(

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/layout.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/layout.ts
@@ -35,12 +35,9 @@ const GAP = 16;
 const CANVAS_W = 1240;
 const MIN_CANVAS_H = 600;
 
-// Well-known node ids for the platform fixtures. The double-underscore prefix
-// keeps the synthetic topic chips out of any real endpoint-id namespace.
-const RESOLVER_TOPIC = "topic::__resolver";
-const MANAGER_TOPIC = "topic::__manager";
+// Well-known node id for the Resolver — the single platform fixture, rendered
+// to the right of the consuming endpoints where every outcome converges.
 const RESOLVER_PLATFORM = "platform::resolver";
-const STORE_PLATFORM = "platform::store";
 
 /**
  * Builds the full flow layout (nodes, routes, byEndpoint index) from the
@@ -81,9 +78,7 @@ export function buildFlowLayout(
   // One topic per producing endpoint is a NimBus platform invariant, so the
   // chip is titled with the endpoint id directly — no separate topic catalog
   // exists to consult. Chips mirror producer order so each chip sits roughly
-  // beside its producer. The Resolver/Manager chips are platform plumbing
-  // present in every deployment, hence appended unconditionally at the bottom
-  // and exempt from endpoint filtering.
+  // beside its producer.
   const topicNodes: FlowNode[] = producers.map((n) => ({
     id: `topic::${n.id}`,
     kind: "topic",
@@ -95,20 +90,18 @@ export function buildFlowLayout(
     h: TOPIC_H,
     health: "good",
   }));
-  topicNodes.push(
-    platformTopicChip(RESOLVER_TOPIC, "Resolver", "outcome stream"),
-    platformTopicChip(MANAGER_TOPIC, "Manager", "recovery commands"),
-  );
 
-  const platformNodes: FlowNode[] = [
-    platformNode(RESOLVER_PLATFORM, "Resolver Worker"),
-    platformNode(STORE_PLATFORM, "Message Store"),
-  ];
+  // The Resolver is the only platform fixture — every consumer's outcomes
+  // converge on it. Present in every deployment and exempt from filtering.
+  const platformNodes: FlowNode[] = [platformNode(RESOLVER_PLATFORM, "Resolver")];
 
   stackColumn(producerNodes);
   stackColumn(topicNodes);
   stackColumn(consumerNodes);
   stackColumn(platformNodes);
+  // Sit the lone Resolver fixture beside the consumer column it collects
+  // outcomes from, rather than pinned to the top margin.
+  centerColumn(platformNodes, columnCenter(consumerNodes));
 
   const nodes: FlowNode[] = [
     ...producerNodes,
@@ -167,19 +160,15 @@ export function buildFlowLayout(
   deliverRoutes.sort(compareStrings((r) => r.id));
   routes.push(...deliverRoutes);
 
-  // outcome: every consumer reports to the Resolver topic, then two static
-  // hops complete the platform story (Resolver topic → worker → store).
-  // Outcome routes carry no event types: outcomes are status records, not
-  // typed business events.
-  const resolverTopic = nodeById.get(RESOLVER_TOPIC)!;
-  const resolverWorker = nodeById.get(RESOLVER_PLATFORM)!;
+  // outcome: every consumer reports to the Resolver, which sits to the right
+  // of the consumer column. Outcome routes carry no event types: outcomes are
+  // status records, not typed business events.
+  const resolver = nodeById.get(RESOLVER_PLATFORM)!;
   for (const n of consumers) {
     routes.push(
-      makeRoute("outcome", nodeById.get(`consumer::${n.id}`)!, resolverTopic, []),
+      makeRoute("outcome", nodeById.get(`consumer::${n.id}`)!, resolver, []),
     );
   }
-  routes.push(makeRoute("outcome", resolverTopic, resolverWorker, []));
-  routes.push(makeRoute("outcome", resolverWorker, nodeById.get(STORE_PLATFORM)!, []));
 
   // byEndpoint: the animator's entry point — it receives semantic events
   // keyed by endpoint id and needs the concrete route ids without scanning
@@ -192,7 +181,7 @@ export function buildFlowLayout(
       deliver: deliverRoutes
         .filter((r) => r.toNodeId === consumerNodeId)
         .map((r) => r.id),
-      outcome: `outcome::${consumerNodeId}::${RESOLVER_TOPIC}`,
+      outcome: `outcome::${consumerNodeId}::${RESOLVER_PLATFORM}`,
     };
   }
 
@@ -249,20 +238,6 @@ function endpointNode(
   };
 }
 
-function platformTopicChip(id: string, title: string, subtitle: string): FlowNode {
-  return {
-    id,
-    kind: "topic",
-    title,
-    subtitle,
-    x: COL_X.topic,
-    y: 0,
-    w: COL_W.topic,
-    h: TOPIC_H,
-    health: "good",
-  };
-}
-
 function platformNode(id: string, title: string): FlowNode {
   return {
     id,
@@ -287,6 +262,29 @@ function stackColumn(column: FlowNode[]): void {
     node.y = y;
     y += node.h + GAP;
   }
+}
+
+/** Vertical center of an already-stacked column; top margin when empty. */
+function columnCenter(column: FlowNode[]): number {
+  if (column.length === 0) return TOP_MARGIN;
+  const top = column[0].y;
+  const last = column[column.length - 1];
+  return (top + last.y + last.h) / 2;
+}
+
+/**
+ * Shifts an already-stacked column so its block centers on `center`, never
+ * rising above the top margin. Mutates y in place — safe because every node
+ * was created inside buildFlowLayout.
+ */
+function centerColumn(column: FlowNode[], center: number): void {
+  if (column.length === 0) return;
+  const top = column[0].y;
+  const last = column[column.length - 1];
+  const blockCenter = (top + last.y + last.h) / 2;
+  const shift = Math.max(center - blockCenter, TOP_MARGIN - top);
+  if (shift === 0) return;
+  for (const node of column) node.y += shift;
 }
 
 function makeRoute(

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/layout.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/layout.ts
@@ -1,0 +1,350 @@
+// Layout engine for the Live Flow page (spec 020, FR-002). Consumes the
+// Topology page's already-derived TopologyData and produces the deterministic
+// four-column layered layout: producers → topics → consumers → platform.
+// Deliberately pure — no DOM, no clock, no randomness — so vitest can pin the
+// geometry exactly and the page can memoise the result by input identity.
+// The animator addresses routes by the stable ids built here; changing any id
+// scheme is a breaking change for it.
+
+import type { TopologyData, TopologyNode } from "components/topology/types";
+import type {
+  EndpointRouteIndex,
+  FlowLayout,
+  FlowNode,
+  FlowRoute,
+  FlowRouteKind,
+} from "./types";
+
+export interface LayoutOptions {
+  /** Endpoints to render; undefined = all. Both producer and consumer roles of a visible endpoint render. */
+  visibleEndpointIds?: ReadonlySet<string>;
+}
+
+// Fixed column geometry. The canvas is an SVG viewBox, so these absolute
+// numbers scale with the container — keeping them constant (instead of
+// measuring text) is what makes route paths reproducible in tests and stable
+// across renders. Topic chips get extra width because endpoint ids run longer
+// than display names.
+const COL_X = { producer: 20, topic: 330, consumer: 660, platform: 990 } as const;
+const COL_W = { producer: 220, topic: 240, consumer: 220, platform: 220 } as const;
+const ENDPOINT_H = 64;
+const TOPIC_H = 40;
+const PLATFORM_H = 72;
+const TOP_MARGIN = 20;
+const GAP = 16;
+const CANVAS_W = 1240;
+const MIN_CANVAS_H = 600;
+
+// Well-known node ids for the platform fixtures. The double-underscore prefix
+// keeps the synthetic topic chips out of any real endpoint-id namespace.
+const RESOLVER_TOPIC = "topic::__resolver";
+const MANAGER_TOPIC = "topic::__manager";
+const RESOLVER_PLATFORM = "platform::resolver";
+const STORE_PLATFORM = "platform::store";
+
+/**
+ * Builds the full flow layout (nodes, routes, byEndpoint index) from the
+ * topology catalog. Deterministic: identical input always yields a
+ * deep-equal layout regardless of catalog array order.
+ */
+export function buildFlowLayout(
+  data: TopologyData,
+  opts?: LayoutOptions,
+): FlowLayout {
+  const visible = opts?.visibleEndpointIds;
+  const isVisible = (id: string): boolean =>
+    visible === undefined || visible.has(id);
+
+  // An endpoint with both roles appears in BOTH columns (the convention
+  // proven by topology-flow.tsx), so the two populations are derived
+  // independently rather than partitioning the catalog. Sort by the
+  // role-relevant traffic so the busiest endpoints surface at the top where
+  // the operator's eye lands first; ties fall back to name for stability.
+  const producers = data.nodes
+    .filter((n) => n.publishCount > 0 && isVisible(n.id))
+    .sort(
+      (a, b) => b.publishedMessages - a.publishedMessages || compareByName(a, b),
+    );
+  const consumers = data.nodes
+    .filter((n) => n.subscribeCount > 0 && isVisible(n.id))
+    .sort(
+      (a, b) => b.handledMessages - a.handledMessages || compareByName(a, b),
+    );
+
+  const producerNodes = producers.map((n) =>
+    endpointNode("producer", n, `publishes ${n.publishCount} event type(s)`),
+  );
+  const consumerNodes = consumers.map((n) =>
+    endpointNode("consumer", n, `handles ${n.subscribeCount} event type(s)`),
+  );
+
+  // One topic per producing endpoint is a NimBus platform invariant, so the
+  // chip is titled with the endpoint id directly — no separate topic catalog
+  // exists to consult. Chips mirror producer order so each chip sits roughly
+  // beside its producer. The Resolver/Manager chips are platform plumbing
+  // present in every deployment, hence appended unconditionally at the bottom
+  // and exempt from endpoint filtering.
+  const topicNodes: FlowNode[] = producers.map((n) => ({
+    id: `topic::${n.id}`,
+    kind: "topic",
+    endpointId: n.id,
+    title: n.id,
+    x: COL_X.topic,
+    y: 0,
+    w: COL_W.topic,
+    h: TOPIC_H,
+    health: "good",
+  }));
+  topicNodes.push(
+    platformTopicChip(RESOLVER_TOPIC, "Resolver", "outcome stream"),
+    platformTopicChip(MANAGER_TOPIC, "Manager", "recovery commands"),
+  );
+
+  const platformNodes: FlowNode[] = [
+    platformNode(RESOLVER_PLATFORM, "Resolver Worker"),
+    platformNode(STORE_PLATFORM, "Message Store"),
+  ];
+
+  stackColumn(producerNodes);
+  stackColumn(topicNodes);
+  stackColumn(consumerNodes);
+  stackColumn(platformNodes);
+
+  const nodes: FlowNode[] = [
+    ...producerNodes,
+    ...topicNodes,
+    ...consumerNodes,
+    ...platformNodes,
+  ];
+  const nodeById = new Map(nodes.map((n) => [n.id, n]));
+
+  const routes: FlowRoute[] = [];
+
+  // publish: producer → its own topic. Event types come from the flow edges
+  // (not publishCount) because flowEdges are the only place TopologyData ties
+  // concrete event-type ids to a producing endpoint; types nobody subscribes
+  // to simply don't decorate the route.
+  const eventTypesByProducer = new Map<string, Set<string>>();
+  for (const edge of data.flowEdges) {
+    let set = eventTypesByProducer.get(edge.from);
+    if (!set) {
+      set = new Set<string>();
+      eventTypesByProducer.set(edge.from, set);
+    }
+    for (const eventTypeId of edge.eventTypeIds) set.add(eventTypeId);
+  }
+  for (const n of producers) {
+    routes.push(
+      makeRoute(
+        "publish",
+        nodeById.get(`producer::${n.id}`)!,
+        nodeById.get(`topic::${n.id}`)!,
+        [...(eventTypesByProducer.get(n.id) ?? [])].sort(),
+      ),
+    );
+  }
+
+  // deliver: topic → consumer, one route per flow edge whose BOTH ends
+  // survived filtering. An edge referencing a hidden or unknown endpoint is
+  // dropped silently — the page's filter UI owns messaging about hidden
+  // traffic, the layout just stays consistent.
+  const producerIds = new Set(producers.map((n) => n.id));
+  const consumerIds = new Set(consumers.map((n) => n.id));
+  const deliverRoutes: FlowRoute[] = [];
+  for (const edge of data.flowEdges) {
+    if (!producerIds.has(edge.from) || !consumerIds.has(edge.to)) continue;
+    deliverRoutes.push(
+      makeRoute(
+        "deliver",
+        nodeById.get(`topic::${edge.from}`)!,
+        nodeById.get(`consumer::${edge.to}`)!,
+        [...edge.eventTypeIds],
+      ),
+    );
+  }
+  // Sorting by id makes the output independent of flowEdges array order —
+  // part of the determinism contract — and pre-sorts byEndpoint.deliver.
+  deliverRoutes.sort(compareStrings((r) => r.id));
+  routes.push(...deliverRoutes);
+
+  // outcome: every consumer reports to the Resolver topic, then two static
+  // hops complete the platform story (Resolver topic → worker → store).
+  // Outcome routes carry no event types: outcomes are status records, not
+  // typed business events.
+  const resolverTopic = nodeById.get(RESOLVER_TOPIC)!;
+  const resolverWorker = nodeById.get(RESOLVER_PLATFORM)!;
+  for (const n of consumers) {
+    routes.push(
+      makeRoute("outcome", nodeById.get(`consumer::${n.id}`)!, resolverTopic, []),
+    );
+  }
+  routes.push(makeRoute("outcome", resolverTopic, resolverWorker, []));
+  routes.push(makeRoute("outcome", resolverWorker, nodeById.get(STORE_PLATFORM)!, []));
+
+  // byEndpoint: the animator's entry point — it receives semantic events
+  // keyed by endpoint id and needs the concrete route ids without scanning
+  // the route list per event.
+  const byEndpoint: Record<string, EndpointRouteIndex> = {};
+  for (const n of consumers) {
+    const consumerNodeId = `consumer::${n.id}`;
+    byEndpoint[n.id] = {
+      nodeId: consumerNodeId,
+      deliver: deliverRoutes
+        .filter((r) => r.toNodeId === consumerNodeId)
+        .map((r) => r.id),
+      outcome: `outcome::${consumerNodeId}::${RESOLVER_TOPIC}`,
+    };
+  }
+
+  // Height tracks the tallest column so big catalogs scroll instead of
+  // squeezing; the 600 floor keeps small/empty layouts from collapsing into
+  // a squashed band when the SVG scales to its container.
+  let maxBottom = 0;
+  for (const n of nodes) maxBottom = Math.max(maxBottom, n.y + n.h);
+  const height = Math.max(MIN_CANVAS_H, maxBottom + TOP_MARGIN);
+
+  return { nodes, routes, width: CANVAS_W, height, byEndpoint };
+}
+
+/**
+ * Helper the page uses for the default filter: top-N endpoint ids by
+ * (publishedMessages + handledMessages), ties broken by name. Combined
+ * traffic rather than per-role so a both-role endpoint's full footprint
+ * counts once; the name tiebreak keeps the default view stable on quiet
+ * platforms where most totals are zero.
+ */
+export function topEndpointIds(data: TopologyData, n: number): string[] {
+  if (n <= 0) return [];
+  return [...data.nodes]
+    .sort(
+      (a, b) =>
+        b.publishedMessages +
+          b.handledMessages -
+          (a.publishedMessages + a.handledMessages) || compareByName(a, b),
+    )
+    .slice(0, n)
+    .map((node) => node.id);
+}
+
+// ----- internals -----------------------------------------------------------
+
+function endpointNode(
+  kind: "producer" | "consumer",
+  n: TopologyNode,
+  subtitle: string,
+): FlowNode {
+  return {
+    id: `${kind}::${n.id}`,
+    kind,
+    endpointId: n.id,
+    title: n.name,
+    subtitle,
+    x: COL_X[kind],
+    y: 0, // assigned by stackColumn
+    w: COL_W[kind],
+    h: ENDPOINT_H,
+    // Endpoint health travels onto both column instances; topics/platform
+    // stay "good" because the catalog has no health signal for them.
+    health: n.health,
+  };
+}
+
+function platformTopicChip(id: string, title: string, subtitle: string): FlowNode {
+  return {
+    id,
+    kind: "topic",
+    title,
+    subtitle,
+    x: COL_X.topic,
+    y: 0,
+    w: COL_W.topic,
+    h: TOPIC_H,
+    health: "good",
+  };
+}
+
+function platformNode(id: string, title: string): FlowNode {
+  return {
+    id,
+    kind: "platform",
+    title,
+    x: COL_X.platform,
+    y: 0,
+    w: COL_W.platform,
+    h: PLATFORM_H,
+    health: "good",
+  };
+}
+
+/**
+ * Vertical stacking with a fixed top margin and gap. Mutates y in place —
+ * safe because every node was created inside buildFlowLayout, never
+ * caller-owned.
+ */
+function stackColumn(column: FlowNode[]): void {
+  let y = TOP_MARGIN;
+  for (const node of column) {
+    node.y = y;
+    y += node.h + GAP;
+  }
+}
+
+function makeRoute(
+  kind: FlowRouteKind,
+  from: FlowNode,
+  to: FlowNode,
+  eventTypeIds: string[],
+): FlowRoute {
+  return {
+    id: `${kind}::${from.id}::${to.id}`,
+    kind,
+    fromNodeId: from.id,
+    toNodeId: to.id,
+    eventTypeIds,
+    d: bezier(from, to),
+  };
+}
+
+/**
+ * Cubic bezier from the from-node's right-center anchor to the to-node's
+ * left-center anchor — same shape language as topology-flow.tsx ribbons.
+ * dx clamps the control-point pull to [40, 120]: enough curve for short hops
+ * to read as flow, without long platform routes ballooning; the 40 floor also
+ * gives right-to-left routes (consumer → Resolver topic) a readable S-curve
+ * instead of a degenerate straight line. Coordinates round to one decimal so
+ * path strings stay byte-stable across runs and engines.
+ */
+function bezier(from: FlowNode, to: FlowNode): string {
+  const x1 = from.x + from.w;
+  const y1 = from.y + from.h / 2;
+  const x2 = to.x;
+  const y2 = to.y + to.h / 2;
+  const dx = Math.min(120, Math.max(40, (x2 - x1) / 2));
+  return `M ${r1(x1)} ${r1(y1)} C ${r1(x1 + dx)} ${r1(y1)}, ${r1(x2 - dx)} ${r1(y2)}, ${r1(x2)} ${r1(y2)}`;
+}
+
+function r1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/**
+ * Code-unit comparison instead of localeCompare: layout identity must not
+ * depend on the runtime's collation tables (ICU builds differ between node
+ * and browsers). Endpoint id is the final tiebreaker so ordering stays total
+ * even with duplicate display names.
+ */
+function compareByName(a: TopologyNode, b: TopologyNode): number {
+  if (a.name < b.name) return -1;
+  if (a.name > b.name) return 1;
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
+}
+
+function compareStrings<T>(key: (item: T) => string): (a: T, b: T) => number {
+  return (a, b) => {
+    const ka = key(a);
+    const kb = key(b);
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  };
+}

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/layout.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/layout.ts
@@ -99,7 +99,12 @@ export function buildFlowLayout(
     );
 
   const producerNodes = producers.map((n) =>
-    endpointNode("producer", n, `publishes ${n.publishCount} event type(s)`),
+    endpointNode(
+      "producer",
+      n,
+      `publishes ${n.publishCount} event type(s)`,
+      producerTitle(n.name),
+    ),
   );
   const consumerNodes = consumers.map((n) =>
     endpointNode("consumer", n, `handles ${n.subscribeCount} event type(s)`),
@@ -188,19 +193,26 @@ export function buildFlowLayout(
   const producerIds = new Set(producers.map((n) => n.id));
   const consumerIds = new Set(consumers.map((n) => n.id));
   const deliverRoutes: FlowRoute[] = [];
+  // Each deliver route's matching publish leg (producer → its topic), so the
+  // byEndpoint index can pair them into full producer → topic → consumer
+  // journeys the animator rides with a single dot.
+  const publishByDeliver = new Map<string, string>();
   for (const edge of edges) {
     if (!producerIds.has(edge.from) || !consumerIds.has(edge.to)) continue;
-    deliverRoutes.push(
-      makeRoute(
-        "deliver",
-        nodeById.get(`topic::${edge.from}`)!,
-        nodeById.get(`consumer::${edge.to}`)!,
-        [...edge.eventTypeIds],
-      ),
+    const route = makeRoute(
+      "deliver",
+      nodeById.get(`topic::${edge.from}`)!,
+      nodeById.get(`consumer::${edge.to}`)!,
+      [...edge.eventTypeIds],
+    );
+    deliverRoutes.push(route);
+    publishByDeliver.set(
+      route.id,
+      `publish::producer::${edge.from}::topic::${edge.from}`,
     );
   }
   // Sorting by id makes the output independent of flowEdges array order —
-  // part of the determinism contract — and pre-sorts byEndpoint.deliver.
+  // part of the determinism contract — and pre-sorts byEndpoint journeys.
   deliverRoutes.sort(compareStrings((r) => r.id));
   routes.push(...deliverRoutes);
 
@@ -216,15 +228,17 @@ export function buildFlowLayout(
 
   // byEndpoint: the animator's entry point — it receives semantic events
   // keyed by endpoint id and needs the concrete route ids without scanning
-  // the route list per event.
+  // the route list per event. Each inbound journey pairs the publish leg with
+  // its deliver leg so a dot rides producer → topic → consumer in one go;
+  // deliverRoutes is already id-sorted, so journeys stay deterministic.
   const byEndpoint: Record<string, EndpointRouteIndex> = {};
   for (const n of consumers) {
     const consumerNodeId = `consumer::${n.id}`;
     byEndpoint[n.id] = {
       nodeId: consumerNodeId,
-      deliver: deliverRoutes
+      journeys: deliverRoutes
         .filter((r) => r.toNodeId === consumerNodeId)
-        .map((r) => r.id),
+        .map((r) => [publishByDeliver.get(r.id)!, r.id]),
       outcome: `outcome::${consumerNodeId}::${RESOLVER_PLATFORM}`,
     };
   }
@@ -262,16 +276,28 @@ export function topEndpointIds(data: TopologyData, n: number): string[] {
 
 // ----- internals -----------------------------------------------------------
 
+/**
+ * Left-column label: an endpoint's publishing side is shown as its "adapter" —
+ * the service that sends — e.g. "CrmEndpoint" → "Crm Adapter". Names without
+ * the conventional "Endpoint" suffix just gain the " Adapter" tag so the
+ * producer column reads consistently as the senders.
+ */
+function producerTitle(name: string): string {
+  const base = name.replace(/endpoint$/i, "").trim();
+  return `${base.length > 0 ? base : name} Adapter`;
+}
+
 function endpointNode(
   kind: "producer" | "consumer",
   n: TopologyNode,
   subtitle: string,
+  title: string = n.name,
 ): FlowNode {
   return {
     id: `${kind}::${n.id}`,
     kind,
     endpointId: n.id,
-    title: n.name,
+    title,
     subtitle,
     x: COL_X[kind],
     y: 0, // assigned by stackColumn

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/layout.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/layout.ts
@@ -35,6 +35,11 @@ const GAP = 16;
 const CANVAS_W = 1240;
 const MIN_CANVAS_H = 600;
 
+// "Azure Service Bus" container around the topic column: a header band above
+// the chips for the title/subtitle, and padding around the chip stack.
+const SB_HEADER_H = 40;
+const SB_PAD = 12;
+
 // Well-known node id for the Resolver — the single platform fixture, rendered
 // to the right of the consuming endpoints where every outcome converges.
 const RESOLVER_PLATFORM = "platform::resolver";
@@ -96,12 +101,26 @@ export function buildFlowLayout(
   const platformNodes: FlowNode[] = [platformNode(RESOLVER_PLATFORM, "Resolver")];
 
   stackColumn(producerNodes);
-  stackColumn(topicNodes);
+  // Topic chips start below the Service Bus header band that frames them.
+  stackColumn(topicNodes, TOP_MARGIN + SB_HEADER_H);
   stackColumn(consumerNodes);
   stackColumn(platformNodes);
   // Sit the lone Resolver fixture beside the consumer column it collects
   // outcomes from, rather than pinned to the top margin.
   centerColumn(platformNodes, columnCenter(consumerNodes));
+
+  // The Service Bus container wraps the topic chips with padding plus the
+  // header band; only present when there are topics to frame.
+  let serviceBus: FlowLayout["serviceBus"];
+  if (topicNodes.length > 0) {
+    const last = topicNodes[topicNodes.length - 1];
+    serviceBus = {
+      x: COL_X.topic - SB_PAD,
+      y: TOP_MARGIN,
+      w: COL_W.topic + SB_PAD * 2,
+      h: last.y + last.h + SB_PAD - TOP_MARGIN,
+    };
+  }
 
   const nodes: FlowNode[] = [
     ...producerNodes,
@@ -190,9 +209,10 @@ export function buildFlowLayout(
   // a squashed band when the SVG scales to its container.
   let maxBottom = 0;
   for (const n of nodes) maxBottom = Math.max(maxBottom, n.y + n.h);
+  if (serviceBus) maxBottom = Math.max(maxBottom, serviceBus.y + serviceBus.h);
   const height = Math.max(MIN_CANVAS_H, maxBottom + TOP_MARGIN);
 
-  return { nodes, routes, width: CANVAS_W, height, byEndpoint };
+  return { nodes, routes, width: CANVAS_W, height, byEndpoint, serviceBus };
 }
 
 /**
@@ -256,8 +276,8 @@ function platformNode(id: string, title: string): FlowNode {
  * safe because every node was created inside buildFlowLayout, never
  * caller-owned.
  */
-function stackColumn(column: FlowNode[]): void {
-  let y = TOP_MARGIN;
+function stackColumn(column: FlowNode[], startY: number = TOP_MARGIN): void {
+  let y = startY;
   for (const node of column) {
     node.y = y;
     y += node.h + GAP;

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/types.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/types.ts
@@ -104,8 +104,14 @@ export interface FlowRoute {
 export interface EndpointRouteIndex {
   /** The consumer-column node for this endpoint. */
   nodeId: string;
-  /** Routes that bring messages INTO the endpoint (topic → consumer). */
-  deliver: string[];
+  /**
+   * Inbound delivery journeys — one per upstream edge, each an ordered list of
+   * route-segment ids the dot chains through: `[publish (producer → topic),
+   * deliver (topic → consumer)]`. Sorted by the deliver segment id for
+   * determinism. Riding the whole journey makes a message read as sent from
+   * its producer adapter, through its Service Bus topic, into this endpoint.
+   */
+  journeys: string[][];
   /** Route carrying outcomes endpoint → Resolver topic. */
   outcome: string;
 }

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/types.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/types.ts
@@ -117,6 +117,11 @@ export interface FlowLayout {
   width: number;
   height: number;
   byEndpoint: Record<string, EndpointRouteIndex>;
+  /**
+   * "Azure Service Bus" container framing the topic column — the chips are the
+   * real per-endpoint SB topics. Absent when there are no topics to frame.
+   */
+  serviceBus?: { x: number; y: number; w: number; h: number };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/NimBus.WebApp/ClientApp/src/components/flow/types.ts
+++ b/src/NimBus.WebApp/ClientApp/src/components/flow/types.ts
@@ -1,0 +1,173 @@
+// Domain model for the Live Flow page (spec 020, Phase 1). Three modules share
+// these shapes: derive-deltas (pure snapshot diffing), layout (pure positioning),
+// and the animator/page (rendering). Derivation is deliberately layout-agnostic —
+// it emits semantic events keyed by endpoint; the page resolves them onto
+// concrete routes via FlowLayout.byEndpoint. Phase 2's per-message `flowactivity`
+// hub events will feed the same FlowActivityEvent shape with real attribution.
+
+/**
+ * Numeric mirror of api.EndpointStatusCount. The generated client deserializes
+ * `eventTime` to a moment instance; pure modules must not depend on moment, so
+ * the hook converts to epoch ms at the boundary.
+ */
+export interface StatusSnapshot {
+  endpointId: string;
+  failed: number;
+  deferred: number;
+  pending: number;
+  unsupported: number;
+  deadlettered: number;
+  /** True when storageStatus === "ok" — counts are authoritative. */
+  storageOk: boolean;
+  subscriptionStatus?: string;
+  /** Epoch ms of the server-side EventTime (falls back to receipt time). */
+  at: number;
+}
+
+/**
+ * Semantic activity derived from one snapshot pair (Phase 1) or reported
+ * directly by the server (Phase 2).
+ *
+ * - "arrived":      new messages reached the endpoint (pending rose)
+ * - "completed":    pending fell without failures/deferrals rising
+ * - "failed":       failed count rose
+ * - "deferred":     deferred count rose (messages parked)
+ * - "released":     deferred count fell (resubmit or skip — Phase 1 cannot
+ *                   tell which, so this advances no counter, only the log)
+ * - "deadlettered": deadletter count rose
+ */
+export type FlowActivityKind =
+  | "arrived"
+  | "completed"
+  | "failed"
+  | "deferred"
+  | "released"
+  | "deadlettered";
+
+export interface FlowActivityEvent {
+  endpointId: string;
+  kind: FlowActivityKind;
+  /** Real magnitude of the change (counter/log use this). */
+  count: number;
+  /** Dots to actually render: min(count, MAX_DOTS_PER_DELTA). */
+  dots: number;
+  /** Shown as a "×N" badge when count > dots; 1 otherwise. */
+  multiplier: number;
+  /** Epoch ms the underlying snapshot reported. */
+  at: number;
+}
+
+/** Per-endpoint diff result; `baseline` marks the first-ever snapshot. */
+export interface EndpointDelta {
+  endpointId: string;
+  events: FlowActivityEvent[];
+  baseline: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Layout
+// ---------------------------------------------------------------------------
+
+export type FlowNodeKind = "producer" | "topic" | "consumer" | "platform";
+export type FlowNodeHealth = "good" | "warn" | "bad" | "idle";
+
+export interface FlowNode {
+  /** Unique within the layout: e.g. "producer::CrmEndpoint", "topic::CrmEndpoint". */
+  id: string;
+  kind: FlowNodeKind;
+  /** Endpoint id when the node represents (a column instance of) an endpoint. */
+  endpointId?: string;
+  title: string;
+  /** Secondary line, e.g. system name or event-type count. */
+  subtitle?: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  health: FlowNodeHealth;
+}
+
+export type FlowRouteKind = "publish" | "deliver" | "outcome";
+
+export interface FlowRoute {
+  /** Stable: `${kind}::${fromNodeId}::${toNodeId}` — React key + animator handle. */
+  id: string;
+  kind: FlowRouteKind;
+  fromNodeId: string;
+  toNodeId: string;
+  eventTypeIds: string[];
+  /** SVG path data (cubic bezier between node anchors). */
+  d: string;
+}
+
+/** Animation entry points for one endpoint, resolved once per layout. */
+export interface EndpointRouteIndex {
+  /** The consumer-column node for this endpoint. */
+  nodeId: string;
+  /** Routes that bring messages INTO the endpoint (topic → consumer). */
+  deliver: string[];
+  /** Route carrying outcomes endpoint → Resolver topic. */
+  outcome: string;
+}
+
+export interface FlowLayout {
+  nodes: FlowNode[];
+  routes: FlowRoute[];
+  /** Canvas extent for the viewBox. */
+  width: number;
+  height: number;
+  byEndpoint: Record<string, EndpointRouteIndex>;
+}
+
+// ---------------------------------------------------------------------------
+// Page state
+// ---------------------------------------------------------------------------
+
+export type ConnectionMode = "connecting" | "live" | "polling";
+
+export interface ActivityEntry {
+  id: string;
+  at: number;
+  endpointId: string;
+  kind: FlowActivityKind;
+  count: number;
+  message: string;
+}
+
+/**
+ * Counter keys mirror the demo's gauge strip. Seeded from /api/metrics/overview
+ * for the selected period; advanced live by derived events (see derive-deltas);
+ * reconciled against /api/endpointstatus/all every RECONCILE_MS.
+ */
+export interface FlowCounters {
+  published: number;
+  completed: number;
+  failed: number;
+  deferred: number;
+  deadlettered: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants (spec FR-007/FR-009; deliberately not user-configurable in v1)
+// ---------------------------------------------------------------------------
+
+export const MAX_INFLIGHT_DOTS = 60;
+export const MAX_DOTS_PER_DELTA = 8;
+export const POLL_MS = 5_000;
+export const RECONCILE_MS = 60_000;
+export const LOG_MAX = 50;
+export const TOP_N_DEFAULT = 12;
+
+/**
+ * Status palette — matches the demo's outcome colors so screenshots read the
+ * same across the marketing demo and the real page. Used for SVG fills only;
+ * chrome around the canvas uses Tailwind semantic tokens.
+ */
+export const ACTIVITY_COLORS: Record<FlowActivityKind, string> = {
+  arrived: "#60a5fa", // blue
+  completed: "#34d399", // green
+  failed: "#f87171", // red
+  deferred: "#fbbf24", // amber
+  released: "#22d3ee", // cyan
+  deadlettered: "#c084fc", // purple
+};

--- a/src/NimBus.WebApp/ClientApp/src/components/sidebar.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/components/sidebar.tsx
@@ -121,6 +121,25 @@ const Icon = {
       />
     </svg>
   ),
+  flow: (
+    <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none">
+      <circle cx="3.5" cy="5" r="2" stroke="currentColor" strokeWidth="1.4" />
+      <circle cx="12.5" cy="11" r="2" stroke="currentColor" strokeWidth="1.4" />
+      <path
+        d="M5.5 6.5c2.5 1.5 2.5 2.5 5 4"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M8.7 10.9l1.8.4.4-1.8"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
   monitor: (
     <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none">
       <rect
@@ -169,6 +188,12 @@ const NAV: NavGroup[] = [
         name: "Topology",
         path: "/Topology",
         icon: Icon.topology,
+      },
+      {
+        name: "Flow",
+        path: "/Flow",
+        icon: Icon.flow,
+        badge: "live",
       },
       {
         name: "Monitor",

--- a/src/NimBus.WebApp/ClientApp/src/hooks/use-flow-data.ts
+++ b/src/NimBus.WebApp/ClientApp/src/hooks/use-flow-data.ts
@@ -1,0 +1,455 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as api from "api-client";
+import { useTopologyData } from "components/topology/use-topology-data";
+import { applyToCounters, deriveDelta } from "components/flow/derive-deltas";
+import {
+  LOG_MAX,
+  POLL_MS,
+  RECONCILE_MS,
+} from "components/flow/types";
+import type {
+  ActivityEntry,
+  ConnectionMode,
+  FlowActivityEvent,
+  FlowActivityKind,
+  FlowCounters,
+  StatusSnapshot,
+} from "components/flow/types";
+import type { TopologyData } from "components/topology/types";
+import {
+  subscribeEndpointUpdates,
+} from "lib/grid-events-connection";
+
+/**
+ * Activity-log verb per event kind. Exported so the page can rebuild the
+ * humanized line around a linked endpoint name without duplicating the map.
+ */
+export const FLOW_KIND_VERB: Record<FlowActivityKind, string> = {
+  arrived: "arrived",
+  completed: "completed",
+  failed: "failed",
+  deferred: "deferred",
+  released: "released",
+  deadlettered: "dead-lettered",
+};
+
+export interface UseFlowDataOptions {
+  period: api.Period;
+  /**
+   * While true, derived activity buffers instead of advancing counters, log,
+   * or dots; the buffer applies in one pass on resume (spec US3-1). Snapshot
+   * tracking continues throughout, so parking strips stay authoritative and
+   * nothing is lost or double-counted.
+   */
+  paused: boolean;
+  /** Called with derived activity for the page to animate. NOT called while document.hidden (dots dropped; counters/log still update). */
+  onActivity: (events: FlowActivityEvent[]) => void;
+}
+
+export interface UseFlowDataResult {
+  topology: TopologyData | undefined;
+  topologyLoading: boolean;
+  topologyError?: string;
+  counters: FlowCounters;
+  log: ActivityEntry[];
+  mode: ConnectionMode; // "connecting" | "live" | "polling"
+  /** Latest authoritative snapshot per endpoint — drives parking strips (FR-006). */
+  snapshots: Record<string, StatusSnapshot>;
+}
+
+const ZERO_COUNTERS: FlowCounters = {
+  published: 0,
+  completed: 0,
+  failed: 0,
+  deferred: 0,
+  deadlettered: 0,
+};
+
+/**
+ * Bound on derived events held back while paused (US3-1). On overflow the
+ * oldest events are evicted: their dots and log lines condense into a single
+ * marker line on resume, but their counter contributions are carried forward
+ * so the gauges never lose counts ("buffered deltas apply ... without being
+ * lost").
+ */
+const PAUSE_BUFFER_MAX = 500;
+
+function addCounters(a: FlowCounters, b: FlowCounters): FlowCounters {
+  return {
+    published: a.published + b.published,
+    completed: a.completed + b.completed,
+    failed: a.failed + b.failed,
+    deferred: a.deferred + b.deferred,
+    deadlettered: a.deadlettered + b.deadlettered,
+  };
+}
+
+/**
+ * Boundary conversion to the pure modules' StatusSnapshot. Handles BOTH
+ * sources feeding the pipeline:
+ *  - hub payloads: raw camelCase JSON, `eventTime` is an ISO string
+ *  - polled api.EndpointStatusCount: `eventTime` is a moment instance
+ * Defensive throughout — missing numbers read as 0 and a missing/garbled
+ * eventTime falls back to receipt time, so a malformed broadcast degrades to
+ * a slightly mistimed snapshot instead of NaN propagating into the diff.
+ */
+function toSnapshot(raw: unknown): StatusSnapshot | undefined {
+  if (raw === null || typeof raw !== "object") return undefined;
+  const r = raw as Record<string, unknown>;
+  const endpointId = r["endpointId"];
+  if (typeof endpointId !== "string" || endpointId.length === 0) {
+    return undefined;
+  }
+
+  const num = (value: unknown): number =>
+    typeof value === "number" && Number.isFinite(value) ? value : 0;
+
+  const eventTime = r["eventTime"];
+  let at: number;
+  if (typeof eventTime === "string") {
+    at = Date.parse(eventTime) || Date.now();
+  } else if (
+    eventTime !== null &&
+    typeof eventTime === "object" &&
+    typeof (eventTime as { valueOf?: unknown }).valueOf === "function"
+  ) {
+    const ms = Number((eventTime as { valueOf(): unknown }).valueOf());
+    at = Number.isFinite(ms) && ms > 0 ? ms : Date.now();
+  } else {
+    at = Date.now();
+  }
+
+  return {
+    endpointId,
+    failed: num(r["failedCount"]),
+    deferred: num(r["deferredCount"]),
+    pending: num(r["pendingCount"]),
+    unsupported: num(r["unsupportedCount"]),
+    deadlettered: num(r["deadletterCount"]),
+    storageOk: r["storageStatus"] === "ok",
+    subscriptionStatus:
+      typeof r["subscriptionStatus"] === "string"
+        ? r["subscriptionStatus"]
+        : undefined,
+    at,
+  };
+}
+
+/**
+ * Live data feed for the Flow page (spec 020, Phase 1). One pipeline serves
+ * both signal sources: hub `endpointupdate` events and status polls each
+ * become StatusSnapshots, diff against the previous snapshot per endpoint
+ * (deriveDelta), and fan out to counters, the activity log, the parking-strip
+ * snapshots, and the page's animator callback.
+ *
+ *  - On mount a full status poll BASELINES every endpoint: deriveDelta marks
+ *    first sightings baseline (no animation) but the snapshots populate the
+ *    parking strips immediately (US2 acceptance 1).
+ *  - While the hub is connected ("live") fallback polling stays off; when it
+ *    drops we poll every POLL_MS ("polling") and re-upgrade on reconnect.
+ *  - A reconcile poll runs every RECONCILE_MS regardless of mode (missed
+ *    broadcasts drift the counters, FR-005). Its snapshots flow through the
+ *    same pipeline so corrections animate naturally; it skips a tick when
+ *    fallback polling already covered the window.
+ *  - Counters seed from /api/metrics/overview for the selected period and
+ *    advance with derived deltas. Period change re-seeds the counters only —
+ *    prevRef tracks status counts, which are unrelated to the metrics window.
+ *  - While `paused`, derived activity buffers (bounded) instead of advancing
+ *    counters/log/dots; the resume edge applies the whole buffer in one pass
+ *    (US3-1). Snapshots keep updating regardless — FR-006 strips stay live.
+ */
+export function useFlowData(opts: UseFlowDataOptions): UseFlowDataResult {
+  const { period, paused } = opts;
+  const {
+    data: topology,
+    loading: topologyLoading,
+    error: topologyError,
+  } = useTopologyData({ period });
+
+  const [counters, setCounters] = useState<FlowCounters>(ZERO_COUNTERS);
+  const [log, setLog] = useState<ActivityEntry[]>([]);
+  const [mode, setMode] = useState<ConnectionMode>("connecting");
+  const [snapshots, setSnapshots] = useState<Record<string, StatusSnapshot>>(
+    {},
+  );
+
+  // Refs because these mutate on every event/poll but only need to bake into
+  // state when a processing pass actually produces something to render.
+  const clientRef = useRef<api.Client | null>(null);
+  const prevRef = useRef(new Map<string, StatusSnapshot>());
+  const snapshotsRef = useRef<Record<string, StatusSnapshot>>({});
+  const pollInFlightRef = useRef(false);
+  const lastPollAtRef = useRef(0);
+  /** Mount-time baseline poll; the counter seed awaits it so the deferred /
+   *  dead-letter sums read real snapshots instead of an empty map. */
+  const baselinePollRef = useRef<Promise<void> | null>(null);
+
+  // The animator callback lives in a ref so the pipeline stays stable across
+  // page re-renders (the page passes a useCallback, but we don't rely on it).
+  const onActivityRef = useRef(opts.onActivity);
+  useEffect(() => {
+    onActivityRef.current = opts.onActivity;
+  });
+
+  const logSeqRef = useRef(0);
+
+  const makeEntry = useCallback(
+    (event: FlowActivityEvent): ActivityEntry => ({
+      id: `flow-${++logSeqRef.current}`,
+      at: event.at,
+      endpointId: event.endpointId,
+      kind: event.kind,
+      count: event.count,
+      message: `${event.endpointId}: ${event.count} ${FLOW_KIND_VERB[event.kind]}`,
+    }),
+    [],
+  );
+
+  // Pause buffering (US3-1). The pipeline reads `pausedRef` — not the prop —
+  // so hub events arriving between renders see the current value. Evicted
+  // overflow keeps a count (for the condensed log line) and a counter fold
+  // (so the gauges still reconcile exactly on resume).
+  const pausedRef = useRef(paused);
+  const pauseBufferRef = useRef<FlowActivityEvent[]>([]);
+  const droppedWhilePausedRef = useRef(0);
+  const droppedCountersRef = useRef<FlowCounters>(ZERO_COUNTERS);
+
+  /**
+   * Shared processing pass for hub events and poll results. Batched: one
+   * setCounters + one setLog + one setSnapshots per pass regardless of how
+   * many endpoints changed (NFR-002 throttling posture).
+   */
+  const processSnapshots = useCallback((snaps: StatusSnapshot[]) => {
+    if (snaps.length === 0) return;
+
+    const events: FlowActivityEvent[] = [];
+    const changed: Record<string, StatusSnapshot> = {};
+    for (const snap of snaps) {
+      const delta = deriveDelta(prevRef.current.get(snap.endpointId), snap);
+      prevRef.current.set(snap.endpointId, snap);
+      changed[snap.endpointId] = snap;
+      events.push(...delta.events);
+    }
+
+    // Snapshots are authoritative even when nothing animated (FR-006 — the
+    // parking strip must track DeferredCount, not just deferred deltas).
+    snapshotsRef.current = { ...snapshotsRef.current, ...changed };
+    setSnapshots(snapshotsRef.current);
+
+    if (events.length === 0) return;
+
+    // US3-1: while paused nothing advances visibly. prevRef above ALREADY
+    // moved on, so diffing keeps tracking the live stream — the buffer holds
+    // exactly the deltas the user hasn't seen yet, ready to apply in one
+    // pass on resume without loss or double-counting.
+    if (pausedRef.current) {
+      const buffer = pauseBufferRef.current;
+      buffer.push(...events);
+      const overflow = buffer.length - PAUSE_BUFFER_MAX;
+      if (overflow > 0) {
+        const evicted = buffer.splice(0, overflow);
+        droppedWhilePausedRef.current += evicted.length;
+        droppedCountersRef.current = applyToCounters(
+          droppedCountersRef.current,
+          evicted,
+        );
+      }
+      return;
+    }
+
+    const entries = events.map(makeEntry);
+    setCounters((prev) => applyToCounters(prev, events));
+    setLog((prev) => [...entries, ...prev].slice(0, LOG_MAX));
+
+    // Hidden tab: drop the dots (rAF is suspended anyway — spawning would
+    // just queue a catch-up storm); counters and log above still updated.
+    if (!document.hidden) {
+      onActivityRef.current(events);
+    }
+  }, [makeEntry]);
+
+  /**
+   * Resume pass: everything that accumulated while paused lands as ONE
+   * counter fold, ONE log append, and ONE onActivity batch (the animator's
+   * in-flight cap turns excess dots into edge pulses; the hidden-tab rule
+   * still applies). Buffer-evicted events surface as a single condensed
+   * marker line so the operator knows the log isn't gapless.
+   */
+  const flushPauseBuffer = useCallback(() => {
+    const buffered = pauseBufferRef.current;
+    const dropped = droppedWhilePausedRef.current;
+    const carried = droppedCountersRef.current;
+    if (buffered.length === 0 && dropped === 0) return;
+    pauseBufferRef.current = [];
+    droppedWhilePausedRef.current = 0;
+    droppedCountersRef.current = ZERO_COUNTERS;
+
+    setCounters((prev) => applyToCounters(addCounters(prev, carried), buffered));
+
+    // The buffer accumulated in arrival order; the log reads newest-first,
+    // so it flushes reversed. The condensed marker stands in for the OLDEST
+    // (evicted) updates and therefore sits below the surviving entries.
+    const entries = buffered.map(makeEntry).reverse();
+    if (dropped > 0) {
+      entries.push({
+        id: `flow-${++logSeqRef.current}`,
+        at: Date.now(),
+        // Synthetic entry — no endpoint to link; the page renders it as a
+        // plain muted line.
+        endpointId: "",
+        kind: "released",
+        count: dropped,
+        message: `… ${dropped} earlier update${dropped === 1 ? "" : "s"} condensed while paused`,
+      });
+    }
+    setLog((prev) => [...entries, ...prev].slice(0, LOG_MAX));
+
+    if (buffered.length > 0 && !document.hidden) {
+      onActivityRef.current(buffered);
+    }
+  }, [makeEntry]);
+
+  // Sync the pause ref on every change; the stale value read before the
+  // write doubles as the previous-value tracker for the resume edge.
+  useEffect(() => {
+    const wasPaused = pausedRef.current;
+    pausedRef.current = paused;
+    if (wasPaused && !paused) flushPauseBuffer();
+  }, [paused, flushPauseBuffer]);
+
+  /**
+   * One full status poll — all endpoint ids, then their status counts —
+   * funneled into the shared pipeline. Failures are swallowed: a transient
+   * API blip must not tear down the polling loop; the next tick retries.
+   */
+  const pollStatus = useCallback(async (): Promise<void> => {
+    if (pollInFlightRef.current) return;
+    pollInFlightRef.current = true;
+    try {
+      if (!clientRef.current) {
+        clientRef.current = new api.Client(api.CookieAuth());
+      }
+      const client = clientRef.current;
+      const ids = await client.getEndpointsAll();
+      if (ids.length === 0) {
+        lastPollAtRef.current = Date.now();
+        return;
+      }
+      const counts = await client.postApiEndpointStatusCount(ids);
+      lastPollAtRef.current = Date.now();
+      const snaps = counts
+        .map(toSnapshot)
+        .filter((s): s is StatusSnapshot => s !== undefined);
+      processSnapshots(snaps);
+    } catch {
+      // Swallowed by design — connectivity state is owned by the hub
+      // subscription; a failed poll just means this tick produced no data.
+    } finally {
+      pollInFlightRef.current = false;
+    }
+  }, [processSnapshots]);
+
+  // Mount: baseline poll + hub subscription. The poll runs regardless of how
+  // the hub negotiation lands, so first paint always has authoritative
+  // snapshots; the subscription flips mode on every connectivity transition
+  // and stays "connecting" until the first one resolves.
+  useEffect(() => {
+    let cancelled = false;
+    baselinePollRef.current = pollStatus();
+
+    const subscription = subscribeEndpointUpdates(
+      (raw) => {
+        const snap = toSnapshot(raw);
+        if (snap !== undefined) processSnapshots([snap]);
+      },
+      (state) => {
+        if (!cancelled) setMode(state === "connected" ? "live" : "polling");
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      subscription.dispose();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Fallback polling — only while degraded. Entering "polling" fires an
+  // immediate catch-up poll unless one already ran within the last POLL_MS.
+  useEffect(() => {
+    if (mode !== "polling") return;
+    if (Date.now() - lastPollAtRef.current >= POLL_MS) {
+      void pollStatus();
+    }
+    const handle = window.setInterval(() => {
+      void pollStatus();
+    }, POLL_MS);
+    return () => window.clearInterval(handle);
+  }, [mode, pollStatus]);
+
+  // Reconcile poll — always on, drift correction per FR-005. Skips the tick
+  // when fallback polling already covered the window so degraded mode never
+  // double-polls.
+  useEffect(() => {
+    const handle = window.setInterval(() => {
+      if (Date.now() - lastPollAtRef.current < POLL_MS) return;
+      void pollStatus();
+    }, RECONCILE_MS);
+    return () => window.clearInterval(handle);
+  }, [pollStatus]);
+
+  // Counter seed — mount + period change. published/completed/failed come
+  // from the metrics window; deferred/deadlettered have no period dimension,
+  // so they sum the authoritative snapshots (awaiting the baseline poll on
+  // mount so the sums aren't computed against an empty map). Live deltas
+  // advance the counters from here.
+  useEffect(() => {
+    let cancelled = false;
+    const seed = async (): Promise<void> => {
+      try {
+        if (!clientRef.current) {
+          clientRef.current = new api.Client(api.CookieAuth());
+        }
+        const overview = await clientRef.current.getMetricsOverview(period);
+        await baselinePollRef.current;
+        if (cancelled) return;
+
+        const sum = (
+          rows: api.EndpointEventTypeMessageCount[] | undefined,
+        ): number => (rows ?? []).reduce((acc, r) => acc + (r.count ?? 0), 0);
+
+        let deferred = 0;
+        let deadlettered = 0;
+        for (const snap of Object.values(snapshotsRef.current)) {
+          deferred += snap.deferred;
+          deadlettered += snap.deadlettered;
+        }
+
+        setCounters({
+          published: sum(overview.published),
+          completed: sum(overview.handled),
+          failed: sum(overview.failed),
+          deferred,
+          deadlettered,
+        });
+      } catch {
+        // Seed failure: counters keep their current values and still advance
+        // with live deltas — stale-but-moving beats zeroed-and-wrong.
+      }
+    };
+    void seed();
+    return () => {
+      cancelled = true;
+    };
+  }, [period]);
+
+  return {
+    topology,
+    topologyLoading,
+    topologyError,
+    counters,
+    log,
+    mode,
+    snapshots,
+  };
+}

--- a/src/NimBus.WebApp/ClientApp/src/lib/grid-events-connection.ts
+++ b/src/NimBus.WebApp/ClientApp/src/lib/grid-events-connection.ts
@@ -1,0 +1,80 @@
+import * as signalR from "@microsoft/signalr";
+
+// Shared GridEventsHub subscription (spec 020, FR-003). First client-side
+// consumer of the hub the server has broadcast on since spec 010 — kept as a
+// plain TS module (no React) so future pages can reuse the same connection
+// management without inheriting a hook's lifecycle. The hub URL and event
+// name mirror the server-side constants in Constants.cs
+// (AppEndpoints.GridEventHub / EventSignalNames.EndpointUpdate).
+
+const HUB_URL = "/hubs/gridevents";
+const ENDPOINT_UPDATE_EVENT = "endpointupdate";
+
+export type HubState = "connecting" | "connected" | "disconnected";
+
+export interface GridEventsSubscription {
+  dispose(): void;
+}
+
+/**
+ * Opens a GridEventsHub connection and forwards every `endpointupdate`
+ * payload to `onUpdate`. Payloads arrive as raw camelCase JSON (the hub
+ * serializes EndpointStatusCount directly — NOT generated api-client
+ * instances); callers own the boundary conversion.
+ *
+ * State callbacks fire only on transitions:
+ *  - start() resolved / onreconnected  → "connected"
+ *  - onreconnecting / onclose / start() rejected → "disconnected"
+ *
+ * Reconnect policy is delegated entirely to withAutomaticReconnect(); when
+ * that gives up (onclose) we report "disconnected" and stop — callers fall
+ * back to polling rather than this module retry-looping forever.
+ */
+export function subscribeEndpointUpdates(
+  onUpdate: (raw: unknown) => void,
+  onStateChange: (state: HubState) => void,
+): GridEventsSubscription {
+  const connection = new signalR.HubConnectionBuilder()
+    .withUrl(HUB_URL)
+    .withAutomaticReconnect()
+    .configureLogging(signalR.LogLevel.Warning)
+    .build();
+
+  // dispose() triggers stop(), which fires onclose — the guard keeps that
+  // self-inflicted close from reporting a phantom "disconnected" to a caller
+  // that has already moved on.
+  let disposed = false;
+
+  connection.on(ENDPOINT_UPDATE_EVENT, onUpdate);
+  connection.onreconnecting(() => {
+    if (!disposed) onStateChange("disconnected");
+  });
+  connection.onreconnected(() => {
+    if (!disposed) onStateChange("connected");
+  });
+  connection.onclose(() => {
+    if (!disposed) onStateChange("disconnected");
+  });
+
+  connection
+    .start()
+    .then(() => {
+      if (!disposed) onStateChange("connected");
+    })
+    .catch(() => {
+      // Initial negotiate failed (auth, proxy, server down). Automatic
+      // reconnect only covers established connections, so this is terminal
+      // for the subscription — the caller's polling fallback takes over.
+      if (!disposed) onStateChange("disconnected");
+    });
+
+  return {
+    dispose() {
+      disposed = true;
+      connection.off(ENDPOINT_UPDATE_EVENT, onUpdate);
+      // stop() rejects if called while start() is still negotiating; the
+      // subscription is gone either way, so swallow it.
+      void connection.stop().catch(() => undefined);
+    },
+  };
+}

--- a/src/NimBus.WebApp/ClientApp/src/pages/flow.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/pages/flow.tsx
@@ -8,7 +8,7 @@ import { EmptyState } from "components/ui/empty-state";
 import { Select } from "components/ui/select";
 import { Spinner } from "components/ui/spinner";
 import { cn } from "lib/utils";
-import { FlowAnimator } from "components/flow/animator";
+import { FlowAnimator, type SpawnChain } from "components/flow/animator";
 import { buildFlowLayout, topEndpointIds } from "components/flow/layout";
 import { ACTIVITY_COLORS, TOP_N_DEFAULT } from "components/flow/types";
 import type {
@@ -111,11 +111,12 @@ export default function Flow() {
 
   /**
    * Resolves semantic activity onto concrete routes and spawns dots:
-   * arrived/released ride the deliver routes (round-robin when an endpoint
-   * has several upstream topics), every outcome kind rides the endpoint →
-   * Resolver route. Events for endpoints that are filtered out or unknown to
-   * the catalog are skipped silently — the hook already recorded them in the
-   * log/counters. The ×N badge goes on the FIRST dot only (FR-009).
+   * arrived/released ride the full inbound journey (producer adapter → topic →
+   * consumer, round-robin when an endpoint has several upstream topics) so the
+   * message reads as sent from the left; every outcome kind rides the single
+   * endpoint → Resolver route. Events for endpoints that are filtered out or
+   * unknown to the catalog are skipped silently — the hook already recorded
+   * them in the log/counters. The ×N badge goes on the FIRST dot only (FR-009).
    */
   const handleActivity = useCallback((events: FlowActivityEvent[]) => {
     const layout = layoutRef.current;
@@ -124,15 +125,18 @@ export default function Flow() {
     for (const event of events) {
       const index = layout.byEndpoint[event.endpointId];
       if (index === undefined) continue;
-      const routes =
+      const journeys =
         event.kind === "arrived" || event.kind === "released"
-          ? index.deliver
-          : [index.outcome];
-      if (routes.length === 0) continue;
+          ? index.journeys
+          : [[index.outcome]];
+      if (journeys.length === 0) continue;
       for (let i = 0; i < event.dots; i++) {
-        animator.spawn(routes[i % routes.length], ACTIVITY_COLORS[event.kind], {
-          multiplier: i === 0 ? event.multiplier : 1,
-        });
+        spawnJourney(
+          animator,
+          journeys[i % journeys.length],
+          ACTIVITY_COLORS[event.kind],
+          i === 0 ? event.multiplier : 1,
+        );
       }
     }
   }, []);
@@ -851,6 +855,39 @@ const ActivityLog = ({
 // ---------------------------------------------------------------------------
 // Small helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Rides one dot across an ordered list of route segments (e.g. publish then
+ * deliver) by chaining each segment to the next through the animator. The ×N
+ * badge travels the whole journey. A single-segment list (outcomes) behaves
+ * exactly like a plain spawn.
+ */
+function spawnJourney(
+  animator: FlowAnimator,
+  segments: string[],
+  color: string,
+  multiplier: number,
+): void {
+  const chain = buildChain(segments, color, multiplier);
+  if (chain === undefined) return;
+  animator.spawn(chain.routeId, chain.color, {
+    multiplier: chain.multiplier,
+    next: chain.next,
+  });
+}
+
+/** Folds an ordered segment list into a nested SpawnChain (first → last). */
+function buildChain(
+  segments: string[],
+  color: string,
+  multiplier: number,
+): SpawnChain | undefined {
+  let chain: SpawnChain | undefined;
+  for (let i = segments.length - 1; i >= 0; i--) {
+    chain = { routeId: segments[i], color, multiplier, next: chain };
+  }
+  return chain;
+}
 
 function formatSpeed(speed: number): string {
   return speed

--- a/src/NimBus.WebApp/ClientApp/src/pages/flow.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/pages/flow.tsx
@@ -329,6 +329,67 @@ export default function Flow() {
                   role="img"
                   aria-label="Live message flow diagram"
                 >
+                  {/* Glow filters give dots and active edges the demo's vivid,
+                      "alive" look. Per-element filter regions stay small, so
+                      the GPU cost holds even at the in-flight dot cap. */}
+                  <defs>
+                    <filter
+                      id="flowDotGlow"
+                      x="-75%"
+                      y="-75%"
+                      width="250%"
+                      height="250%"
+                    >
+                      <feGaussianBlur stdDeviation="2.2" result="b" />
+                      <feMerge>
+                        <feMergeNode in="b" />
+                        <feMergeNode in="b" />
+                        <feMergeNode in="SourceGraphic" />
+                      </feMerge>
+                    </filter>
+                    <filter
+                      id="flowRouteGlow"
+                      x="-20%"
+                      y="-20%"
+                      width="140%"
+                      height="140%"
+                    >
+                      <feGaussianBlur stdDeviation="2" result="b" />
+                      <feMerge>
+                        <feMergeNode in="b" />
+                        <feMergeNode in="SourceGraphic" />
+                      </feMerge>
+                    </filter>
+                  </defs>
+                  {/* "Azure Service Bus" container behind everything — frames
+                      the topic chips, which ARE the real per-endpoint SB
+                      topics. Routes and chips draw on top. */}
+                  {layout.serviceBus !== undefined && (
+                    <g aria-hidden="true">
+                      <rect
+                        x={layout.serviceBus.x}
+                        y={layout.serviceBus.y}
+                        width={layout.serviceBus.w}
+                        height={layout.serviceBus.h}
+                        rx={12}
+                        className="flow-sb-box"
+                      />
+                      <text
+                        x={layout.serviceBus.x + 14}
+                        y={layout.serviceBus.y + 23}
+                        className="flow-sb-title"
+                      >
+                        Azure Service Bus
+                      </text>
+                      <text
+                        x={layout.serviceBus.x + 14}
+                        y={layout.serviceBus.y + 36}
+                        className="flow-sb-subtitle"
+                      >
+                        one topic per endpoint
+                      </text>
+                    </g>
+                  )}
                   {layout.routes.map((route) => (
                     <path
                       key={route.id}
@@ -517,11 +578,37 @@ const FlowStyles = () => (
       fill: none;
       stroke: rgb(100 116 139 / 0.9);
       stroke-width: 1.5;
-      opacity: 0.22;
-      transition: opacity 0.25s ease;
+      opacity: 0.32;
+      transition: opacity 0.25s ease, stroke 0.2s ease, stroke-width 0.2s ease;
     }
     .flow-route[data-kind="outcome"] { stroke-dasharray: 4 5; }
-    .flow-route-on { opacity: 0.95; }
+    /* Active edges light up teal and glow — reads on both themes, like the
+       demo's bright cyan flow lines. */
+    .flow-route-on {
+      opacity: 1;
+      stroke: #2dd4bf;
+      stroke-width: 2.5;
+      filter: url(#flowRouteGlow);
+    }
+
+    /* Traveling dots glow in their own color (the filter blurs the colored
+       source), so a single dot reads as vividly as the demo's. */
+    .flow-dot { filter: url(#flowDotGlow); }
+
+    /* "Azure Service Bus" container around the topic chips. */
+    .flow-sb-box {
+      fill: rgb(100 116 139 / 0.05);
+      stroke: rgb(100 116 139 / 0.45);
+      stroke-width: 1.25;
+    }
+    .flow-sb-title {
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      fill: currentColor;
+      opacity: 0.75;
+    }
+    .flow-sb-subtitle { font-size: 9px; fill: currentColor; opacity: 0.45; }
 
     .flow-node { stroke-width: 1.25; }
     .flow-node-producer { fill: rgb(14 165 233 / 0.10); stroke: #0ea5e9; }

--- a/src/NimBus.WebApp/ClientApp/src/pages/flow.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/pages/flow.tsx
@@ -1,0 +1,793 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import * as api from "api-client";
+import Page from "components/page";
+import { Button } from "components/ui/button";
+import { Checkbox } from "components/ui/checkbox";
+import { EmptyState } from "components/ui/empty-state";
+import { Select } from "components/ui/select";
+import { Spinner } from "components/ui/spinner";
+import { cn } from "lib/utils";
+import { FlowAnimator } from "components/flow/animator";
+import { buildFlowLayout, topEndpointIds } from "components/flow/layout";
+import { ACTIVITY_COLORS, TOP_N_DEFAULT } from "components/flow/types";
+import type {
+  ActivityEntry,
+  ConnectionMode,
+  FlowActivityEvent,
+  FlowActivityKind,
+  FlowLayout,
+  FlowNode,
+  StatusSnapshot,
+} from "components/flow/types";
+import type { TopologyData, TopologyNode } from "components/topology/types";
+import { FLOW_KIND_VERB, useFlowData } from "hooks/use-flow-data";
+
+// Live Flow page (spec 020, Phase 1). React owns the static scene — nodes,
+// route paths, parking strips — rebuilt declaratively when topology/filters
+// change; the FlowAnimator owns exactly one <g> (the dot layer) and animates
+// derived activity imperatively so per-frame work never touches React
+// reconciliation (NFR-002). Data plumbing lives in useFlowData; this file is
+// layout resolution (semantic event → concrete routes) plus chrome.
+
+const PERIODS: Array<{ label: string; value: api.Period }> = [
+  { label: "1h", value: api.Period._1h },
+  { label: "12h", value: api.Period._12h },
+  { label: "1d", value: api.Period._1d },
+  { label: "7d", value: api.Period._7d },
+];
+
+// ---------------------------------------------------------------------------
+// Persisted preferences (OQ-2 resolution: persist filter + speed)
+// ---------------------------------------------------------------------------
+
+const PREFS_KEY = "nb.flow.v1";
+
+interface FlowPrefs {
+  speed: number;
+  /**
+   * Explicit endpoint selection. Three-state on purpose:
+   *  - string[]  — the user hand-picked endpoints
+   *  - null      — the user chose "Show all"
+   *  - undefined — never chosen; the page applies the FR-007 default
+   *                (top TOP_N_DEFAULT by traffic when the catalog is bigger)
+   */
+  endpointIds?: string[] | null;
+}
+
+function loadPrefs(): FlowPrefs {
+  if (typeof window === "undefined") return { speed: 1 };
+  try {
+    const raw = window.localStorage.getItem(PREFS_KEY);
+    if (!raw) return { speed: 1 };
+    const parsed = JSON.parse(raw) as Partial<FlowPrefs> | null;
+    if (!parsed || typeof parsed !== "object") return { speed: 1 };
+    const speed =
+      typeof parsed.speed === "number" &&
+      parsed.speed >= 0.25 &&
+      parsed.speed <= 4
+        ? parsed.speed
+        : 1;
+    const endpointIds = Array.isArray(parsed.endpointIds)
+      ? parsed.endpointIds.filter((id): id is string => typeof id === "string")
+      : parsed.endpointIds === null
+        ? null
+        : undefined;
+    return { speed, endpointIds };
+  } catch {
+    return { speed: 1 };
+  }
+}
+
+function savePrefs(prefs: FlowPrefs): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(PREFS_KEY, JSON.stringify(prefs));
+  } catch {
+    // localStorage can be unavailable (private mode, quota); ignore.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function Flow() {
+  const [period, setPeriod] = useState<api.Period>(api.Period._1h);
+  const [paused, setPaused] = useState(false);
+  const [speed, setSpeed] = useState<number>(() => loadPrefs().speed);
+  const [selection, setSelection] = useState<string[] | null | undefined>(
+    () => loadPrefs().endpointIds,
+  );
+  const [eventType, setEventType] = useState("");
+
+  // The animator and the layout index are read from a STABLE callback (the
+  // hook holds onActivity for the lifetime of the subscription), so both live
+  // in refs that the render path keeps current.
+  const dotLayerRef = useRef<SVGGElement | null>(null);
+  const routePathRefs = useRef(new Map<string, SVGPathElement>());
+  const animatorRef = useRef<FlowAnimator | null>(null);
+  const layoutRef = useRef<FlowLayout | undefined>(undefined);
+
+  /**
+   * Resolves semantic activity onto concrete routes and spawns dots:
+   * arrived/released ride the deliver routes (round-robin when an endpoint
+   * has several upstream topics), every outcome kind rides the endpoint →
+   * Resolver route. Events for endpoints that are filtered out or unknown to
+   * the catalog are skipped silently — the hook already recorded them in the
+   * log/counters. The ×N badge goes on the FIRST dot only (FR-009).
+   */
+  const handleActivity = useCallback((events: FlowActivityEvent[]) => {
+    const layout = layoutRef.current;
+    const animator = animatorRef.current;
+    if (layout === undefined || animator === null) return;
+    for (const event of events) {
+      const index = layout.byEndpoint[event.endpointId];
+      if (index === undefined) continue;
+      const routes =
+        event.kind === "arrived" || event.kind === "released"
+          ? index.deliver
+          : [index.outcome];
+      if (routes.length === 0) continue;
+      for (let i = 0; i < event.dots; i++) {
+        animator.spawn(routes[i % routes.length], ACTIVITY_COLORS[event.kind], {
+          multiplier: i === 0 ? event.multiplier : 1,
+        });
+      }
+    }
+  }, []);
+
+  const { topology, topologyLoading, topologyError, counters, log, mode, snapshots } =
+    useFlowData({ period, paused, onActivity: handleActivity });
+
+  // FR-007 default: top N busiest endpoints when the catalog is bigger than
+  // N; everything otherwise. Only applies until the user makes an explicit
+  // choice (persisted across visits).
+  const effectiveSelection = useMemo<string[] | null>(() => {
+    if (selection !== undefined) return selection;
+    if (topology !== undefined && topology.nodes.length > TOP_N_DEFAULT) {
+      return topEndpointIds(topology, TOP_N_DEFAULT);
+    }
+    return null;
+  }, [selection, topology]);
+
+  const visibleSet = useMemo(
+    () => (effectiveSelection === null ? undefined : new Set(effectiveSelection)),
+    [effectiveSelection],
+  );
+
+  // Event-type filtering happens BEFORE layout: drop non-matching flowEdges
+  // from a shallow copy so the layout engine simply never sees those routes.
+  const filteredData = useMemo<TopologyData | undefined>(() => {
+    if (topology === undefined || eventType === "") return topology;
+    return {
+      ...topology,
+      flowEdges: topology.flowEdges.filter((e) =>
+        e.eventTypeIds.includes(eventType),
+      ),
+    };
+  }, [topology, eventType]);
+
+  const layout = useMemo<FlowLayout | undefined>(() => {
+    if (filteredData === undefined || filteredData.nodes.length === 0) {
+      return undefined;
+    }
+    return buildFlowLayout(filteredData, { visibleEndpointIds: visibleSet });
+  }, [filteredData, visibleSet]);
+  layoutRef.current = layout;
+
+  const eventTypeOptions = useMemo(() => {
+    if (topology === undefined) return [];
+    const out = new Set<string>();
+    for (const edge of topology.flowEdges) {
+      for (const id of edge.eventTypeIds) out.add(id);
+    }
+    return Array.from(out).sort();
+  }, [topology]);
+
+  // Animator lifecycle — created once the canvas exists, torn down with the
+  // page. Keyed on a boolean so layout-to-layout changes (filters) reuse the
+  // same instance; invalidatePaths below handles re-rendered paths.
+  const canvasReady = layout !== undefined;
+  useEffect(() => {
+    if (!canvasReady) return;
+    const dotLayer = dotLayerRef.current;
+    if (dotLayer === null) return;
+    const animator = new FlowAnimator({
+      dotLayer,
+      getPathEl: (id) => routePathRefs.current.get(id) ?? null,
+      reducedMotion: window.matchMedia("(prefers-reduced-motion: reduce)")
+        .matches,
+    });
+    animatorRef.current = animator;
+    animator.start();
+    return () => {
+      animator.dispose();
+      if (animatorRef.current === animator) animatorRef.current = null;
+    };
+  }, [canvasReady]);
+
+  // Declared after the creation effect so they also run on the commit that
+  // instantiates the animator (applying the persisted speed immediately).
+  useEffect(() => {
+    animatorRef.current?.setSpeed(speed);
+  }, [speed, canvasReady]);
+  useEffect(() => {
+    animatorRef.current?.setPaused(paused);
+  }, [paused, canvasReady]);
+
+  // Filters/topology re-render the route paths — drop memoized lengths so
+  // new dots measure the new geometry (in-flight dots keep their own).
+  useEffect(() => {
+    animatorRef.current?.invalidatePaths();
+  }, [layout]);
+
+  useEffect(() => {
+    savePrefs({ speed, endpointIds: selection });
+  }, [speed, selection]);
+
+  // Coarse clock for the activity log's relative timestamps — 30 s keeps
+  // them honest without re-rendering the static SVG every second.
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    const handle = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => window.clearInterval(handle);
+  }, []);
+
+  const visibleCount = useMemo(() => {
+    if (topology === undefined) return 0;
+    if (effectiveSelection === null) return topology.nodes.length;
+    const known = new Set(topology.nodes.map((n) => n.id));
+    return effectiveSelection.filter((id) => known.has(id)).length;
+  }, [topology, effectiveSelection]);
+
+  return (
+    <Page
+      title="Flow"
+      subtitle="Live message flow across producers, topics, and endpoints — derived from real-time status deltas."
+      actions={
+        <>
+          <ModeBadge mode={mode} />
+          <div className="inline-flex items-center bg-card border border-border rounded-nb-md p-[3px] gap-[2px]">
+            {PERIODS.map((p) => (
+              <button
+                key={p.value}
+                onClick={() => setPeriod(p.value)}
+                className={cn(
+                  "px-3 py-1.5 rounded-md text-xs font-semibold transition-colors",
+                  period === p.value
+                    ? "bg-primary text-white"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+        </>
+      }
+    >
+      <div className="w-full flex flex-col gap-4">
+        {layout !== undefined && topology !== undefined ? (
+          <>
+            <div className="flex flex-wrap items-center gap-2.5">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setPaused((p) => !p)}
+                title={paused ? "Resume the animation" : "Freeze dots in place"}
+              >
+                {paused ? "▶ Resume" : "❚❚ Pause"}
+              </Button>
+              <label className="inline-flex items-center gap-2 h-8 px-3 bg-card border border-border-strong rounded-nb-md text-xs text-muted-foreground">
+                Speed
+                <input
+                  type="range"
+                  min={0.25}
+                  max={4}
+                  step={0.25}
+                  value={speed}
+                  onChange={(e) => setSpeed(Number(e.target.value))}
+                  className="w-28 accent-primary"
+                  aria-label="Animation speed"
+                />
+                <span className="font-mono text-[11px] w-10 text-right text-foreground">
+                  {formatSpeed(speed)}×
+                </span>
+              </label>
+              <EndpointFilterMenu
+                nodes={topology.nodes}
+                selection={effectiveSelection}
+                visibleCount={visibleCount}
+                onChange={setSelection}
+                onTopN={() =>
+                  setSelection(topEndpointIds(topology, TOP_N_DEFAULT))
+                }
+                onShowAll={() => setSelection(null)}
+              />
+              <Select
+                value={eventType}
+                onChange={(e) => setEventType(e.target.value)}
+                className="h-8 w-auto max-w-[240px] py-0 text-xs"
+                aria-label="Event type filter"
+              >
+                <option value="">All event types</option>
+                {eventTypeOptions.map((id) => (
+                  <option key={id} value={id}>
+                    {id}
+                  </option>
+                ))}
+              </Select>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-4 items-start">
+              <div className="bg-card border border-border rounded-nb-lg p-4 overflow-x-auto min-w-0 text-foreground">
+                <FlowStyles />
+                <svg
+                  viewBox={`0 0 ${layout.width} ${layout.height}`}
+                  className="w-full h-auto min-w-[900px]"
+                  role="img"
+                  aria-label="Live message flow diagram"
+                >
+                  {layout.routes.map((route) => (
+                    <path
+                      key={route.id}
+                      d={route.d}
+                      className="flow-route"
+                      data-kind={route.kind}
+                      ref={(el) => {
+                        if (el) routePathRefs.current.set(route.id, el);
+                        else routePathRefs.current.delete(route.id);
+                      }}
+                    />
+                  ))}
+                  {layout.nodes.map((node) => (
+                    <FlowNodeGroup
+                      key={node.id}
+                      node={node}
+                      snapshot={
+                        node.endpointId !== undefined
+                          ? snapshots[node.endpointId]
+                          : undefined
+                      }
+                    />
+                  ))}
+                  {/* Dot layer LAST so traveling dots draw above everything;
+                      owned exclusively by the FlowAnimator. */}
+                  <g ref={dotLayerRef} />
+                </svg>
+                <p className="m-0 mt-2 text-[11px] italic text-muted-foreground">
+                  Dots are derived from count deltas — representative activity,
+                  not individual messages.
+                </p>
+              </div>
+
+              <aside className="hidden lg:flex flex-col gap-4 min-w-0">
+                <div className="grid grid-cols-2 gap-2">
+                  <CounterGauge
+                    label="Published"
+                    value={counters.published}
+                    color={ACTIVITY_COLORS.arrived}
+                  />
+                  <CounterGauge
+                    label="Completed"
+                    value={counters.completed}
+                    color={ACTIVITY_COLORS.completed}
+                  />
+                  <CounterGauge
+                    label="Failed"
+                    value={counters.failed}
+                    color={ACTIVITY_COLORS.failed}
+                  />
+                  <CounterGauge
+                    label="Deferred"
+                    value={counters.deferred}
+                    color={ACTIVITY_COLORS.deferred}
+                  />
+                  <CounterGauge
+                    label="Dead-lettered"
+                    value={counters.deadlettered}
+                    color={ACTIVITY_COLORS.deadlettered}
+                  />
+                </div>
+                <FlowLegend />
+                <ActivityLog log={log} now={now} />
+              </aside>
+            </div>
+          </>
+        ) : topologyLoading ? (
+          <div className="flex items-center justify-center h-[400px] w-full">
+            <Spinner size="xl" color="primary" />
+          </div>
+        ) : (
+          <EmptyState
+            icon="◌"
+            title={topologyError ?? "No endpoints yet"}
+            description="Register an event type with at least one producer or consumer to watch messages flow."
+          />
+        )}
+      </div>
+    </Page>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Canvas pieces
+// ---------------------------------------------------------------------------
+
+const PARK_DOT_MAX = 6;
+
+/**
+ * One static node. Consumer nodes carry the live decorations: the deferred
+ * parking strip reads the authoritative snapshot count (FR-006 — present on
+ * first paint, no animation required), the attention ring lights while the
+ * latest snapshot reports failures, and a degraded border with a tooltip
+ * flags storage-unavailable endpoints (US2).
+ */
+const FlowNodeGroup = ({
+  node,
+  snapshot,
+}: {
+  node: FlowNode;
+  snapshot: StatusSnapshot | undefined;
+}) => {
+  const isConsumer = node.kind === "consumer";
+  const attention = isConsumer && snapshot !== undefined && snapshot.failed > 0;
+  const degraded = isConsumer && snapshot !== undefined && !snapshot.storageOk;
+  const deferred = isConsumer && snapshot !== undefined ? snapshot.deferred : 0;
+  const isChip = node.kind === "topic";
+  const titleY = isChip
+    ? node.y + 17
+    : node.kind === "platform"
+      ? node.y + node.h / 2 + 4
+      : node.y + 24;
+
+  return (
+    <g>
+      <rect
+        x={node.x}
+        y={node.y}
+        width={node.w}
+        height={node.h}
+        rx={isChip ? 6 : 9}
+        className={cn(
+          "flow-node",
+          `flow-node-${node.kind}`,
+          attention && "flow-attention",
+          degraded && "flow-degraded",
+        )}
+      >
+        {degraded && (
+          <title>
+            Storage unavailable — counts for this endpoint may be stale or
+            zero.
+          </title>
+        )}
+      </rect>
+      <text
+        x={node.x + 12}
+        y={titleY}
+        className={isChip ? "flow-chip-title" : "flow-node-title"}
+      >
+        {truncate(node.title, isChip ? 34 : 26)}
+      </text>
+      {node.subtitle !== undefined && (
+        <text
+          x={node.x + 12}
+          y={isChip ? node.y + 30 : node.y + 38}
+          className={isChip ? "flow-chip-subtitle" : "flow-node-subtitle"}
+        >
+          {truncate(node.subtitle, isChip ? 38 : 30)}
+        </text>
+      )}
+      {deferred > 0 && (
+        <g aria-label={`${deferred} deferred messages parked`}>
+          {Array.from({ length: Math.min(deferred, PARK_DOT_MAX) }, (_, i) => (
+            <circle
+              key={i}
+              cx={node.x + 16 + i * 10}
+              cy={node.y + node.h - 12}
+              r={3.5}
+              className="flow-park-dot"
+            />
+          ))}
+          <text
+            x={node.x + 16 + Math.min(deferred, PARK_DOT_MAX) * 10 + 6}
+            y={node.y + node.h - 8.5}
+            className="flow-park-label"
+          >
+            {deferred.toLocaleString()} parked
+          </text>
+        </g>
+      )}
+    </g>
+  );
+};
+
+/**
+ * Page-scoped SVG styling (all class names flow-prefixed). Node fills use
+ * low-alpha rgb so the same values read on both the cream and warm-black
+ * themes; text uses currentColor inherited from the card's text-foreground.
+ * Dot/parking colors come from ACTIVITY_COLORS to stay in lockstep with the
+ * legend and the animator.
+ */
+const FlowStyles = () => (
+  <style>{`
+    .flow-route {
+      fill: none;
+      stroke: rgb(100 116 139 / 0.9);
+      stroke-width: 1.5;
+      opacity: 0.22;
+      transition: opacity 0.25s ease;
+    }
+    .flow-route[data-kind="outcome"] { stroke-dasharray: 4 5; }
+    .flow-route-on { opacity: 0.95; }
+
+    .flow-node { stroke-width: 1.25; }
+    .flow-node-producer { fill: rgb(14 165 233 / 0.10); stroke: #0ea5e9; }
+    .flow-node-topic { fill: rgb(100 116 139 / 0.12); stroke: rgb(100 116 139 / 0.8); }
+    .flow-node-consumer { fill: rgb(20 184 166 / 0.10); stroke: #14b8a6; }
+    .flow-node-platform { fill: rgb(148 163 184 / 0.10); stroke: #94a3b8; }
+
+    .flow-degraded { stroke: ${ACTIVITY_COLORS.failed}; stroke-dasharray: 5 3; }
+    .flow-attention { animation: flow-attention-pulse 1.6s ease-in-out infinite; }
+    @keyframes flow-attention-pulse {
+      0%, 100% { stroke: ${ACTIVITY_COLORS.failed}; stroke-width: 1.5; }
+      50% { stroke: #ef4444; stroke-width: 3; }
+    }
+
+    .flow-node-title { font-size: 12px; font-weight: 600; fill: currentColor; }
+    .flow-node-subtitle { font-size: 10px; fill: currentColor; opacity: 0.55; }
+    .flow-chip-title { font-size: 10.5px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; fill: currentColor; opacity: 0.8; }
+    .flow-chip-subtitle { font-size: 9px; fill: currentColor; opacity: 0.5; }
+    .flow-dot-label { font-size: 10px; font-weight: 700; fill: currentColor; }
+    .flow-park-dot { fill: ${ACTIVITY_COLORS.deferred}; }
+    .flow-park-label { font-size: 9.5px; font-weight: 700; fill: #d97706; }
+  `}</style>
+);
+
+// ---------------------------------------------------------------------------
+// Controls
+// ---------------------------------------------------------------------------
+
+const ModeBadge = ({ mode }: { mode: ConnectionMode }) => (
+  <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-border bg-card font-mono text-[11px] text-muted-foreground whitespace-nowrap">
+    <span
+      aria-hidden="true"
+      className={cn(
+        "w-2 h-2 rounded-full",
+        mode === "live" && "bg-emerald-500",
+        mode === "polling" && "bg-amber-500",
+        mode === "connecting" && "bg-slate-400 animate-pulse",
+      )}
+    />
+    {mode === "live"
+      ? "Live"
+      : mode === "polling"
+        ? "Degraded — polling"
+        : "Connecting"}
+  </span>
+);
+
+interface EndpointFilterMenuProps {
+  nodes: TopologyNode[];
+  /** Currently effective selection; null = all endpoints visible. */
+  selection: string[] | null;
+  visibleCount: number;
+  onChange: (next: string[]) => void;
+  onTopN: () => void;
+  onShowAll: () => void;
+}
+
+// Dropdown panel with per-endpoint checkboxes plus the FR-007 quick actions.
+// Same lightweight popover pattern as the Topology page's AddFilterMenu:
+// local open state, click-outside to close.
+const EndpointFilterMenu = ({
+  nodes,
+  selection,
+  visibleCount,
+  onChange,
+  onTopN,
+  onShowAll,
+}: EndpointFilterMenuProps) => {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  const isChecked = (id: string): boolean =>
+    selection === null || selection.includes(id);
+  const toggle = (id: string): void => {
+    const base = selection ?? nodes.map((n) => n.id);
+    onChange(
+      base.includes(id) ? base.filter((x) => x !== id) : [...base, id],
+    );
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <Button variant="ghost" size="sm" onClick={() => setOpen((o) => !o)}>
+        Endpoints · {visibleCount}/{nodes.length}
+      </Button>
+      {open && (
+        <div
+          className={cn(
+            "absolute z-10 mt-1 left-0",
+            "bg-card border border-border rounded-nb-md shadow-md",
+            "min-w-[280px] max-h-[360px] overflow-y-auto p-2",
+          )}
+          role="menu"
+        >
+          <div className="flex gap-1.5 pb-2 mb-2 border-b border-border">
+            <Button variant="quiet" size="xs" onClick={onTopN}>
+              Top {TOP_N_DEFAULT}
+            </Button>
+            <Button variant="quiet" size="xs" onClick={onShowAll}>
+              Show all
+            </Button>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            {nodes.map((node) => (
+              <Checkbox
+                key={node.id}
+                label={node.name}
+                checked={isChecked(node.id)}
+                onChange={() => toggle(node.id)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Sidebar
+// ---------------------------------------------------------------------------
+
+const CounterGauge = ({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: number;
+  color: string;
+}) => (
+  <div className="bg-card border border-border rounded-nb-md px-3 py-2.5">
+    <div className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+      {label}
+    </div>
+    <div className="text-lg font-bold tabular-nums" style={{ color }}>
+      {value.toLocaleString()}
+    </div>
+  </div>
+);
+
+const LEGEND_KINDS: Array<{ kind: FlowActivityKind; label: string }> = [
+  { kind: "arrived", label: "Arrived" },
+  { kind: "completed", label: "Completed" },
+  { kind: "failed", label: "Failed" },
+  { kind: "deferred", label: "Deferred" },
+  { kind: "released", label: "Released" },
+  { kind: "deadlettered", label: "Dead-lettered" },
+];
+
+const FlowLegend = () => (
+  <div className="bg-card border border-border rounded-nb-md px-3 py-2.5 flex flex-wrap gap-x-4 gap-y-1.5">
+    {LEGEND_KINDS.map(({ kind, label }) => (
+      <span
+        key={kind}
+        className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground"
+      >
+        <span
+          aria-hidden="true"
+          className="w-2.5 h-2.5 rounded-full"
+          style={{ background: ACTIVITY_COLORS[kind] }}
+        />
+        {label}
+      </span>
+    ))}
+  </div>
+);
+
+const ActivityLog = ({
+  log,
+  now,
+}: {
+  log: ActivityEntry[];
+  now: number;
+}) => (
+  <div className="bg-card border border-border rounded-nb-md p-3 flex flex-col gap-2 min-h-0">
+    <div className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+      Activity
+    </div>
+    {log.length === 0 ? (
+      <p className="text-[12px] text-muted-foreground m-0">
+        Waiting for endpoint activity…
+      </p>
+    ) : (
+      <ul className="m-0 p-0 list-none flex flex-col gap-1.5 overflow-y-auto max-h-[420px]">
+        {log.map((entry) => (
+          <li
+            key={entry.id}
+            className="flex items-baseline gap-2 text-[12px] leading-snug"
+          >
+            <span className="font-mono text-[10px] text-muted-foreground shrink-0 w-9 text-right">
+              {relativeAgo(Math.max(0, now - entry.at))}
+            </span>
+            <span
+              aria-hidden="true"
+              className={cn(
+                "w-1.5 h-1.5 rounded-full shrink-0",
+                entry.endpointId === "" && "bg-muted-foreground/40",
+              )}
+              style={
+                entry.endpointId === ""
+                  ? undefined
+                  : { background: ACTIVITY_COLORS[entry.kind] }
+              }
+            />
+            {entry.endpointId === "" ? (
+              // Synthetic line (e.g. pause-buffer overflow) — no endpoint to
+              // link, so render the hook's message verbatim.
+              <span className="min-w-0 truncate italic text-muted-foreground">
+                {entry.message}
+              </span>
+            ) : (
+              <span className="min-w-0 truncate">
+                <Link
+                  to={`/Endpoints/Details/${encodeURIComponent(entry.endpointId)}`}
+                  className="text-foreground font-medium no-underline hover:text-primary"
+                >
+                  {entry.endpointId}
+                </Link>
+                <span className="text-muted-foreground">
+                  {`: ${entry.count.toLocaleString()} ${FLOW_KIND_VERB[entry.kind]}`}
+                </span>
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    )}
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+function formatSpeed(speed: number): string {
+  return speed
+    .toFixed(2)
+    .replace(/0+$/, "")
+    .replace(/\.$/, "");
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s;
+}
+
+function relativeAgo(ms: number): string {
+  const s = Math.max(0, Math.round(ms / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.round(h / 24)}d`;
+}

--- a/src/NimBus.WebApp/ClientApp/src/pages/flow.tsx
+++ b/src/NimBus.WebApp/ClientApp/src/pages/flow.tsx
@@ -20,7 +20,7 @@ import type {
   FlowNode,
   StatusSnapshot,
 } from "components/flow/types";
-import type { TopologyData, TopologyNode } from "components/topology/types";
+import type { TopologyNode } from "components/topology/types";
 import { FLOW_KIND_VERB, useFlowData } from "hooks/use-flow-data";
 
 // Live Flow page (spec 020, Phase 1). React owns the static scene — nodes,
@@ -156,24 +156,18 @@ export default function Flow() {
     [effectiveSelection],
   );
 
-  // Event-type filtering happens BEFORE layout: drop non-matching flowEdges
-  // from a shallow copy so the layout engine simply never sees those routes.
-  const filteredData = useMemo<TopologyData | undefined>(() => {
-    if (topology === undefined || eventType === "") return topology;
-    return {
-      ...topology,
-      flowEdges: topology.flowEdges.filter((e) =>
-        e.eventTypeIds.includes(eventType),
-      ),
-    };
-  }, [topology, eventType]);
-
+  // The engine owns event-type filtering: it narrows producers/topics/consumers
+  // and their routes to the selected type's flow (role-aware, so no orphaned
+  // nodes). Empty string = the full catalog.
   const layout = useMemo<FlowLayout | undefined>(() => {
-    if (filteredData === undefined || filteredData.nodes.length === 0) {
+    if (topology === undefined || topology.nodes.length === 0) {
       return undefined;
     }
-    return buildFlowLayout(filteredData, { visibleEndpointIds: visibleSet });
-  }, [filteredData, visibleSet]);
+    return buildFlowLayout(topology, {
+      visibleEndpointIds: visibleSet,
+      eventType: eventType || undefined,
+    });
+  }, [topology, visibleSet, eventType]);
   layoutRef.current = layout;
 
   const eventTypeOptions = useMemo(() => {

--- a/src/NimBus.WebApp/Controllers/ApiContract/ApplicationImplementation.cs
+++ b/src/NimBus.WebApp/Controllers/ApiContract/ApplicationImplementation.cs
@@ -1,7 +1,6 @@
 ﻿using NimBus.MessageStore.Abstractions;
 using NimBus.WebApp.ManagementApi;
 using NimBus.WebApp.Services;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using System;
@@ -13,15 +12,11 @@ using System.Threading.Tasks;
 
 namespace NimBus.WebApp.Controllers.ApiContract
 {
-    // Application status endpoint is intentionally anonymous to support health checks
-    // and status monitoring without authentication.
-    // The endpoint only returns non-sensitive information (environment name and version).
-    namespace NimBus.WebApp.ManagementApi
-    {
-        [AllowAnonymous]
-        public partial class ApplicationApiController : Controller { }
-    }
-
+    // The stats endpoint is intentionally anonymous (health checks / status
+    // monitoring); that exemption is applied per-action by
+    // AllowAnonymousActionsConvention rather than class-level [AllowAnonymous],
+    // so the other actions on ApplicationApiController (e.g. /api/me) stay
+    // behind the global authorization filter.
     public class ApplicationImplementation : IApplicationApiController
     {
         private readonly IConfiguration _config;

--- a/src/NimBus.WebApp/Controllers/ApiContract/StorageHookImplementation.cs
+++ b/src/NimBus.WebApp/Controllers/ApiContract/StorageHookImplementation.cs
@@ -15,7 +15,9 @@ using NimBus.Core;
 using NimBus.WebApp.Services;
 
 // Webhook endpoints are anonymous because Azure Event Grid cannot authenticate via cookies/tokens.
-// Security is enforced via a shared webhook key validated on every request.
+// Security is enforced via a shared webhook key validated on every request — sent in the
+// X-Webhook-Key header (preferred; configure as an Event Grid custom delivery header) or the
+// legacy ?key= query parameter.
 namespace NimBus.WebApp.ManagementApi
 {
     [AllowAnonymous]
@@ -26,6 +28,14 @@ namespace NimBus.WebApp.Controllers
 {
     public class StorageHookImplementation : IStorageHookApiController
     {
+        /// <summary>
+        /// Header carrying the webhook key. Preferred over the legacy ?key=
+        /// query parameter because query strings end up in proxy and gateway
+        /// access logs; Event Grid subscriptions can send it via custom
+        /// delivery headers.
+        /// </summary>
+        public const string WebhookKeyHeaderName = "X-Webhook-Key";
+
         private readonly IHubContext<GridEventsHub> _hubContext;
         private readonly ILogger<StorageHookImplementation> _logger;
         private readonly INimBusMessageStore _cosmosClient;
@@ -79,10 +89,13 @@ namespace NimBus.WebApp.Controllers
         }
 
         /// <summary>
-        /// Validates the webhook key from the request query string against the configured key.
-        /// In Development, missing config falls back to a warning + allow so a local
-        /// dashboard can run without Event Grid wiring; in any other environment a
-        /// missing key fails closed to avoid leaving an anonymous endpoint open.
+        /// Validates the webhook key from the X-Webhook-Key header (preferred) or,
+        /// for existing Event Grid subscriptions, the legacy ?key= query parameter.
+        /// Keys are compared in fixed time so the comparison does not leak key
+        /// bytes through response timing. In Development, missing config falls
+        /// back to a warning + allow so a local dashboard can run without Event
+        /// Grid wiring; in any other environment a missing key fails closed to
+        /// avoid leaving an anonymous endpoint open.
         /// </summary>
         private bool ValidateWebhookKey()
         {
@@ -98,8 +111,14 @@ namespace NimBus.WebApp.Controllers
                 return false;
             }
 
-            var requestKey = _httpContextAccessor.HttpContext?.Request.Query["key"].ToString();
-            if (string.IsNullOrEmpty(requestKey) || !string.Equals(requestKey, _webhookKey, StringComparison.Ordinal))
+            var request = _httpContextAccessor.HttpContext?.Request;
+            var requestKey = request?.Headers[WebhookKeyHeaderName].ToString();
+            if (string.IsNullOrEmpty(requestKey))
+            {
+                requestKey = request?.Query["key"].ToString();
+            }
+
+            if (string.IsNullOrEmpty(requestKey) || !FixedTimeEquals(requestKey, _webhookKey))
             {
                 _logger.LogWarning("Webhook request rejected: invalid or missing webhook key");
                 return false;
@@ -107,5 +126,10 @@ namespace NimBus.WebApp.Controllers
 
             return true;
         }
+
+        private static bool FixedTimeEquals(string left, string right)
+            => System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(
+                System.Text.Encoding.UTF8.GetBytes(left),
+                System.Text.Encoding.UTF8.GetBytes(right));
     }
 }

--- a/src/NimBus.WebApp/Startup.cs
+++ b/src/NimBus.WebApp/Startup.cs
@@ -191,6 +191,14 @@ namespace NimBus.WebApp
                 }).AddMicrosoftIdentityUI();
             }
 
+            // The NSwag-generated controllers cannot carry per-action attributes,
+            // so the stats endpoint's anonymous exemption is applied via an
+            // application-model convention instead of a class-level
+            // [AllowAnonymous] (which would silently exempt every action on the
+            // controller, e.g. /api/me).
+            services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(options =>
+                options.Conventions.Add(new AllowAnonymousActionsConvention()));
+
             // Entra/OIDC parity with the Identity cookie's clean-401 behaviour
             // (spec 010 FR-011/FR-012). When an anonymous, non-bearer request to
             // the SignalR hub or /api/* is challenged, the policy scheme forwards

--- a/tests/NimBus.CommandLine.Tests/CommandRunnerClientFactoryTests.cs
+++ b/tests/NimBus.CommandLine.Tests/CommandRunnerClientFactoryTests.cs
@@ -1,0 +1,84 @@
+using Xunit;
+
+namespace NimBus.CommandLine.Tests;
+
+public class CommandRunnerClientFactoryTests
+{
+    private const string SbNamespace = "nimbus-test.servicebus.windows.net";
+    private const string SbConnectionString =
+        "Endpoint=sb://nimbus-test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=Zm9vYmFyZm9vYmFy";
+
+    private const string CosmosEndpoint = "https://nimbus-test.documents.azure.com/";
+    private const string CosmosConnectionString =
+        "AccountEndpoint=https://nimbus-test.documents.azure.com/;AccountKey=Zm9vYmFyZm9vYmFyZm9vYmFyZm9vYmFyZm9vYmFyZm9vYmFyZm9vYmFyZm9vYmFy;";
+
+    [Fact]
+    public async Task CreateServiceBusClient_WithConnectionString_UsesConnectionString()
+    {
+        await using var client = CommandRunner.CreateServiceBusClient(SbConnectionString);
+        Assert.Equal(SbNamespace, client.FullyQualifiedNamespace);
+    }
+
+    [Fact]
+    public async Task CreateServiceBusClient_WithFullyQualifiedNamespace_UsesEntraIdCredential()
+    {
+        await using var client = CommandRunner.CreateServiceBusClient(SbNamespace);
+        Assert.Equal(SbNamespace, client.FullyQualifiedNamespace);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CreateServiceBusClient_WithoutValue_ThrowsWithGuidance(string? value)
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => CommandRunner.CreateServiceBusClient(value));
+        Assert.Contains(CommandRunner.SbConnectionStringEnvName, ex.Message);
+    }
+
+    [Fact]
+    public void CreateServiceBusAdministrationClient_WithConnectionString_Succeeds()
+    {
+        var client = CommandRunner.CreateServiceBusAdministrationClient(SbConnectionString);
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void CreateServiceBusAdministrationClient_WithFullyQualifiedNamespace_Succeeds()
+    {
+        var client = CommandRunner.CreateServiceBusAdministrationClient(SbNamespace);
+        Assert.NotNull(client);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void CreateServiceBusAdministrationClient_WithoutValue_ThrowsWithGuidance(string? value)
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => CommandRunner.CreateServiceBusAdministrationClient(value));
+        Assert.Contains(CommandRunner.SbConnectionStringEnvName, ex.Message);
+    }
+
+    [Fact]
+    public void CreateCosmosClient_WithConnectionString_UsesConnectionString()
+    {
+        using var client = CommandRunner.CreateCosmosClient(CosmosConnectionString);
+        Assert.Equal(new Uri(CosmosEndpoint), client.Endpoint);
+    }
+
+    [Fact]
+    public void CreateCosmosClient_WithAccountEndpoint_UsesEntraIdCredential()
+    {
+        using var client = CommandRunner.CreateCosmosClient(CosmosEndpoint);
+        Assert.Equal(new Uri(CosmosEndpoint), client.Endpoint);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void CreateCosmosClient_WithoutValue_ThrowsWithGuidance(string? value)
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => CommandRunner.CreateCosmosClient(value));
+        Assert.Contains(CommandRunner.DbConnectionStringEnvName, ex.Message);
+    }
+}

--- a/tests/NimBus.Resolver.Tests/HttpEndpointStateChangeNotifierTests.cs
+++ b/tests/NimBus.Resolver.Tests/HttpEndpointStateChangeNotifierTests.cs
@@ -1,0 +1,108 @@
+#pragma warning disable CA1707, CA2007
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NimBus.Resolver;
+
+namespace NimBus.Resolver.Tests;
+
+[TestClass]
+public class HttpEndpointStateChangeNotifierTests
+{
+    private static readonly Uri WebAppBase = new("http://webapp.local/");
+
+    [TestMethod]
+    public async Task Notify_PostsToStorageHookRoute_WithEscapedEndpointId()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK);
+        using var client = new HttpClient(handler) { BaseAddress = WebAppBase };
+        var notifier = new HttpEndpointStateChangeNotifier(client, webhookKey: null);
+
+        await notifier.NotifyEndpointStateChangedAsync("Crm Endpoint");
+
+        Assert.AreEqual(HttpMethod.Post, handler.Method);
+        // AbsoluteUri preserves the wire-form escaping (ToString() decodes it for display).
+        Assert.AreEqual(
+            "http://webapp.local/api/storagehook/cosmos/Crm%20Endpoint",
+            handler.RequestUri!.AbsoluteUri);
+    }
+
+    [TestMethod]
+    public async Task Notify_SendsWebhookKeyHeader_WhenConfigured()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK);
+        using var client = new HttpClient(handler) { BaseAddress = WebAppBase };
+        var notifier = new HttpEndpointStateChangeNotifier(client, webhookKey: "s3cret");
+
+        await notifier.NotifyEndpointStateChangedAsync("BillingEndpoint");
+
+        Assert.AreEqual("s3cret", handler.WebhookKey);
+    }
+
+    [TestMethod]
+    public async Task Notify_OmitsWebhookKeyHeader_WhenNotConfigured()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK);
+        using var client = new HttpClient(handler) { BaseAddress = WebAppBase };
+        var notifier = new HttpEndpointStateChangeNotifier(client, webhookKey: "");
+
+        await notifier.NotifyEndpointStateChangedAsync("BillingEndpoint");
+
+        Assert.IsNull(handler.WebhookKey);
+    }
+
+    [TestMethod]
+    public async Task Notify_SwallowsTransportFailures()
+    {
+        var handler = new ThrowingHandler();
+        using var client = new HttpClient(handler) { BaseAddress = WebAppBase };
+        var notifier = new HttpEndpointStateChangeNotifier(client, webhookKey: null);
+
+        // Must not throw — realtime push is best-effort.
+        await notifier.NotifyEndpointStateChangedAsync("BillingEndpoint");
+    }
+
+    [TestMethod]
+    public async Task Notify_DoesNotPost_ForEmptyEndpointId()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK);
+        using var client = new HttpClient(handler) { BaseAddress = WebAppBase };
+        var notifier = new HttpEndpointStateChangeNotifier(client, webhookKey: null);
+
+        await notifier.NotifyEndpointStateChangedAsync("");
+
+        Assert.IsFalse(handler.Sent, "No request should be sent for an empty endpoint id.");
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+
+        public CapturingHandler(HttpStatusCode status) => _status = status;
+
+        public bool Sent { get; private set; }
+        public HttpMethod? Method { get; private set; }
+        public Uri? RequestUri { get; private set; }
+        public string? WebhookKey { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Sent = true;
+            Method = request.Method;
+            RequestUri = request.RequestUri;
+            WebhookKey = request.Headers.TryGetValues("X-Webhook-Key", out var values)
+                ? string.Join(",", values)
+                : null;
+            return Task.FromResult(new HttpResponseMessage(_status));
+        }
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new HttpRequestException("connection refused");
+    }
+}

--- a/tests/NimBus.WebApp.Tests/AnonymousEndpointsTests.cs
+++ b/tests/NimBus.WebApp.Tests/AnonymousEndpointsTests.cs
@@ -1,0 +1,158 @@
+#pragma warning disable CA1707, CA2007
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NimBus.WebApp.ManagementApi;
+
+namespace NimBus.WebApp.Tests;
+
+/// <summary>
+/// Verifies that the anonymous exemption on the NSwag-generated controllers is
+/// scoped to exactly the intended actions: /api/app/stats stays anonymous (for
+/// health probes), /api/me requires authentication despite living on the same
+/// controller, and the storage-hook webhook stays anonymous (key-gated).
+/// Mirrors the production setup: global AuthorizeFilter requiring an
+/// authenticated user plus the AllowAnonymousActionsConvention.
+/// </summary>
+[TestClass]
+public class AnonymousEndpointsTests
+{
+    private const string TestAuthScheme = "TestAuthenticated";
+    private const string TestAuthHeader = "X-Test-Auth";
+
+    private static IHost _host = null!;
+    private static TestServer _server = null!;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        var builder = new HostBuilder()
+            .ConfigureWebHost(web =>
+            {
+                web.UseTestServer();
+                web.ConfigureServices(services =>
+                {
+                    services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+                    services.AddSingleton<IApplicationApiController>(new StubApplicationApi());
+                    services.AddSingleton<IStorageHookApiController>(new StubStorageHookApi());
+
+                    services
+                        .AddAuthentication(TestAuthScheme)
+                        .AddScheme<AuthenticationSchemeOptions, HeaderAuthHandler>(TestAuthScheme, _ => { });
+                    services.AddAuthorization();
+
+                    services.AddControllers(options =>
+                    {
+                        var policy = new AuthorizationPolicyBuilder()
+                            .RequireAuthenticatedUser()
+                            .Build();
+                        options.Filters.Add(new AuthorizeFilter(policy));
+                        options.Conventions.Add(new AllowAnonymousActionsConvention());
+                    })
+                    .AddApplicationPart(typeof(ApplicationApiController).Assembly);
+                });
+                web.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseAuthentication();
+                    app.UseAuthorization();
+                    app.UseEndpoints(endpoints => endpoints.MapControllers());
+                });
+            });
+
+        _host = await builder.StartAsync();
+        _server = _host.GetTestServer();
+    }
+
+    [ClassCleanup]
+    public static async Task ClassCleanup()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    [TestMethod]
+    public async Task App_stats_is_reachable_anonymously()
+    {
+        using var client = _server.CreateClient();
+        using var response = await client.GetAsync("/api/app/stats");
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Me_requires_authentication()
+    {
+        using var client = _server.CreateClient();
+        using var response = await client.GetAsync("/api/me");
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Me_succeeds_when_authenticated()
+    {
+        using var client = _server.CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHeader, "yes");
+        using var response = await client.GetAsync("/api/me");
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Storage_hook_webhook_is_reachable_anonymously()
+    {
+        using var client = _server.CreateClient();
+        using var response = await client.PostAsync("/api/storagehook/cosmos/ep-1", content: null);
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    private sealed class StubApplicationApi : IApplicationApiController
+    {
+        public Task<ActionResult<ApplicationStatus>> GetApiAppStatsAsync()
+            => Task.FromResult<ActionResult<ApplicationStatus>>(new OkObjectResult(new ApplicationStatus()));
+
+        public Task<ActionResult<UserInfo>> GetMeAsync()
+            => Task.FromResult<ActionResult<UserInfo>>(new OkObjectResult(new UserInfo()));
+    }
+
+    private sealed class StubStorageHookApi : IStorageHookApiController
+    {
+        public Task<IActionResult> StoragehookReceiveCosmosAsync(string endpointId)
+            => Task.FromResult<IActionResult>(new OkResult());
+    }
+
+    private sealed class HeaderAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public HeaderAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder) : base(options, logger, encoder) { }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.ContainsKey(TestAuthHeader))
+                return Task.FromResult(AuthenticateResult.NoResult());
+
+            var identity = new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "test-user"),
+                new Claim(ClaimTypes.Name, "Test User"),
+            }, Scheme.Name);
+            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme.Name);
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}

--- a/tests/NimBus.WebApp.Tests/StorageHookWebhookKeyTests.cs
+++ b/tests/NimBus.WebApp.Tests/StorageHookWebhookKeyTests.cs
@@ -1,0 +1,214 @@
+#pragma warning disable CA1707, CA2007
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NimBus.Core;
+using NimBus.Core.Endpoints;
+using NimBus.Core.Events;
+using NimBus.Testing.Conformance;
+using NimBus.WebApp.Controllers;
+using NimBus.WebApp.Hubs;
+
+namespace NimBus.WebApp.Tests;
+
+/// <summary>
+/// Covers the webhook-key gate on the anonymous storage-hook endpoint: the key
+/// is accepted from the X-Webhook-Key header (preferred) or the legacy ?key=
+/// query parameter, compared in fixed time, and fails closed outside
+/// Development when unconfigured.
+/// </summary>
+[TestClass]
+public class StorageHookWebhookKeyTests
+{
+    private const string ConfiguredKey = "test-webhook-key-123";
+    private const string KnownEndpointId = "ep-1";
+
+    [TestMethod]
+    public async Task Receive_accepts_key_from_header_and_pushes_update()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[StorageHookImplementation.WebhookKeyHeaderName] = ConfiguredKey;
+        var proxy = new RecordingClientProxy();
+        var sut = CreateSut(ConfiguredKey, Environments.Production, context, proxy);
+
+        var result = await sut.StoragehookReceiveAsync(KnownEndpointId);
+
+        Assert.IsInstanceOfType(result, typeof(OkResult));
+        Assert.AreEqual(1, proxy.SentMethods.Count);
+    }
+
+    [TestMethod]
+    public async Task Receive_accepts_legacy_key_from_query_string()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString($"?key={ConfiguredKey}");
+        var sut = CreateSut(ConfiguredKey, Environments.Production, context, new RecordingClientProxy());
+
+        var result = await sut.StoragehookReceiveAsync(KnownEndpointId);
+
+        Assert.IsInstanceOfType(result, typeof(OkResult));
+    }
+
+    [TestMethod]
+    public async Task Receive_rejects_wrong_key()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[StorageHookImplementation.WebhookKeyHeaderName] = "wrong-key";
+        var sut = CreateSut(ConfiguredKey, Environments.Production, context, new RecordingClientProxy());
+
+        var result = await sut.StoragehookReceiveAsync(KnownEndpointId);
+
+        Assert.IsInstanceOfType(result, typeof(UnauthorizedResult));
+    }
+
+    [TestMethod]
+    public async Task Receive_rejects_missing_key()
+    {
+        var sut = CreateSut(ConfiguredKey, Environments.Production, new DefaultHttpContext(), new RecordingClientProxy());
+
+        var result = await sut.StoragehookReceiveAsync(KnownEndpointId);
+
+        Assert.IsInstanceOfType(result, typeof(UnauthorizedResult));
+    }
+
+    [TestMethod]
+    public async Task Receive_fails_closed_when_key_unconfigured_outside_development()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?key=anything");
+        var sut = CreateSut(configuredKey: null, Environments.Production, context, new RecordingClientProxy());
+
+        var result = await sut.StoragehookReceiveAsync(KnownEndpointId);
+
+        Assert.IsInstanceOfType(result, typeof(UnauthorizedResult));
+    }
+
+    [TestMethod]
+    public async Task Receive_allows_unconfigured_key_in_development()
+    {
+        var sut = CreateSut(configuredKey: null, Environments.Development, new DefaultHttpContext(), new RecordingClientProxy());
+
+        var result = await sut.StoragehookReceiveAsync(KnownEndpointId);
+
+        Assert.IsInstanceOfType(result, typeof(OkResult));
+    }
+
+    [TestMethod]
+    public async Task Receive_with_valid_key_but_unknown_endpoint_returns_bad_request()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[StorageHookImplementation.WebhookKeyHeaderName] = ConfiguredKey;
+        var sut = CreateSut(ConfiguredKey, Environments.Production, context, new RecordingClientProxy());
+
+        var result = await sut.StoragehookReceiveAsync("unknown-endpoint");
+
+        Assert.IsInstanceOfType(result, typeof(BadRequestResult));
+    }
+
+    private static StorageHookImplementation CreateSut(
+        string? configuredKey, string environment, HttpContext httpContext, RecordingClientProxy proxy)
+    {
+        var configValues = new Dictionary<string, string?>();
+        if (configuredKey is not null)
+        {
+            configValues["EventGrid:WebhookKey"] = configuredKey;
+        }
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configValues).Build();
+
+        return new StorageHookImplementation(
+            new FakeHubContext(proxy),
+            NullLogger<StorageHookImplementation>.Instance,
+            new InMemoryMessageStore(),
+            new FakePlatform(KnownEndpointId),
+            new HttpContextAccessor { HttpContext = httpContext },
+            new FakeHostEnvironment(environment),
+            configuration);
+    }
+
+    private sealed class FakeHostEnvironment : IHostEnvironment
+    {
+        public FakeHostEnvironment(string environmentName) => EnvironmentName = environmentName;
+
+        public string EnvironmentName { get; set; }
+        public string ApplicationName { get; set; } = "NimBus.WebApp.Tests";
+        public string ContentRootPath { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+
+    private sealed class FakeHubContext : IHubContext<GridEventsHub>
+    {
+        public FakeHubContext(RecordingClientProxy proxy) => Clients = new FakeHubClients(proxy);
+
+        public IHubClients Clients { get; }
+        public IGroupManager Groups => throw new NotSupportedException();
+    }
+
+    private sealed class FakeHubClients : IHubClients
+    {
+        private readonly RecordingClientProxy _proxy;
+
+        public FakeHubClients(RecordingClientProxy proxy) => _proxy = proxy;
+
+        public IClientProxy All => _proxy;
+        public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds) => _proxy;
+        public IClientProxy Client(string connectionId) => _proxy;
+        public IClientProxy Clients(IReadOnlyList<string> connectionIds) => _proxy;
+        public IClientProxy Group(string groupName) => _proxy;
+        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds) => _proxy;
+        public IClientProxy Groups(IReadOnlyList<string> groupNames) => _proxy;
+        public IClientProxy User(string userId) => _proxy;
+        public IClientProxy Users(IReadOnlyList<string> userIds) => _proxy;
+    }
+
+    private sealed class RecordingClientProxy : IClientProxy
+    {
+        public List<string> SentMethods { get; } = new();
+
+        public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)
+        {
+            SentMethods.Add(method);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakePlatform : IPlatform
+    {
+        private readonly List<IEndpoint> _endpoints;
+
+        public FakePlatform(params string[] endpointIds)
+        {
+            _endpoints = endpointIds.Select(id => (IEndpoint)new FakeEndpoint(id)).ToList();
+        }
+
+        public IEnumerable<IEndpoint> Endpoints => _endpoints;
+        public IEnumerable<IEventType> EventTypes => Enumerable.Empty<IEventType>();
+        public IEnumerable<IEndpoint> GetConsumers(IEventType eventType) => Enumerable.Empty<IEndpoint>();
+        public IEnumerable<IEndpoint> GetProducers(IEventType eventType) => Enumerable.Empty<IEndpoint>();
+    }
+
+    private sealed class FakeEndpoint : IEndpoint
+    {
+        public FakeEndpoint(string id) => Id = id;
+
+        public string Id { get; }
+        public string Name => Id;
+        public string Description => string.Empty;
+        public string Namespace => string.Empty;
+        public string SecurityGroupName => string.Empty;
+        public ISystem System => null!;
+        public IEnumerable<IEventType> EventTypesProduced => Enumerable.Empty<IEventType>();
+        public IEnumerable<IEventType> EventTypesConsumed => Enumerable.Empty<IEventType>();
+        public IEnumerable<IRoleAssignment> RoleAssignments => Enumerable.Empty<IRoleAssignment>();
+    }
+}


### PR DESCRIPTION
## Summary

  Adds the **Live Flow** page to the management WebApp — a real-time, animated view of
  messages moving across producers, Service Bus topics, consuming endpoints, and the
  Resolver — derived from live endpoint-status deltas. To make it observable on the SQL
  storage provider (which has no Cosmos Change Feed), the Resolver gains a write-path hook
  that pushes endpoint-state changes to the WebApp. The CRM/ERP demo is extended with the
  controls needed to actually *drive* and *showcase* the flow: a traffic simulator, an
  adjustable processing delay, and a clearer Flow layout.

  Implements `docs/superpowers/plans/020-live-flow-monitor-phase1.md`.

  ## What's included

  ### Live Flow page (WebApp)
  - New `/Flow` page (`src/NimBus.WebApp/ClientApp/src/pages/flow.tsx`) with a four-column
    layout: producer adapters → Azure Service Bus topics → consumers → Resolver.
  - Imperative SVG dot animator (`components/flow/animator.ts`) on a single virtual clock —
    per-frame work never touches React reconciliation (NFR-002); pause/speed/hidden-tab all
    ride the same clock (NFR-003). Pure, unit-tested layout + delta-derivation engine
    (`layout.ts`, `derive-deltas.ts`, `types.ts`, `use-flow-data.ts`).
  - Live decorations: glow on active edges/dots, deferred "parking" strips, attention rings
    on failing endpoints, degraded-storage borders, a counters strip, legend, and activity log.
  - Controls: pause, speed, endpoint filter (top-N default), and an event-type filter that
    narrows the **whole** diagram to one type's flow.
  - Messages now animate the **full journey** — out of the producer *adapter*, through its
    Service Bus topic, into the consumer — as one chained dot, so the left-hand senders read
    as the origin. Producer nodes are labelled as adapters (e.g. `CrmEndpoint` → `Crm Adapter`).

  ### Resolver live-push hook
  - `HttpEndpointStateChangeNotifier` broadcasts `endpointupdate` to the WebApp's storage-hook
    webhook on the Resolver write path, so the Flow page animates in real time on SQL storage
    (best-effort; pages still reconcile via polling). Wired via `ResolverBuilderExtensions` /
    `ServiceExtensions`, plus AppHost wiring. Covered by `HttpEndpointStateChangeNotifierTests`.

  ### CRM/ERP demo drivers
  - **Simulate mode** (`Crm.Web`): a header toggle that runs up to 2 parallel workers doing
    randomized create/update/delete on accounts & contacts (500 ms–2 s gaps), publishing real
    `CrmAccount*`/`CrmContact*` events — instant live traffic for the Flow page.
  - **Processing delay** (`Erp.Web` + `Erp.Api` + `Erp.Adapter.Functions`): a panel toggle +
    100 ms–100 s slider that holds each inbound ERP message for the configured time before its
    handler runs (a new `ProcessingDelayMiddleware` reading a lock-guarded `ProcessingDelayState`
    via `/api/admin/processing-delay`) — simulates a slow consumer so processing visibly takes
    time on the Flow monitor. Mirrors the existing ServiceMode/HandoffMode pattern.
  - **Vite `strictPort`** fix: pins the demo SPAs to their Aspire-assigned port so Vite never
    silently drifts off it during a restart (which previously left Aspire's proxy pointed at a
    dead port — "page does not load").

  ## How to try it
  1. `dotnet run --project samples/CrmErpDemo/CrmErpDemo.AppHost`
  2. Open the **CRM Demo**, click **Simulate** (and/or use the ERP **Processing delay** panel).
  3. Open the management WebApp's **Flow** page and watch messages animate end-to-end.

  ## Testing
  - WebApp: vitest suites for the flow layout + delta derivation pass; full `tsc` + production
    `vite build` clean.
  - Resolver: `HttpEndpointStateChangeNotifierTests` pass.
  - Demo: `Erp.Api` and `Erp.Adapter.Functions` build clean (0 errors); `Crm.Web` / `Erp.Web`
    production builds clean.

  ## Notes
  - Flow dots are derived from count deltas — representative activity, not individual messages
    (Phase 1; per-message `flowactivity` attribution is Phase 2).
  - ERP processing delay up to 100 s stays within the Functions Service Bus trigger's default
    lock auto-renew window (5 min), so long delays don't trip lock expiry.